### PR TITLE
Issue #24: CSV equipment inventory export

### DIFF
--- a/docs/staff.md
+++ b/docs/staff.md
@@ -112,6 +112,15 @@ From the equipment detail page, you can upload and manage reference materials:
 
 When a piece of equipment is retired or removed from the space, archive it instead of deleting it. Archiving is a soft delete that preserves all history (repair records, documents, photos) while removing the equipment from active views.
 
+### Exporting the Inventory to CSV
+
+From the equipment registry page, click the **Export CSV** button (next to **Add Equipment**) to download a spreadsheet of the equipment inventory. The file (`equipment_inventory.csv`) opens directly in Excel, Google Sheets, LibreOffice Calc, or any other spreadsheet tool.
+
+The export includes one row per equipment item with these columns: `id`, `name`, `manufacturer`, `model`, `serial_number`, `area`, `acquisition_date`, `acquisition_source`, `acquisition_cost`, `warranty_expiration`, `description`, `is_archived`, `created_at`, and `updated_at`.
+
+- If you have an area filter applied on the registry page, the export is scoped to just that area. Clear the filter first if you want the full inventory.
+- Archived equipment is excluded by default. To include archived items, append `?include_archived=1` to the export URL (or combine with an area filter, e.g. `/equipment/export.csv?area_id=3&include_archived=1`).
+
 ![Equipment Detail Page](images/equipment-detail.png)
 
 ## Managing Areas

--- a/esb/services/equipment_service.py
+++ b/esb/services/equipment_service.py
@@ -443,15 +443,15 @@ CSV_EXPORT_COLUMNS = [
     'updated_at',
 ]
 
-_CSV_INJECTION_TRIGGERS = ('=', '+', '-', '@', '\t', '\r')
+_CSV_INJECTION_TRIGGERS = ('=', '+', '-', '@')
 
 
 def _sanitize_csv_cell(value):
     """Prefix formula-leading characters with a single quote to defuse Excel/LibreOffice injection.
 
-    Spreadsheet apps ignore leading whitespace when deciding whether a cell is a
-    formula, so detect triggers after any leading whitespace while preserving
-    the original string contents.
+    Spreadsheet apps ignore leading whitespace (including tabs and CRs) when
+    deciding whether a cell is a formula, so detect the formula triggers after
+    any leading whitespace while preserving the original string contents.
     """
     if isinstance(value, str) and value.lstrip().startswith(_CSV_INJECTION_TRIGGERS):
         return "'" + value

