### PR TITLE
Add optional New Relic APM and browser monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,10 @@ STATIC_PAGE_PUSH_TARGET=
 # Google Cloud credentials (only needed if STATIC_PAGE_PUSH_METHOD=gcs and not using instance metadata/Workload Identity)
 # GOOGLE_APPLICATION_CREDENTIALS=
 
+# New Relic APM and Browser Monitoring (optional)
+# NEW_RELIC_LICENSE_KEY=
+# NEW_RELIC_APP_NAME=Equipment Status Board
+
 # Flask configuration
 FLASK_APP=esb:create_app
 FLASK_DEBUG=1

--- a/docs/administrators.md
+++ b/docs/administrators.md
@@ -86,6 +86,8 @@ Open `http://localhost:5000` in a browser (or the server's IP/hostname on port 5
 | `AWS_ACCESS_KEY_ID` | AWS access key for S3 static page push. Only needed if `STATIC_PAGE_PUSH_METHOD=s3` and not using an IAM role. | No | _(empty)_ | `AKIAIOSFODNN7EXAMPLE` |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key for S3 static page push. Only needed if `STATIC_PAGE_PUSH_METHOD=s3` and not using an IAM role. | No | _(empty)_ | `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY` |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to Google Cloud service account JSON key file. Only needed if `STATIC_PAGE_PUSH_METHOD=gcs` and not using instance metadata or Workload Identity. | No | _(empty)_ | `/path/to/service-account.json` |
+| `NEW_RELIC_LICENSE_KEY` | New Relic license key. Enables APM and browser monitoring when set. Leave empty to disable. | No | _(empty)_ | `abc123def456...` |
+| `NEW_RELIC_APP_NAME` | Application name shown in the New Relic dashboard. | No | `Equipment Status Board` | `ESB Production` |
 
 !!! warning
     Always set `SECRET_KEY` to a unique random value in production. The default value is insecure and only suitable for development.
@@ -136,6 +138,7 @@ The application Docker image includes these key Python packages:
 - **boto3** — AWS S3 client for static page push (when using `s3` method)
 - **google-cloud-storage** — Google Cloud Storage client for static page push (when using `gcs` method)
 - **qrcode[pil]** — QR code generation for equipment pages
+- **newrelic** — New Relic APM and browser monitoring agent (optional, activated by `NEW_RELIC_LICENSE_KEY`)
 - **gunicorn** — Production WSGI server
 
 ## Slack App Configuration
@@ -210,6 +213,44 @@ Set the push method via the `STATIC_PAGE_PUSH_METHOD` environment variable:
 - **`gcs`** — Uploads the static page to a Google Cloud Storage bucket specified by `STATIC_PAGE_PUSH_TARGET`. Uses Google's default credential chain (`GOOGLE_APPLICATION_CREDENTIALS` environment variable, GCE instance metadata, or Workload Identity). When using Docker with a service account key file, add a volume mount for the credentials file in `docker-compose.yml` (e.g., `- ./service-account.json:/app/service-account.json:ro`) and set `GOOGLE_APPLICATION_CREDENTIALS=/app/service-account.json`.
 
 The static page is pushed by the background worker whenever it detects a status change during its polling cycle.
+
+## New Relic Monitoring (Optional)
+
+New Relic integration provides server-side APM (Application Performance Monitoring) and browser monitoring for end users. When enabled, it automatically instruments the Flask application, background worker, and injects browser monitoring JavaScript into all pages.
+
+### Enabling New Relic
+
+Set the `NEW_RELIC_LICENSE_KEY` environment variable in your `.env` file:
+
+```bash
+NEW_RELIC_LICENSE_KEY=your-license-key-here
+NEW_RELIC_APP_NAME=Equipment Status Board
+```
+
+Restart all services after updating:
+
+```bash
+docker compose restart app worker
+```
+
+Both the web application and background worker will begin reporting to New Relic. Browser monitoring JavaScript is automatically injected into every page served by the application.
+
+### Verifying
+
+After enabling, check the New Relic dashboard for your application name. You should see:
+
+- **APM data** — web transactions, throughput, error rates, and response times
+- **Browser data** — page load times, JavaScript errors, and AJAX calls from end users
+
+If no data appears, check the app and worker logs for New Relic-related errors:
+
+```bash
+docker compose logs app | grep -i "new.relic\|newrelic"
+```
+
+### Disabling
+
+To disable New Relic, remove or comment out `NEW_RELIC_LICENSE_KEY` in your `.env` file and restart the services. When the license key is not set, no New Relic code is loaded and there is zero performance impact.
 
 ## Ongoing Maintenance
 

--- a/esb/__init__.py
+++ b/esb/__init__.py
@@ -1,11 +1,15 @@
 """ESB application package."""
 
+import os
+
 from flask import Flask, flash, redirect, render_template, request, session, url_for
 
 from esb.config import config
 from esb.extensions import csrf, db, login_manager, migrate
 from esb.utils.filters import register_filters
 from esb.views import register_blueprints
+
+_newrelic_initialized = False
 
 
 def create_app(config_name='default'):
@@ -14,6 +18,17 @@ def create_app(config_name='default'):
     Args:
         config_name: Configuration key ('development', 'testing', 'production', 'default').
     """
+    global _newrelic_initialized
+    nr_license = os.environ.get('NEW_RELIC_LICENSE_KEY', '')
+    if nr_license and not _newrelic_initialized:
+        import newrelic.agent
+        settings = newrelic.agent.global_settings()
+        settings.license_key = nr_license
+        settings.app_name = os.environ.get('NEW_RELIC_APP_NAME', 'Equipment Status Board')
+        settings.browser_monitoring.auto_instrument = False
+        newrelic.agent.initialize()
+        _newrelic_initialized = True
+
     app = Flask(__name__)
     app.config.from_object(config[config_name])
 
@@ -47,6 +62,16 @@ def create_app(config_name='default'):
 
     # Register custom Jinja2 filters
     register_filters(app)
+
+    # New Relic browser monitoring context processor
+    if nr_license:
+        @app.context_processor
+        def newrelic_browser_snippets():
+            import newrelic.agent
+            return {
+                'newrelic_browser_header': newrelic.agent.get_browser_timing_header(),
+                'newrelic_browser_footer': newrelic.agent.get_browser_timing_footer(),
+            }
 
     # Register error handlers
     @app.errorhandler(403)

--- a/esb/config.py
+++ b/esb/config.py
@@ -21,6 +21,8 @@ class Config:
     SLACK_OOPS_CHANNEL = os.environ.get('SLACK_OOPS_CHANNEL', '#oops')
     STATIC_PAGE_PUSH_METHOD = os.environ.get('STATIC_PAGE_PUSH_METHOD', 'local')
     STATIC_PAGE_PUSH_TARGET = os.environ.get('STATIC_PAGE_PUSH_TARGET', '')
+    NEW_RELIC_LICENSE_KEY = os.environ.get('NEW_RELIC_LICENSE_KEY', '')
+    NEW_RELIC_APP_NAME = os.environ.get('NEW_RELIC_APP_NAME', 'Equipment Status Board')
 
 
 class DevelopmentConfig(Config):

--- a/esb/templates/base.html
+++ b/esb/templates/base.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap.min.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
     {% block extra_css %}{% endblock %}
+    {% if newrelic_browser_header is defined %}{{ newrelic_browser_header|safe }}{% endif %}
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top">
@@ -73,5 +74,6 @@
     <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
     {% block extra_js %}{% endblock %}
+    {% if newrelic_browser_footer is defined %}{{ newrelic_browser_footer|safe }}{% endif %}
 </body>
 </html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "equipment-status-board"
-version = "0.1.0"
+version = "0.2.0"
 description = "Equipment status tracking and repair management for Decatur Makers makerspace"
 requires-python = ">=3.14"
 dependencies = [
@@ -12,6 +12,7 @@ dependencies = [
     "PyMySQL>=1.1.1",
     "python-dotenv>=1.1.0",
     "gunicorn>=23.0.0",
+    "newrelic>=10.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ slack-bolt>=1.27.0
 qrcode[pil]>=8.0
 boto3>=1.35.0
 google-cloud-storage>=2.18.0
+newrelic>=10.0.0


### PR DESCRIPTION
## Summary
- Adds optional New Relic APM and browser monitoring, activated by setting `NEW_RELIC_LICENSE_KEY`
- Server-side agent instruments the Flask app and background worker; browser monitoring JS is auto-injected into all pages via a Jinja2 context processor
- When the license key is not set, no New Relic code is loaded (zero impact)
- Bumps version to 0.2.0

## Changes
- `esb/__init__.py` — Conditional NR agent initialization + browser monitoring context processor
- `esb/config.py` — `NEW_RELIC_LICENSE_KEY` and `NEW_RELIC_APP_NAME` config vars
- `esb/templates/base.html` — Browser monitoring snippet injection points
- `requirements.txt` / `pyproject.toml` — `newrelic>=10.0.0` dependency
- `.env.example` — Commented-out NR variables
- `docs/administrators.md` — Env var reference + new "New Relic Monitoring" section

## Test plan
- [x] All 947 existing tests pass
- [x] Linter passes
- [ ] Deploy without `NEW_RELIC_LICENSE_KEY` — verify no errors and no NR artifacts in page source
- [ ] Deploy with `NEW_RELIC_LICENSE_KEY` set — verify NR browser JS appears in page source and data flows to NR dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)