### PR TITLE
fix: normalize UPLOAD_PATH to absolute and fix serve_upload filepath splitting

### DIFF
--- a/esb/__init__.py
+++ b/esb/__init__.py
@@ -32,6 +32,12 @@ def create_app(config_name='default'):
     app = Flask(__name__)
     app.config.from_object(config[config_name])
 
+    # Normalize UPLOAD_PATH to absolute so file serving is not sensitive to
+    # the process working directory (which can differ between dev and Docker).
+    _upload_path = app.config.get('UPLOAD_PATH', 'uploads')
+    if not os.path.isabs(_upload_path):
+        app.config['UPLOAD_PATH'] = os.path.abspath(_upload_path)
+
     # Initialize extensions
     db.init_app(app)
     login_manager.init_app(app)

--- a/esb/views/public.py
+++ b/esb/views/public.py
@@ -4,6 +4,7 @@ The status dashboard and kiosk are publicly accessible (no login required).
 """
 
 import os
+import posixpath
 from collections import OrderedDict
 
 from flask import Blueprint, abort, current_app, flash, redirect, render_template, request, send_from_directory, url_for
@@ -217,9 +218,9 @@ def serve_upload(filepath):
     if '..' in filepath or not filepath.startswith('equipment/'):
         abort(404)
     upload_path = current_app.config['UPLOAD_PATH']
-    # Split into directory and bare filename so send_from_directory receives a
-    # single path component without internal slashes (required by Werkzeug's
-    # safe_join, which rejects path components that contain os.sep).
-    directory = os.path.join(upload_path, os.path.dirname(filepath))
-    filename = os.path.basename(filepath)
+    # Use posixpath (not os.path) to split the URL-sourced filepath, so
+    # platform-dependent separators can't trick os.path.join into dropping
+    # the upload_path prefix.
+    directory = os.path.join(upload_path, posixpath.dirname(filepath))
+    filename = posixpath.basename(filepath)
     return send_from_directory(directory, filename)

--- a/esb/views/public.py
+++ b/esb/views/public.py
@@ -3,6 +3,7 @@
 The status dashboard and kiosk are publicly accessible (no login required).
 """
 
+import os
 from collections import OrderedDict
 
 from flask import Blueprint, abort, current_app, flash, redirect, render_template, request, send_from_directory, url_for
@@ -216,4 +217,9 @@ def serve_upload(filepath):
     if '..' in filepath or not filepath.startswith('equipment/'):
         abort(404)
     upload_path = current_app.config['UPLOAD_PATH']
-    return send_from_directory(upload_path, filepath)
+    # Split into directory and bare filename so send_from_directory receives a
+    # single path component without internal slashes (required by Werkzeug's
+    # safe_join, which rejects path components that contain os.sep).
+    directory = os.path.join(upload_path, os.path.dirname(filepath))
+    filename = os.path.basename(filepath)
+    return send_from_directory(directory, filename)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,7 @@
 """Smoke tests for ESB application."""
 
+import os
+
 from esb import create_app
 
 
@@ -38,3 +40,13 @@ class TestAppFactory:
         """Non-existent route returns 404."""
         resp = client.get('/nonexistent-route-that-does-not-exist')
         assert resp.status_code == 404
+
+    def test_upload_path_is_absolute(self):
+        """UPLOAD_PATH is normalized to an absolute path at startup.
+
+        Ensures file serving works regardless of the process working directory,
+        which differs between dev (project root) and Docker deployments (/app).
+        """
+        app = create_app('testing')
+        with app.app_context():
+            assert os.path.isabs(app.config['UPLOAD_PATH'])

--- a/tests/test_views/test_public_views.py
+++ b/tests/test_views/test_public_views.py
@@ -769,6 +769,20 @@ class TestServeUploadView:
         response = client.get('/public/uploads/repair/1/photos/secret.jpg')
         assert response.status_code == 404
 
+    def test_serves_equipment_photo(self, client, app, make_area, make_equipment, tmp_path):
+        """Serves a photo file from the equipment uploads directory."""
+        area = make_area(name='Shop')
+        equip = make_equipment(name='Drill', area=area)
+
+        photo_dir = tmp_path / 'equipment' / str(equip.id) / 'photos'
+        photo_dir.mkdir(parents=True)
+        (photo_dir / 'front.jpg').write_bytes(b'JPEG')
+
+        app.config['UPLOAD_PATH'] = str(tmp_path)
+        response = client.get(f'/public/uploads/equipment/{equip.id}/photos/front.jpg')
+        assert response.status_code == 200
+        assert response.data == b'JPEG'
+
     def test_returns_404_for_missing_file(self, client, app, tmp_path):
         """Returns 404 when requested file does not exist."""
         app.config['UPLOAD_PATH'] = str(tmp_path)


### PR DESCRIPTION
Fixes #7

**Root causes:**

1. `UPLOAD_PATH` defaulted to a relative path (`'uploads'`). Flask's `send_from_directory` resolves relative paths against the process working directory, which differs between development (project root) and Docker deployments (`/app` via `WORKDIR`). Normalizing to absolute in `create_app()` ensures consistent resolution regardless of deployment context.

2. `serve_upload` passed the full filepath (e.g. `equipment/2/docs/file.pdf`) as the second argument to `send_from_directory`. Werkzeug's `safe_join` rejects path components that contain `os.sep` (`/` on Linux), causing 404 for all public file requests. Fix splits the filepath into a directory and bare filename before the call.

Generated with [Claude Code](https://claude.ai/code)