--- a/esb/services/equipment_service.py
+++ b/esb/services/equipment_service.py
@@ -4,6 +4,8 @@ All area/equipment business logic lives here. Views call these functions;
 they never query models directly.
 """
 
+import csv
+import io
 from datetime import date
 from decimal import Decimal
 
@@ -420,3 +422,70 @@ def get_equipment_links(equipment_id: int) -> list[ExternalLink]:
             .order_by(ExternalLink.created_at.desc())
         ).scalars().all()
     )
+
+
+CSV_EXPORT_COLUMNS = [
+    'id',
+    'name',
+    'manufacturer',
+    'model',
+    'serial_number',
+    'area',
+    'acquisition_date',
+    'acquisition_source',
+    'acquisition_cost',
+    'warranty_expiration',
+    'description',
+    'is_archived',
+    'created_at',
+    'updated_at',
+]
+
+_CSV_INJECTION_TRIGGERS = ('=', '+', '-', '@', '\t', '\r')
+
+
+def _sanitize_csv_cell(value):
+    """Prefix formula-leading characters with a single quote to defuse Excel/LibreOffice injection."""
+    if isinstance(value, str) and value.startswith(_CSV_INJECTION_TRIGGERS):
+        return "'" + value
+    return value
+
+
+def export_equipment_csv(
+    area_id: int | None = None,
+    include_archived: bool = False,
+) -> str:
+    """Return CSV text of equipment inventory.
+
+    Args:
+        area_id: If provided, limit export to equipment in this area.
+        include_archived: If True, include archived equipment in export.
+    """
+    query = db.select(Equipment).order_by(Equipment.name)
+    if not include_archived:
+        query = query.filter_by(is_archived=False)
+    if area_id is not None:
+        query = query.filter_by(area_id=area_id)
+    equipment = list(db.session.execute(query).scalars().all())
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(CSV_EXPORT_COLUMNS)
+    for eq in equipment:
+        writer.writerow([
+            eq.id,
+            _sanitize_csv_cell(eq.name),
+            _sanitize_csv_cell(eq.manufacturer),
+            _sanitize_csv_cell(eq.model),
+            _sanitize_csv_cell(eq.serial_number or ''),
+            _sanitize_csv_cell(eq.area.name) if eq.area else '',
+            eq.acquisition_date.isoformat() if eq.acquisition_date else '',
+            _sanitize_csv_cell(eq.acquisition_source or ''),
+            str(eq.acquisition_cost) if eq.acquisition_cost is not None else '',
+            eq.warranty_expiration.isoformat() if eq.warranty_expiration else '',
+            _sanitize_csv_cell(eq.description or ''),
+            'true' if eq.is_archived else 'false',
+            eq.created_at.isoformat() if eq.created_at else '',
+            eq.updated_at.isoformat() if eq.updated_at else '',
+        ])
+    return buf.getvalue()

--- a/esb/services/equipment_service.py
+++ b/esb/services/equipment_service.py
@@ -9,6 +9,8 @@ import io
 from datetime import date
 from decimal import Decimal
 
+from sqlalchemy.orm import joinedload
+
 from esb.extensions import db
 from esb.models.area import Area
 from esb.models.equipment import Equipment
@@ -445,23 +447,34 @@ _CSV_INJECTION_TRIGGERS = ('=', '+', '-', '@', '\t', '\r')
 
 
 def _sanitize_csv_cell(value):
-    """Prefix formula-leading characters with a single quote to defuse Excel/LibreOffice injection."""
-    if isinstance(value, str) and value.startswith(_CSV_INJECTION_TRIGGERS):
+    """Prefix formula-leading characters with a single quote to defuse Excel/LibreOffice injection.
+
+    Spreadsheet apps ignore leading whitespace when deciding whether a cell is a
+    formula, so detect triggers after any leading whitespace while preserving
+    the original string contents.
+    """
+    if isinstance(value, str) and value.lstrip().startswith(_CSV_INJECTION_TRIGGERS):
         return "'" + value
     return value
 
 
 def export_equipment_csv(
+    username: str,
     area_id: int | None = None,
     include_archived: bool = False,
 ) -> str:
-    """Return CSV text of equipment inventory.
+    """Return CSV text of equipment inventory and emit an audit log entry.
 
     Args:
+        username: User performing the export (recorded in the audit log).
         area_id: If provided, limit export to equipment in this area.
         include_archived: If True, include archived equipment in export.
     """
-    query = db.select(Equipment).order_by(Equipment.name)
+    query = (
+        db.select(Equipment)
+        .options(joinedload(Equipment.area))
+        .order_by(Equipment.name)
+    )
     if not include_archived:
         query = query.filter_by(is_archived=False)
     if area_id is not None:
@@ -488,4 +501,11 @@ def export_equipment_csv(
             eq.created_at.isoformat() if eq.created_at else '',
             eq.updated_at.isoformat() if eq.updated_at else '',
         ])
+
+    log_mutation('equipment.exported_csv', username, {
+        'area_id': area_id,
+        'include_archived': include_archived,
+        'row_count': len(equipment),
+    })
+
     return buf.getvalue()

--- a/esb/templates/equipment/list.html
+++ b/esb/templates/equipment/list.html
@@ -5,9 +5,13 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1>Equipment Registry</h1>
-    {% if current_user.role == 'staff' %}
-    <a href="{{ url_for('equipment.create') }}" class="btn btn-primary">Add Equipment</a>
-    {% endif %}
+    <div class="d-flex gap-2">
+        <a href="{{ url_for('equipment.export_csv', area_id=selected_area_id) if selected_area_id else url_for('equipment.export_csv') }}"
+           class="btn btn-outline-secondary">Export CSV</a>
+        {% if current_user.role == 'staff' %}
+        <a href="{{ url_for('equipment.create') }}" class="btn btn-primary">Add Equipment</a>
+        {% endif %}
+    </div>
 </div>
 
 <form method="GET" action="{{ url_for('equipment.index') }}" class="mb-3">

