### PR TITLE
Link equipment tiles on status dashboard to QR code pages

### DIFF
--- a/esb/templates/public/status_dashboard.html
+++ b/esb/templates/public/status_dashboard.html
@@ -25,7 +25,7 @@
     <div class="row g-3">
       {% for item in area_data.equipment %}
       <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
-        <a href="{{ url_for('public.equipment_page', id=item.equipment.id) }}" class="text-decoration-none">
+        <a href="{{ url_for('public.equipment_page', id=item.equipment.id) }}" class="text-decoration-none text-reset d-block h-100">
           <div class="card h-100 status-card status-card-{{ item.status.color }}">
             <div class="card-body">
               <div class="d-flex justify-content-between align-items-start">

--- a/esb/templates/public/status_dashboard.html
+++ b/esb/templates/public/status_dashboard.html
@@ -25,19 +25,21 @@
     <div class="row g-3">
       {% for item in area_data.equipment %}
       <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
-        <div class="card h-100 status-card status-card-{{ item.status.color }}">
-          <div class="card-body">
-            <div class="d-flex justify-content-between align-items-start">
-              <h5 class="card-title mb-1">{{ item.equipment.name }}</h5>
-              {% set status = item.status %}
-              {% set variant = 'compact' %}
-              {% include 'components/_status_indicator.html' %}
+        <a href="{{ url_for('public.equipment_page', id=item.equipment.id) }}" class="text-decoration-none">
+          <div class="card h-100 status-card status-card-{{ item.status.color }}">
+            <div class="card-body">
+              <div class="d-flex justify-content-between align-items-start">
+                <h5 class="card-title mb-1">{{ item.equipment.name }}</h5>
+                {% set status = item.status %}
+                {% set variant = 'compact' %}
+                {% include 'components/_status_indicator.html' %}
+              </div>
+              {% if item.status.color != 'green' and item.status.issue_description %}
+              <p class="card-text text-muted small mt-2 mb-0">{{ item.status.issue_description }}</p>
+              {% endif %}
             </div>
-            {% if item.status.color != 'green' and item.status.issue_description %}
-            <p class="card-text text-muted small mt-2 mb-0">{{ item.status.issue_description }}</p>
-            {% endif %}
           </div>
-        </div>
+        </a>
       </div>
       {% endfor %}
     </div>

--- a/tests/test_views/test_public_views.py
+++ b/tests/test_views/test_public_views.py
@@ -197,6 +197,15 @@ class TestStatusDashboardView:
         response = staff_client.get('/public/')
         assert b'Spindle motor failed' in response.data
 
+    def test_equipment_tiles_link_to_equipment_page(self, client, make_area, make_equipment):
+        """Equipment tiles on the status dashboard link to the QR code equipment page (issue #13)."""
+        area = make_area(name='Shop')
+        equip = make_equipment(name='Table Saw', area=area)
+
+        response = client.get('/public/')
+        html = response.data.decode()
+        assert f'/public/equipment/{equip.id}' in html
+
     def test_not_sure_severity_displays_as_yellow(
         self, staff_client, make_area, make_equipment, make_repair_record,
     ):


### PR DESCRIPTION
Resolves #13: wraps each equipment card on /public/ in an anchor tag linking to /public/equipment/<id>, so users can tap/click a tile to reach the full equipment status and report-problem page.

Adds a test confirming the links are rendered.

Generated with [Claude Code](https://claude.ai/code)