### PR TITLE
fix: enable gunicorn access logs to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN mkdir -p /app/uploads
 
 EXPOSE 5000
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "1", "--threads", "2", "esb:create_app()"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "1", "--threads", "2", "--access-logfile", "-", "esb:create_app()"]


### PR DESCRIPTION
Add --access-logfile - to the gunicorn CMD so HTTP access logs are written to stdout and captured by Docker/journald alongside audit logs.

Fixes #8