--- a/esb/views/equipment.py
+++ b/esb/views/equipment.py
@@ -60,7 +60,7 @@ def export_csv():
     body = ('\ufeff' + csv_text).encode('utf-8')
     return Response(
         body,
-        mimetype='text/csv; charset=utf-8',
+        content_type='text/csv; charset=utf-8',
         headers={
             'Content-Disposition': 'attachment; filename="equipment_inventory.csv"',
         },

--- a/esb/views/equipment.py
+++ b/esb/views/equipment.py
@@ -50,7 +50,7 @@ def index():
 def export_csv():
     """Download the equipment inventory as a CSV file."""
     area_id = request.args.get('area_id', type=int)
-    include_archived = request.args.get('include_archived', default='0') in ('1', 'true', 'True')
+    include_archived = request.args.get('include_archived', default='0').lower() in ('1', 'true')
     csv_text = equipment_service.export_equipment_csv(
         username=current_user.username,
         area_id=area_id,

--- a/esb/views/equipment.py
+++ b/esb/views/equipment.py
@@ -26,7 +26,6 @@ from esb.forms.equipment_forms import (
 from esb.services import equipment_service, upload_service
 from esb.utils.decorators import role_required
 from esb.utils.exceptions import ValidationError
-from esb.utils.logging import log_mutation
 
 equipment_bp = Blueprint('equipment', __name__, url_prefix='/equipment')
 
@@ -53,13 +52,10 @@ def export_csv():
     area_id = request.args.get('area_id', type=int)
     include_archived = request.args.get('include_archived', default='0') in ('1', 'true', 'True')
     csv_text = equipment_service.export_equipment_csv(
+        username=current_user.username,
         area_id=area_id,
         include_archived=include_archived,
     )
-    log_mutation('equipment.exported_csv', current_user.username, {
-        'area_id': area_id,
-        'include_archived': include_archived,
-    })
     # Prepend UTF-8 BOM so Excel opens non-ASCII correctly; serve as UTF-8.
     body = ('\ufeff' + csv_text).encode('utf-8')
     return Response(

--- a/esb/views/equipment.py
+++ b/esb/views/equipment.py
@@ -4,6 +4,7 @@ import os
 
 from flask import (
     Blueprint,
+    Response,
     abort,
     current_app,
     flash,
@@ -25,6 +26,7 @@ from esb.forms.equipment_forms import (
 from esb.services import equipment_service, upload_service
 from esb.utils.decorators import role_required
 from esb.utils.exceptions import ValidationError
+from esb.utils.logging import log_mutation
 
 equipment_bp = Blueprint('equipment', __name__, url_prefix='/equipment')
 
@@ -41,6 +43,31 @@ def index():
         equipment=equipment,
         areas=areas,
         selected_area_id=area_id,
+    )
+
+
+@equipment_bp.route('/export.csv')
+@login_required
+def export_csv():
+    """Download the equipment inventory as a CSV file."""
+    area_id = request.args.get('area_id', type=int)
+    include_archived = request.args.get('include_archived', default='0') in ('1', 'true', 'True')
+    csv_text = equipment_service.export_equipment_csv(
+        area_id=area_id,
+        include_archived=include_archived,
+    )
+    log_mutation('equipment.exported_csv', current_user.username, {
+        'area_id': area_id,
+        'include_archived': include_archived,
+    })
+    # Prepend UTF-8 BOM so Excel opens non-ASCII correctly; serve as UTF-8.
+    body = ('\ufeff' + csv_text).encode('utf-8')
+    return Response(
+        body,
+        mimetype='text/csv; charset=utf-8',
+        headers={
+            'Content-Disposition': 'attachment; filename="equipment_inventory.csv"',
+        },
     )
 
 

--- a/tests/test_services/test_equipment_service.py
+++ b/tests/test_services/test_equipment_service.py
@@ -960,13 +960,13 @@ class TestSearchEquipmentByName:
 
 
 class TestExportEquipmentCsv:
-    """Tests for equipment_service.export_equipment_csv()."""
+    """Tests for equipment_service.export_equipment_csv(username='tester')."""
 
     def test_returns_header_only_when_empty(self, app):
         """Empty equipment set returns only the CSV header."""
         from esb.services.equipment_service import export_equipment_csv, CSV_EXPORT_COLUMNS
 
-        csv_text = export_equipment_csv()
+        csv_text = export_equipment_csv(username='tester')
         lines = csv_text.strip().splitlines()
         assert len(lines) == 1
         assert lines[0] == ','.join(CSV_EXPORT_COLUMNS)
@@ -980,7 +980,7 @@ class TestExportEquipmentCsv:
         area = make_area('Woodshop', '#wood')
         make_equipment('Table Saw', 'SawStop', 'PCS', area=area)
 
-        reader = _csv.reader(_io.StringIO(export_equipment_csv()))
+        reader = _csv.reader(_io.StringIO(export_equipment_csv(username='tester')))
         header = next(reader)
         assert header == CSV_EXPORT_COLUMNS
 
@@ -997,12 +997,87 @@ class TestExportEquipmentCsv:
             serial_number='+1234',
             acquisition_source='-bad',
         )
-        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv())))
+        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv(username='tester'))))
         row = rows[0]
         assert row['name'].startswith("'=")
         assert row['description'].startswith("'@")
         assert row['serial_number'].startswith("'+")
         assert row['acquisition_source'].startswith("'-")
