### PR TITLE
Issue #9: Use container-fluid on Kanban page to eliminate unneeded horizontal scroll

### DIFF
--- a/esb/templates/base.html
+++ b/esb/templates/base.html
@@ -62,7 +62,7 @@
         </div>
     </nav>
 
-    <main class="container mt-3">
+    <main class="{% block main_container_class %}container{% endblock %} mt-3">
         {% include 'components/_flash_messages.html' %}
         {% block content %}{% endblock %}
     </main>

--- a/esb/templates/repairs/kanban.html
+++ b/esb/templates/repairs/kanban.html
@@ -2,6 +2,8 @@
 
 {% block title %}Kanban Board - Equipment Status Board{% endblock %}
 
+{% block main_container_class %}container-fluid{% endblock %}
+
 {% macro kanban_card(record) %}
 <a href="{{ url_for('repairs.detail', id=record.id) }}"
    class="card mb-2 text-decoration-none text-body kanban-card kanban-card-{{ record.aging_tier }}"

--- a/tests/test_views/test_repair_views.py
+++ b/tests/test_views/test_repair_views.py
@@ -1,5 +1,6 @@
 """Tests for repair record views."""
 
+import re
 from datetime import UTC, datetime, timedelta
 from io import BytesIO
 from unittest.mock import patch
@@ -9,6 +10,13 @@ from esb.models.document import Document
 from esb.models.repair_record import RepairRecord
 from esb.models.repair_timeline_entry import RepairTimelineEntry
 from esb.utils.exceptions import ValidationError
+
+
+def _main_element_classes(html: str) -> list[str]:
+    """Return the class list on the rendered ``<main>`` element."""
+    match = re.search(r'<main\b[^>]*\bclass="([^"]*)"', html)
+    assert match, 'no <main> element with class attribute found'
+    return match.group(1).split()
 
 
 class TestCreateRepairRecord:
@@ -813,14 +821,14 @@ class TestKanbanBoard:
         """Kanban page renders <main> with container-fluid so columns can use full viewport width (issue #9)."""
         resp = staff_client.get('/repairs/kanban')
         assert resp.status_code == 200
-        html = resp.data.decode()
-        assert '<main class="container-fluid mt-3">' in html
-        assert '<main class="container mt-3">' not in html
+        classes = _main_element_classes(resp.data.decode())
+        assert 'container-fluid' in classes
+        assert 'container' not in classes
 
     def test_non_kanban_pages_use_default_container(self, staff_client):
         """Non-kanban pages retain the default fixed-width .container wrapper."""
         resp = staff_client.get('/equipment/')
         assert resp.status_code == 200
-        html = resp.data.decode()
-        assert '<main class="container mt-3">' in html
-        assert '<main class="container-fluid mt-3">' not in html
+        classes = _main_element_classes(resp.data.decode())
+        assert 'container' in classes
+        assert 'container-fluid' not in classes

--- a/tests/test_views/test_repair_views.py
+++ b/tests/test_views/test_repair_views.py
@@ -808,3 +808,19 @@ class TestKanbanBoard:
         _db.session.commit()
         resp = staff_client.get('/repairs/kanban')
         assert b'kanban-card-hot' in resp.data
+
+    def test_kanban_uses_container_fluid(self, staff_client):
+        """Kanban page renders <main> with container-fluid so columns can use full viewport width (issue #9)."""
+        resp = staff_client.get('/repairs/kanban')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert '<main class="container-fluid mt-3">' in html
+        assert '<main class="container mt-3">' not in html
+
+    def test_non_kanban_pages_use_default_container(self, staff_client):
+        """Non-kanban pages retain the default fixed-width .container wrapper."""
+        resp = staff_client.get('/equipment/')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert '<main class="container mt-3">' in html
+        assert '<main class="container-fluid mt-3">' not in html


### PR DESCRIPTION
## Summary
- Fixes #9. The Kanban board lived inside the app's default Bootstrap `.container` (max 1320px). With seven 250px columns plus gaps the board is ~1800px, so wide displays showed unnecessary whitespace on each side while the board itself still needed horizontal scrolling.
- Added a `main_container_class` Jinja block in `base.html` and overrode it to `container-fluid` in `kanban.html`, so only the Kanban page spans the full viewport width. All other pages keep the fixed-width `.container` wrapper.
- Added two regression tests: one asserting the Kanban page uses `container-fluid`, and one asserting a non-Kanban page still uses `.container`.

## Test plan
- [x] `make test` — full suite passes (982 tests)
- [x] `make lint` — ruff clean
- [ ] Manual: on a >1800px-wide display, confirm Kanban columns span edge-to-edge within gutters and no horizontal scrollbar appears until columns actually exceed viewport width
- [ ] Manual: confirm non-Kanban pages (Equipment, Repairs, Admin, Status) are visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)