### PR TITLE
Fix Claude Code workflow permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Grant `contents: write`, `pull-requests: write`, and `issues: write` to `claude.yml` so Claude can push branches, create PRs, and comment on issues
- Grant `pull-requests: write` and `issues: write` to `claude-code-review.yml` so Claude can post review comments on PRs
- Root cause of issue #7 (Claude did work but couldn't open a PR) and PR #19 (review ran but no comment posted)

## Context
Investigation found that both workflows had read-only permissions. Claude Code completed its work successfully (85 turns/$3.87 on issue #7, 14 turns/$0.79 reviewing PR #19) but couldn't write results back to GitHub due to insufficient permissions.

## Test plan
- [ ] Merge this PR and comment `@claude` on an issue to verify it can create a PR
- [ ] Open a PR to verify the code review workflow posts comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)