+
+    def test_formula_injection_defused_with_leading_whitespace(
+        self, app, make_area, make_equipment,
+    ):
+        """Formula triggers preceded by whitespace are still defused."""
+        import csv as _csv
+        import io as _io
+        from esb.services.equipment_service import export_equipment_csv
+
+        area = make_area('Woodshop', '#wood')
+        make_equipment(
+            ' =SUM(A1:A9)', 'SawStop', 'PCS', area=area,
+            description='\t=BAD()',
+        )
+        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv(username='tester'))))
+        row = rows[0]
+        # Original leading whitespace preserved, quote prepended
+        assert row['name'] == "' =SUM(A1:A9)"
+        assert row['description'].startswith("'")
+        assert '=BAD()' in row['description']
+
+    def test_export_is_audit_logged_by_service(
+        self, app, make_area, make_equipment, capture,
+    ):
+        """Service emits equipment.exported_csv mutation with username/filters/row count."""
+        import json as _json
+        from esb.services.equipment_service import export_equipment_csv
+
+        area = make_area('Woodshop', '#wood')
+        make_equipment('Table Saw', 'SawStop', 'PCS', area=area)
+        make_equipment('Drill Press', 'JET', 'JDP-17', area=area)
+        capture.records.clear()
+
+        export_equipment_csv(username='alice', area_id=area.id, include_archived=True)
+
+        entries = [
+            _json.loads(r.message) for r in capture.records
+            if 'equipment.exported_csv' in r.message
+        ]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry['user'] == 'alice'
+        assert entry['data']['area_id'] == area.id
+        assert entry['data']['include_archived'] is True
+        assert entry['data']['row_count'] == 2
+
+    def test_export_does_not_n_plus_one_on_area(
+        self, app, make_area, make_equipment, db,
+    ):
+        """Area name is eager-loaded; export does not fire a query per row."""
+        from sqlalchemy import event
+        from esb.services.equipment_service import export_equipment_csv
+
+        area = make_area('Woodshop', '#wood')
+        for i in range(5):
+            make_equipment(f'Item {i}', 'Co', 'M', area=area)
+
+        # Detach loaded equipment/area instances so the export fires fresh queries.
+        db.session.expire_all()
+
+        query_count = 0
+
+        def _count(conn, cursor, statement, params, context, executemany):
+            nonlocal query_count
+            query_count += 1
+
+        engine = db.engine
+        event.listen(engine, 'before_cursor_execute', _count)
+        try:
+            export_equipment_csv(username='tester')
+        finally:
+            event.remove(engine, 'before_cursor_execute', _count)
+
+        # One SELECT for equipment + area (joinedload); no per-row lazy loads.
+        assert query_count <= 2, f'expected eager-loaded export, saw {query_count} queries'
 
     def test_includes_all_active_equipment(self, app, make_area, make_equipment):
         """All non-archived equipment appears in export, ordered by name."""
@@ -1015,7 +1090,7 @@ class TestExportEquipmentCsv:
         make_equipment('Table Saw', 'SawStop', 'PCS', area=area)
         make_equipment('Drill Press', 'JET', 'JDP-17', area=area)
 
-        csv_text = export_equipment_csv()
+        csv_text = export_equipment_csv(username='tester')
         reader = _csv.DictReader(_io.StringIO(csv_text))
         rows = list(reader)
         assert [r['name'] for r in rows] == ['Band Saw', 'Drill Press', 'Table Saw']
@@ -1039,7 +1114,7 @@ class TestExportEquipmentCsv:
             description='Main table saw',
         )
 
-        csv_text = export_equipment_csv()
+        csv_text = export_equipment_csv(username='tester')
         rows = list(_csv.DictReader(_io.StringIO(csv_text)))
         assert len(rows) == 1
         row = rows[0]
@@ -1066,7 +1141,7 @@ class TestExportEquipmentCsv:
         area = make_area('Woodshop', '#wood')
         make_equipment('Basic Tool', 'Co', 'M1', area=area)
 
-        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv())))
+        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv(username='tester'))))
         row = rows[0]
         assert row['serial_number'] == ''
         assert row['acquisition_date'] == ''
@@ -1085,7 +1160,7 @@ class TestExportEquipmentCsv:
         make_equipment('Active', 'Co', 'M', area=area)
         make_equipment('Retired', 'Co', 'M', area=area, is_archived=True)
 
-        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv())))
+        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv(username='tester'))))
         names = [r['name'] for r in rows]
         assert names == ['Active']
 
@@ -1099,7 +1174,7 @@ class TestExportEquipmentCsv:
         make_equipment('Active', 'Co', 'M', area=area)
         make_equipment('Retired', 'Co', 'M', area=area, is_archived=True)
 
-        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv(include_archived=True))))
+        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv(username='tester', include_archived=True))))
         names = sorted(r['name'] for r in rows)
         assert names == ['Active', 'Retired']
         archived_row = next(r for r in rows if r['name'] == 'Retired')
@@ -1116,7 +1191,7 @@ class TestExportEquipmentCsv:
         make_equipment('Table Saw', 'SawStop', 'PCS', area=wood)
         make_equipment('Welder', 'Lincoln', '210MP', area=metal)
 
-        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv(area_id=wood.id))))
+        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv(username='tester', area_id=wood.id))))
         assert [r['name'] for r in rows] == ['Table Saw']
 
     def test_field_with_comma_is_quoted(self, app, make_area, make_equipment):
@@ -1128,5 +1203,5 @@ class TestExportEquipmentCsv:
             'Saw', 'Co', 'M', area=area,
             description='Model A, with stand',
         )
-        csv_text = export_equipment_csv()
+        csv_text = export_equipment_csv(username='tester')
         assert '"Model A, with stand"' in csv_text

--- a/tests/test_services/test_equipment_service.py
+++ b/tests/test_services/test_equipment_service.py
@@ -957,3 +957,176 @@ class TestSearchEquipmentByName:
         # '_' should not act as a single-char wildcard
         result = search_equipment_by_name('_')
         assert result == []
+
+
+class TestExportEquipmentCsv:
+    """Tests for equipment_service.export_equipment_csv()."""
+
+    def test_returns_header_only_when_empty(self, app):
+        """Empty equipment set returns only the CSV header."""
+        from esb.services.equipment_service import export_equipment_csv, CSV_EXPORT_COLUMNS
+
+        csv_text = export_equipment_csv()
+        lines = csv_text.strip().splitlines()
+        assert len(lines) == 1
+        assert lines[0] == ','.join(CSV_EXPORT_COLUMNS)
+
+    def test_header_column_order_is_stable(self, app, make_area, make_equipment):
+        """Header row matches CSV_EXPORT_COLUMNS exactly, including order."""
+        import csv as _csv
+        import io as _io
+        from esb.services.equipment_service import export_equipment_csv, CSV_EXPORT_COLUMNS
+
+        area = make_area('Woodshop', '#wood')
+        make_equipment('Table Saw', 'SawStop', 'PCS', area=area)
+
+        reader = _csv.reader(_io.StringIO(export_equipment_csv()))
+        header = next(reader)
+        assert header == CSV_EXPORT_COLUMNS
+
+    def test_formula_injection_is_defused(self, app, make_area, make_equipment):
+        """Fields starting with formula triggers are prefixed with a single quote."""
+        import csv as _csv
+        import io as _io
+        from esb.services.equipment_service import export_equipment_csv
+
+        area = make_area('Woodshop', '#wood')
+        make_equipment(
+            '=SUM(A1:A9)', 'SawStop', 'PCS', area=area,
+            description='@cmd|/c calc',
+            serial_number='+1234',
+            acquisition_source='-bad',
+        )
+        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv())))
+        row = rows[0]
+        assert row['name'].startswith("'=")
+        assert row['description'].startswith("'@")
+        assert row['serial_number'].startswith("'+")
+        assert row['acquisition_source'].startswith("'-")
+
+    def test_includes_all_active_equipment(self, app, make_area, make_equipment):
+        """All non-archived equipment appears in export, ordered by name."""
+        import csv as _csv
+        import io as _io
+        from esb.services.equipment_service import export_equipment_csv
+
+        area = make_area('Woodshop', '#wood')
+        make_equipment('Band Saw', 'Jet', 'JWBS', area=area)
+        make_equipment('Table Saw', 'SawStop', 'PCS', area=area)
+        make_equipment('Drill Press', 'JET', 'JDP-17', area=area)
+
+        csv_text = export_equipment_csv()
+        reader = _csv.DictReader(_io.StringIO(csv_text))
+        rows = list(reader)
+        assert [r['name'] for r in rows] == ['Band Saw', 'Drill Press', 'Table Saw']
+
+    def test_populates_all_relevant_fields(self, app, make_area, make_equipment):
+        """Each required field is exported correctly."""
+        import csv as _csv
+        import io as _io
+        from decimal import Decimal
+        from datetime import date
+        from esb.services.equipment_service import export_equipment_csv
+
+        area = make_area('Woodshop', '#wood')
+        make_equipment(
+            'Table Saw', 'SawStop', 'PCS', area=area,
+            serial_number='SN123',
+            acquisition_date=date(2022, 5, 10),
+            acquisition_source='Donation',
+            acquisition_cost=Decimal('1234.56'),
+            warranty_expiration=date(2025, 5, 10),
+            description='Main table saw',
+        )
+
+        csv_text = export_equipment_csv()
+        rows = list(_csv.DictReader(_io.StringIO(csv_text)))
+        assert len(rows) == 1
+        row = rows[0]
+        assert row['name'] == 'Table Saw'
+        assert row['manufacturer'] == 'SawStop'
+        assert row['model'] == 'PCS'
+        assert row['serial_number'] == 'SN123'
+        assert row['area'] == 'Woodshop'
+        assert row['acquisition_date'] == '2022-05-10'
+        assert row['acquisition_source'] == 'Donation'
+        assert row['acquisition_cost'] == '1234.56'
+        assert row['warranty_expiration'] == '2025-05-10'
+        assert row['description'] == 'Main table saw'
+        assert row['is_archived'] == 'false'
+        assert row['created_at']
+        assert row['updated_at']
+
+    def test_null_fields_exported_as_empty(self, app, make_area, make_equipment):
+        """None-valued optional fields are exported as empty strings."""
+        import csv as _csv
+        import io as _io
+        from esb.services.equipment_service import export_equipment_csv
+
+        area = make_area('Woodshop', '#wood')
+        make_equipment('Basic Tool', 'Co', 'M1', area=area)
+
+        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv())))
+        row = rows[0]
+        assert row['serial_number'] == ''
+        assert row['acquisition_date'] == ''
+        assert row['acquisition_source'] == ''
+        assert row['acquisition_cost'] == ''
+        assert row['warranty_expiration'] == ''
+        assert row['description'] == ''
+
+    def test_excludes_archived_by_default(self, app, make_area, make_equipment):
+        """Archived equipment is not included unless requested."""
+        import csv as _csv
+        import io as _io
+        from esb.services.equipment_service import export_equipment_csv
+
+        area = make_area('Woodshop', '#wood')
+        make_equipment('Active', 'Co', 'M', area=area)
+        make_equipment('Retired', 'Co', 'M', area=area, is_archived=True)
+
+        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv())))
+        names = [r['name'] for r in rows]
+        assert names == ['Active']
+
+    def test_include_archived_option(self, app, make_area, make_equipment):
+        """include_archived=True yields archived rows too."""
+        import csv as _csv
+        import io as _io
+        from esb.services.equipment_service import export_equipment_csv
+
+        area = make_area('Woodshop', '#wood')
+        make_equipment('Active', 'Co', 'M', area=area)
+        make_equipment('Retired', 'Co', 'M', area=area, is_archived=True)
+
+        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv(include_archived=True))))
+        names = sorted(r['name'] for r in rows)
+        assert names == ['Active', 'Retired']
+        archived_row = next(r for r in rows if r['name'] == 'Retired')
+        assert archived_row['is_archived'] == 'true'
+
+    def test_area_filter(self, app, make_area, make_equipment):
+        """area_id filter restricts output to equipment in that area."""
+        import csv as _csv
+        import io as _io
+        from esb.services.equipment_service import export_equipment_csv
+
+        wood = make_area('Woodshop', '#wood')
+        metal = make_area('Metal Shop', '#metal')
+        make_equipment('Table Saw', 'SawStop', 'PCS', area=wood)
+        make_equipment('Welder', 'Lincoln', '210MP', area=metal)
+
+        rows = list(_csv.DictReader(_io.StringIO(export_equipment_csv(area_id=wood.id))))
+        assert [r['name'] for r in rows] == ['Table Saw']
+
+    def test_field_with_comma_is_quoted(self, app, make_area, make_equipment):
+        """Fields containing commas are properly quoted."""
+        from esb.services.equipment_service import export_equipment_csv
+
+        area = make_area('Woodshop', '#wood')
+        make_equipment(
+            'Saw', 'Co', 'M', area=area,
+            description='Model A, with stand',
+        )
+        csv_text = export_equipment_csv()
+        assert '"Model A, with stand"' in csv_text

--- a/tests/test_views/test_equipment_views.py
+++ b/tests/test_views/test_equipment_views.py
@@ -1256,10 +1256,13 @@ class TestExportCsv:
         assert b'/equipment/export.csv' in resp.data
 
     def test_response_is_utf8_with_bom(self, staff_client, make_equipment):
-        """Response body starts with a UTF-8 BOM and declares charset=utf-8."""
+        """Response body starts with a UTF-8 BOM and declares charset=utf-8 exactly once."""
         make_equipment('Équipe Saw', 'SawStop', 'PCS')
         resp = staff_client.get('/equipment/export.csv')
-        assert 'charset=utf-8' in resp.headers.get('Content-Type', '').lower()
+        content_type = resp.headers.get('Content-Type', '').lower()
+        assert 'charset=utf-8' in content_type
+        # Guard against a duplicated "charset=utf-8; charset=utf-8" header.
+        assert content_type.count('charset=') == 1
         assert resp.data.startswith(b'\xef\xbb\xbf')
         body = resp.data.decode('utf-8-sig')
         assert 'Équipe Saw' in body

--- a/tests/test_views/test_equipment_views.py
+++ b/tests/test_views/test_equipment_views.py
@@ -1249,6 +1249,31 @@ class TestExportCsv:
         body = resp.data.decode('utf-8')
         assert 'Old Saw' in body
 
+    def test_include_archived_parsing_is_case_insensitive(
+        self, staff_client, make_equipment, db,
+    ):
+        """include_archived accepts truthy values regardless of case."""
+        eq = make_equipment('Old Saw', 'OldCo', 'Old')
+        eq.is_archived = True
+        db.session.commit()
+
+        for value in ('TRUE', 'True', 'true', 'TrUe'):
+            resp = staff_client.get(f'/equipment/export.csv?include_archived={value}')
+            body = resp.data.decode('utf-8')
+            assert 'Old Saw' in body, f'value={value!r} did not enable archived rows'
+
+    def test_include_archived_false_excludes_archived(
+        self, staff_client, make_equipment, db,
+    ):
+        """include_archived with a non-truthy value does not bring archived rows."""
+        eq = make_equipment('Old Saw', 'OldCo', 'Old')
+        eq.is_archived = True
+        db.session.commit()
+
+        resp = staff_client.get('/equipment/export.csv?include_archived=no')
+        body = resp.data.decode('utf-8')
+        assert 'Old Saw' not in body
+
     def test_list_page_has_export_button(self, staff_client):
         """Equipment list page exposes the Export CSV link."""
         resp = staff_client.get('/equipment/')

--- a/tests/test_views/test_equipment_views.py
+++ b/tests/test_views/test_equipment_views.py
@@ -1171,3 +1171,110 @@ class TestDocumentMutationLogging:
             if 'equipment_link.deleted' in r.message
         ]
         assert len(entries) == 1
+
+
+class TestExportCsv:
+    """Tests for GET /equipment/export.csv."""
+
+    def test_unauthenticated_redirects_to_login(self, client):
+        """Unauthenticated users are redirected to login."""
+        resp = client.get('/equipment/export.csv')
+        assert resp.status_code == 302
+        assert '/auth/login' in resp.headers['Location']
+
+    def test_staff_can_download(self, staff_client, make_equipment):
+        """Staff can download the CSV export."""
+        make_equipment('Table Saw', 'SawStop', 'PCS')
+        resp = staff_client.get('/equipment/export.csv')
+        assert resp.status_code == 200
+        assert resp.mimetype == 'text/csv'
+        assert 'attachment' in resp.headers.get('Content-Disposition', '')
+        assert 'equipment_inventory.csv' in resp.headers.get('Content-Disposition', '')
+
+    def test_tech_can_download(self, tech_client, make_equipment):
+        """Technicians can download the CSV export."""
+        make_equipment('Drill Press', 'JET', 'JDP-17')
+        resp = tech_client.get('/equipment/export.csv')
+        assert resp.status_code == 200
+
+    def test_csv_content_includes_equipment(self, staff_client, make_equipment):
+        """CSV body contains the equipment name and identifying fields."""
+        make_equipment('Table Saw', 'SawStop', 'PCS')
+        resp = staff_client.get('/equipment/export.csv')
+        body = resp.data.decode('utf-8')
+        assert 'Table Saw' in body
+        assert 'SawStop' in body
+        assert 'PCS' in body
+
+    def test_csv_has_header_row(self, staff_client):
+        """First CSV line is the header row."""
+        resp = staff_client.get('/equipment/export.csv')
+        body = resp.data.decode('utf-8')
+        first_line = body.splitlines()[0]
+        assert 'name' in first_line
+        assert 'manufacturer' in first_line
+        assert 'model' in first_line
+        assert 'serial_number' in first_line
+        assert 'area' in first_line
+
+    def test_area_filter_applies(self, staff_client, make_area, make_equipment):
+        """Passing area_id restricts export to that area."""
+        wood = make_area('Woodshop', '#wood')
+        metal = make_area('Metal Shop', '#metal')
+        make_equipment('Table Saw', 'SawStop', 'PCS', area=wood)
+        make_equipment('Welder', 'Lincoln', '210MP', area=metal)
+
+        resp = staff_client.get(f'/equipment/export.csv?area_id={wood.id}')
+        body = resp.data.decode('utf-8')
+        assert 'Table Saw' in body
+        assert 'Welder' not in body
+
+    def test_archived_excluded_by_default(self, staff_client, make_equipment, db):
+        """Archived equipment is not in the default export."""
+        eq = make_equipment('Old Saw', 'OldCo', 'Old')
+        eq.is_archived = True
+        db.session.commit()
+
+        resp = staff_client.get('/equipment/export.csv')
+        body = resp.data.decode('utf-8')
+        assert 'Old Saw' not in body
+
+    def test_include_archived_parameter(self, staff_client, make_equipment, db):
+        """include_archived=1 brings archived rows into the export."""
+        eq = make_equipment('Old Saw', 'OldCo', 'Old')
+        eq.is_archived = True
+        db.session.commit()
+
+        resp = staff_client.get('/equipment/export.csv?include_archived=1')
+        body = resp.data.decode('utf-8')
+        assert 'Old Saw' in body
+
+    def test_list_page_has_export_button(self, staff_client):
+        """Equipment list page exposes the Export CSV link."""
+        resp = staff_client.get('/equipment/')
+        assert b'Export CSV' in resp.data
+        assert b'/equipment/export.csv' in resp.data
+
+    def test_response_is_utf8_with_bom(self, staff_client, make_equipment):
+        """Response body starts with a UTF-8 BOM and declares charset=utf-8."""
+        make_equipment('Équipe Saw', 'SawStop', 'PCS')
+        resp = staff_client.get('/equipment/export.csv')
+        assert 'charset=utf-8' in resp.headers.get('Content-Type', '').lower()
+        assert resp.data.startswith(b'\xef\xbb\xbf')
+        body = resp.data.decode('utf-8-sig')
+        assert 'Équipe Saw' in body
+
+    def test_export_is_audit_logged(self, staff_client, make_equipment, capture):
+        """Downloading the CSV emits an equipment.exported_csv mutation log."""
+        make_equipment('Table Saw', 'SawStop', 'PCS')
+        capture.records.clear()
+        resp = staff_client.get('/equipment/export.csv?include_archived=1')
+        assert resp.status_code == 200
+        entries = [
+            json.loads(r.message) for r in capture.records
+            if 'equipment.exported_csv' in r.message
+        ]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry['user'] == 'staffuser'
+        assert entry['data']['include_archived'] is True


### PR DESCRIPTION
## Summary
- Adds an **Export CSV** button on the equipment registry page and a new `GET /equipment/export.csv` route that returns the full inventory as a spreadsheet-friendly CSV.
- Export includes all relevant fields per issue #24: id, name, manufacturer, model, serial_number, area, acquisition_date/source/cost, warranty_expiration, description, is_archived, created_at, updated_at. Honors the current `area_id` filter; accepts `include_archived=1`.
- Hardening: UTF-8 output with BOM for Excel, defuses CSV formula injection on user-controlled text fields, and emits an `equipment.exported_csv` mutation log entry.

Closes #24

## Test plan
- [x] Service-level tests: header ordering, field population, null handling, archived exclusion/inclusion, area filter, comma-quoting, formula-injection defusal
- [x] View-level tests: auth redirect, staff/tech download, CSV content + header, area filter, archived handling, list-page button presence, UTF-8 BOM + charset, audit log emission
- [x] Full suite passes (1003 tests); `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)