### PR TITLE
Harden notification worker against silent hangs; add Prometheus metrics

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,7 +26,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # Allowed tools: plugin's required tools + project-specific tools for running tests/lint
           claude_args: |
-            --allowedTools "Read,Glob,Grep,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*),Bash(make:*),Bash(venv/bin/python -m pytest:*),Bash(venv/bin/ruff:*),Bash(ruff:*),Bash(python:*),Bash(python3:*),Bash(pip:*),Bash(pip3:*),Bash(python3 -m venv:*),Bash(source:*),Bash(venv/bin/python:*),Bash(venv/bin/pip:*),Bash(grep:*),Bash(find:*),Bash(ls:*),Bash(cat:*),Bash(wc:*),Bash(git:*),Bash(test:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Glob,Grep,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*),Bash(make:*),Bash(venv/bin/python -m pytest:*),Bash(venv/bin/ruff:*),Bash(ruff:*),Bash(python:*),Bash(python3:*),Bash(pip:*),Bash(pip3:*),Bash(python3 -m venv:*),Bash(source:*),Bash(venv/bin/python:*),Bash(venv/bin/pip:*),Bash(grep:*),Bash(find:*),Bash(ls:*),Bash(cat:*),Bash(wc:*),Bash(git:*),Bash(test:*)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,17 @@ services:
       - SLACK_SOCKET_MODE_CONNECT=true
     volumes:
       - ./uploads:/app/uploads
+    healthcheck:
+      # Use Python (already in the image) rather than curl/wget which the
+      # python:3.14-slim base does not include. /health does not touch the
+      # DB, so this catches gunicorn wedges / OOM, not DB-side hangs.
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:5000/health', timeout=5).status == 200 else 1)"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      - autoheal=true
     restart: unless-stopped
 
   db:
@@ -34,6 +45,32 @@ services:
       db:
         condition: service_healthy
     env_file: .env
+    environment:
+      # Force unbuffered stdout/stderr so log lines reach journald immediately
+      # instead of sitting in Python's block buffer when stdout is not a TTY.
+      - PYTHONUNBUFFERED=1
+    healthcheck:
+      # The worker writes /tmp/worker_heartbeat once at startup and then again
+      # at the end of every successful poll iteration. If that file is older
+      # than 180s, the loop is wedged inside the DB poll or notification
+      # handler -- exactly the hang we are guarding against.
+      test: ["CMD", "sh", "-c", "test $(($(date +%s) - $(stat -c %Y /tmp/worker_heartbeat))) -lt 180"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 120s
+    labels:
+      # Picked up by the autoheal sidecar to restart this container when
+      # Docker reports it as unhealthy.
+      - autoheal=true
+    restart: unless-stopped
+
+  autoheal:
+    image: willfarrell/autoheal:latest
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL=autoheal
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,9 @@ services:
       # file is older than 180s the loop is wedged inside the DB poll or a
       # single notification handler -- exactly the hang we are guarding
       # against. The path here is locked to WORKER_HEARTBEAT_PATH above.
-      test: ["CMD", "sh", "-c", "test $(($(date +%s) - $(stat -c %Y /tmp/worker_heartbeat))) -lt 180"]
+      # The explicit -f guard makes the missing-file failure mode intentional
+      # rather than relying on a sh syntax error from an empty $(stat ...).
+      test: ["CMD", "sh", "-c", "[ -f /tmp/worker_heartbeat ] && test $(($(date +%s) - $(stat -c %Y /tmp/worker_heartbeat))) -lt 180"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -71,7 +73,9 @@ services:
     restart: unless-stopped
 
   autoheal:
-    image: willfarrell/autoheal:latest
+    # Pinned to a specific version (rather than :latest) for reproducible
+    # deployments, consistent with how the mariadb image is pinned above.
+    image: willfarrell/autoheal:1.2.0
     environment:
       - AUTOHEAL_CONTAINER_LABEL=autoheal
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,11 +49,16 @@ services:
       # Force unbuffered stdout/stderr so log lines reach journald immediately
       # instead of sitting in Python's block buffer when stdout is not a TTY.
       - PYTHONUNBUFFERED=1
+      # The heartbeat path is intentionally pinned here so it cannot drift out
+      # of sync with the healthcheck command below. `environment:` overrides
+      # any value coming from env_file, so this is authoritative.
+      - WORKER_HEARTBEAT_PATH=/tmp/worker_heartbeat
     healthcheck:
-      # The worker writes /tmp/worker_heartbeat once at startup and then again
-      # at the end of every successful poll iteration. If that file is older
-      # than 180s, the loop is wedged inside the DB poll or notification
-      # handler -- exactly the hang we are guarding against.
+      # The worker writes /tmp/worker_heartbeat at startup, after each DB poll
+      # returns, and after each individual notification is processed. If that
+      # file is older than 180s the loop is wedged inside the DB poll or a
+      # single notification handler -- exactly the hang we are guarding
+      # against. The path here is locked to WORKER_HEARTBEAT_PATH above.
       test: ["CMD", "sh", "-c", "test $(($(date +%s) - $(stat -c %Y /tmp/worker_heartbeat))) -lt 180"]
       interval: 30s
       timeout: 5s

--- a/docs/administrators.md
+++ b/docs/administrators.md
@@ -128,11 +128,11 @@ Background notification processor. Polls the database every 30 seconds for pendi
 - **Image:** Same as the app service
 - **Command:** `flask worker run`
 - **Depends on:** `db` service
-- **Healthcheck:** The worker writes `/tmp/worker_heartbeat` at the top of every poll iteration. Docker reports the container as unhealthy if the heartbeat file is older than 180 seconds, which catches a wedged loop (e.g. silently dropped DB connection).
+- **Healthcheck:** The worker writes `/tmp/worker_heartbeat` at three points: once at startup, once after each DB poll returns, and once after each individual notification is processed. Docker reports the container as unhealthy if the heartbeat file is older than 180 seconds, which catches a wedged loop (e.g. silently dropped DB connection or a single Slack call hung past its timeout). Refreshing per-notification — rather than only at the end of an iteration — means a legitimately long batch of slow Slack calls cannot falsely trip the healthcheck.
 
 ### Autoheal Sidecar
 
-Docker on its own does not restart unhealthy containers — it only marks them unhealthy. The `autoheal` service (`willfarrell/autoheal`) watches for containers labelled `autoheal=true` (currently the worker) and restarts any that go unhealthy. It needs the host's Docker socket mounted so it can issue restart commands:
+Docker on its own does not restart unhealthy containers — it only marks them unhealthy. The `autoheal` service (`willfarrell/autoheal`) watches for containers labelled `autoheal=true` (the `worker` and `app` services) and restarts any that go unhealthy. It needs the host's Docker socket mounted so it can issue restart commands:
 
 ```yaml
 autoheal:

--- a/docs/administrators.md
+++ b/docs/administrators.md
@@ -335,7 +335,7 @@ The background worker processes pending notifications every 30 seconds. It inclu
 docker compose logs -f worker
 ```
 
-The worker container also exposes a Docker healthcheck driven by a heartbeat file (`/tmp/worker_heartbeat`) updated at the top of every poll iteration. To check current health:
+The worker container also exposes a Docker healthcheck driven by a heartbeat file (`/tmp/worker_heartbeat`) refreshed at three points: at startup, after each DB poll returns, and after each individual notification is processed. The healthcheck fails when the file is older than 180 seconds. To check current health:
 
 ```bash
 docker inspect --format '{{.State.Health.Status}}' equipment-status-board-worker-1

--- a/docs/administrators.md
+++ b/docs/administrators.md
@@ -128,8 +128,25 @@ Background notification processor. Polls the database every 30 seconds for pendi
 - **Image:** Same as the app service
 - **Command:** `flask worker run`
 - **Depends on:** `db` service
+- **Healthcheck:** The worker writes `/tmp/worker_heartbeat` at the top of every poll iteration. Docker reports the container as unhealthy if the heartbeat file is older than 180 seconds, which catches a wedged loop (e.g. silently dropped DB connection).
 
-All three services have a restart policy of `unless-stopped`, meaning they automatically restart after crashes or host reboots (unless explicitly stopped).
+### Autoheal Sidecar
+
+Docker on its own does not restart unhealthy containers — it only marks them unhealthy. The `autoheal` service (`willfarrell/autoheal`) watches for containers labelled `autoheal=true` (currently the worker) and restarts any that go unhealthy. It needs the host's Docker socket mounted so it can issue restart commands:
+
+```yaml
+autoheal:
+  image: willfarrell/autoheal:latest
+  environment:
+    - AUTOHEAL_CONTAINER_LABEL=autoheal
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+  restart: unless-stopped
+```
+
+If you do not want autoheal running on your host, you can remove the service from `docker-compose.yml`; the worker's healthcheck will still reflect status in `docker compose ps`, you'll just need to restart it manually when it goes unhealthy.
+
+All four services have a restart policy of `unless-stopped`, meaning they automatically restart after crashes or host reboots (unless explicitly stopped).
 
 ### Runtime Dependencies
 
@@ -317,6 +334,47 @@ The background worker processes pending notifications every 30 seconds. It inclu
 ```bash
 docker compose logs -f worker
 ```
+
+The worker container also exposes a Docker healthcheck driven by a heartbeat file (`/tmp/worker_heartbeat`) updated at the top of every poll iteration. To check current health:
+
+```bash
+docker inspect --format '{{.State.Health.Status}}' equipment-status-board-worker-1
+```
+
+If the worker is reported as `unhealthy`, the autoheal sidecar will restart it automatically (typically within a minute).
+
+### Prometheus Metrics
+
+The application exposes a Prometheus exposition endpoint at `/metrics` (unauthenticated). Two gauges are published from the `pending_notifications` table:
+
+| Metric | Description |
+|--------|-------------|
+| `esb_pending_notifications_count` | Number of rows with `status='pending'`. Always present. |
+| `esb_oldest_pending_notification_timestamp_seconds` | Unix epoch (seconds) of the oldest pending row's `created_at`. **Omitted entirely** when the queue is empty — alert rules should rely on `absent()` rather than checking for a sentinel value. |
+
+These two metrics together catch a stuck worker, a bad Slack token, and a Slack outage — the queue grows and the oldest pending row ages.
+
+Example Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: esb
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['esb.example.com:5000']
+```
+
+Example alert rule (oldest pending row stuck for more than 5 minutes):
+
+```yaml
+- alert: ESBNotificationQueueStuck
+  expr: time() - esb_oldest_pending_notification_timestamp_seconds > 300
+  for: 1m
+  annotations:
+    summary: "ESB notification worker is not draining the queue"
+```
+
+The alert evaluates `time() - X` against a fresh timestamp on every scrape, which is more robust than a worker-computed "age" gauge that would be stale between scrapes.
 
 ### Upload Storage
 

--- a/esb/__init__.py
+++ b/esb/__init__.py
@@ -118,7 +118,10 @@ def create_app(config_name='default'):
         from esb.services import metrics_service
 
         body, content_type = metrics_service.render_metrics()
-        return Response(body, mimetype=content_type)
+        # Use content_type (not mimetype) so the full Prometheus exposition
+        # Content-Type header (which includes 'version=...; charset=utf-8')
+        # is preserved verbatim. Flask's mimetype= drops parameters.
+        return Response(body, content_type=content_type)
 
     # CLI commands
     _register_cli(app)

--- a/esb/__init__.py
+++ b/esb/__init__.py
@@ -108,6 +108,18 @@ def create_app(config_name='default'):
     def health():
         return 'ok'
 
+    # Unauthenticated Prometheus metrics endpoint. Exposes two gauges from
+    # the pending_notifications table so a stuck worker, a bad Slack token,
+    # or a Slack outage shows up as queue growth / staleness in Prometheus.
+    @app.route('/metrics')
+    def metrics():
+        from flask import Response
+
+        from esb.services import metrics_service
+
+        body, content_type = metrics_service.render_metrics()
+        return Response(body, mimetype=content_type)
+
     # CLI commands
     _register_cli(app)
 

--- a/esb/config.py
+++ b/esb/config.py
@@ -4,6 +4,29 @@ import os
 from datetime import timedelta
 
 
+def build_engine_options(database_url: str) -> dict:
+    """Compute SQLAlchemy engine options tuned to the database URL.
+
+    pool_pre_ping detects silently-dropped TCP connections (NAT/conntrack/
+    firewall) before the next query blocks on recv() forever; pool_recycle
+    bounds idle connection age. The MariaDB/MySQL connect_args provide
+    socket-level timeouts so a wedged read cannot hang the worker
+    indefinitely. The connect_args are MariaDB-specific and are omitted for
+    other drivers (e.g. SQLite, which would raise TypeError on these kwargs).
+    """
+    options: dict = {
+        'pool_pre_ping': True,
+        'pool_recycle': 1800,
+    }
+    if database_url.startswith(('mysql', 'mariadb')):
+        options['connect_args'] = {
+            'connect_timeout': 10,
+            'read_timeout': 30,
+            'write_timeout': 30,
+        }
+    return options
+
+
 class Config:
     """Base configuration."""
 
@@ -13,6 +36,8 @@ class Config:
         'DATABASE_URL', 'mysql+pymysql://root:password@localhost/esb'
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_ENGINE_OPTIONS = build_engine_options(SQLALCHEMY_DATABASE_URI)
+    WORKER_HEARTBEAT_PATH = os.environ.get('WORKER_HEARTBEAT_PATH', '/tmp/worker_heartbeat')
     UPLOAD_PATH = os.environ.get('UPLOAD_PATH', 'uploads')
     UPLOAD_MAX_SIZE_MB = int(os.environ.get('UPLOAD_MAX_SIZE_MB', '500'))
     MAX_CONTENT_LENGTH = UPLOAD_MAX_SIZE_MB * 1024 * 1024
@@ -39,6 +64,7 @@ class TestingConfig(Config):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
     WTF_CSRF_ENABLED = False
+    SQLALCHEMY_ENGINE_OPTIONS = build_engine_options(SQLALCHEMY_DATABASE_URI)
 
 
 class SlackTestConfig(TestingConfig):
@@ -57,6 +83,7 @@ class ScreenshotConfig(Config):
     """Configuration for screenshot generation script."""
 
     SQLALCHEMY_DATABASE_URI = 'sqlite:////tmp/esb_screenshots.db'
+    SQLALCHEMY_ENGINE_OPTIONS = build_engine_options(SQLALCHEMY_DATABASE_URI)
 
 
 config = {

--- a/esb/services/metrics_service.py
+++ b/esb/services/metrics_service.py
@@ -1,0 +1,88 @@
+"""Prometheus metrics for the notification queue.
+
+Exposes two gauges that, together, catch a stuck worker, a bad Slack token,
+or a Slack outage:
+
+- ``esb_pending_notifications_count`` — count of rows with status='pending'.
+- ``esb_oldest_pending_notification_timestamp_seconds`` — Unix epoch seconds
+  of the oldest pending row's ``created_at``. **Omitted entirely** when the
+  table has no pending rows; Prometheus alert rules should use ``absent()``
+  rather than a sentinel value.
+
+Alert rules belong in Prometheus, not here. Example::
+
+    time() - esb_oldest_pending_notification_timestamp_seconds > 300
+"""
+
+from datetime import UTC
+
+from prometheus_client import CollectorRegistry, generate_latest
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.exposition import CONTENT_TYPE_LATEST
+
+from esb.extensions import db
+from esb.models.pending_notification import PendingNotification
+
+
+def _query_pending_stats() -> tuple[int, float | None]:
+    """Return (pending_count, oldest_created_at_unix_seconds_or_None)."""
+    count = db.session.execute(
+        db.select(db.func.count(PendingNotification.id))
+        .filter_by(status='pending')
+    ).scalar_one()
+
+    oldest = db.session.execute(
+        db.select(db.func.min(PendingNotification.created_at))
+        .filter_by(status='pending')
+    ).scalar_one()
+
+    if oldest is None:
+        return count, None
+
+    # SQLAlchemy may return naive datetimes (SQLite) or aware datetimes
+    # (MariaDB driver). Treat naive values as UTC -- created_at is always
+    # written as datetime.now(UTC) by the model.
+    if oldest.tzinfo is None:
+        oldest = oldest.replace(tzinfo=UTC)
+
+    return count, oldest.timestamp()
+
+
+class _PendingNotificationsCollector:
+    """Custom collector so the oldest-timestamp metric can be omitted entirely
+    when the queue is empty (rather than emitting a misleading 0 sample).
+
+    Each scrape runs two cheap aggregate queries against the live DB. With the
+    default Dockerfile gunicorn config (1 worker, 2 threads) this is at most
+    two queries per scrape interval. If gunicorn is scaled to N workers the
+    DB load multiplies by N, since each worker handles its own scrape with
+    its own request-scoped DB session.
+    """
+
+    def collect(self):
+        count, oldest_ts = _query_pending_stats()
+
+        yield GaugeMetricFamily(
+            'esb_pending_notifications_count',
+            'Number of notifications in the queue with status=pending.',
+            value=count,
+        )
+
+        if oldest_ts is not None:
+            yield GaugeMetricFamily(
+                'esb_oldest_pending_notification_timestamp_seconds',
+                'Unix timestamp (seconds) of the oldest pending notification. '
+                'Omitted when the queue is empty.',
+                value=oldest_ts,
+            )
+
+
+def render_metrics() -> tuple[bytes, str]:
+    """Render the Prometheus exposition payload and content-type.
+
+    Returns:
+        Tuple of (body, content_type) suitable for a Flask response.
+    """
+    registry = CollectorRegistry()
+    registry.register(_PendingNotificationsCollector())
+    return generate_latest(registry), CONTENT_TYPE_LATEST

--- a/esb/services/metrics_service.py
+++ b/esb/services/metrics_service.py
@@ -25,16 +25,20 @@ from esb.models.pending_notification import PendingNotification
 
 
 def _query_pending_stats() -> tuple[int, float | None]:
-    """Return (pending_count, oldest_created_at_unix_seconds_or_None)."""
-    count = db.session.execute(
-        db.select(db.func.count(PendingNotification.id))
-        .filter_by(status='pending')
-    ).scalar_one()
+    """Return (pending_count, oldest_created_at_unix_seconds_or_None).
 
-    oldest = db.session.execute(
-        db.select(db.func.min(PendingNotification.created_at))
-        .filter_by(status='pending')
-    ).scalar_one()
+    Both aggregates come from a single SELECT so the count and oldest
+    timestamp are guaranteed to be drawn from the same row snapshot
+    (under any isolation level) and so each scrape is one DB round-trip
+    rather than two.
+    """
+    count, oldest = db.session.execute(
+        db.select(
+            db.func.count(PendingNotification.id),
+            db.func.min(PendingNotification.created_at),
+        )
+        .where(PendingNotification.status == 'pending')
+    ).one()
 
     if oldest is None:
         return count, None
@@ -52,11 +56,11 @@ class _PendingNotificationsCollector:
     """Custom collector so the oldest-timestamp metric can be omitted entirely
     when the queue is empty (rather than emitting a misleading 0 sample).
 
-    Each scrape runs two cheap aggregate queries against the live DB. With the
-    default Dockerfile gunicorn config (1 worker, 2 threads) this is at most
-    two queries per scrape interval. If gunicorn is scaled to N workers the
-    DB load multiplies by N, since each worker handles its own scrape with
-    its own request-scoped DB session.
+    Each scrape runs one combined aggregate query against the live DB. With
+    the default Dockerfile gunicorn config (1 worker, 2 threads) this is at
+    most one query per scrape interval. If gunicorn is scaled to N workers
+    the DB load multiplies by N, since each worker handles its own scrape
+    with its own request-scoped DB session.
     """
 
     def collect(self):

--- a/esb/services/notification_service.py
+++ b/esb/services/notification_service.py
@@ -344,10 +344,14 @@ def run_worker_loop(poll_interval: int = 30) -> None:
     heartbeat_path = Path(current_app.config['WORKER_HEARTBEAT_PATH'])
 
     # Write an initial heartbeat so the file exists for the Docker healthcheck
-    # before the first iteration completes. After this, the heartbeat is only
-    # refreshed after a full iteration successfully returns -- so a hang inside
-    # get_pending_notifications() or process_notification() leaves the file
-    # stale and the healthcheck (and autoheal) will catch it.
+    # before the first iteration completes. After this, the heartbeat is
+    # refreshed at every point of forward progress: after the DB poll returns,
+    # and after each notification is processed (success or recorded failure).
+    # A hang inside get_pending_notifications() or inside a single
+    # process_notification() call leaves the file stale, so the healthcheck
+    # (and autoheal) will catch it. Refreshing per-notification matters because
+    # a large batch of slow Slack calls (DEFAULT_BATCH_SIZE=100 * 15s timeout)
+    # can otherwise legitimately exceed the 180s healthcheck threshold.
     _write_heartbeat(heartbeat_path)
 
     logger.info(
@@ -360,6 +364,9 @@ def run_worker_loop(poll_interval: int = 30) -> None:
     while not _shutdown:
         try:
             notifications = get_pending_notifications()
+            # Refresh after the DB poll returns: an idle iteration with no
+            # pending rows still represents forward progress.
+            _write_heartbeat(heartbeat_path)
             consecutive_poll_failures = 0  # Reset on successful poll
             if notifications:
                 logger.info('Processing %d pending notification(s)', len(notifications))
@@ -384,11 +391,10 @@ def run_worker_loop(poll_interval: int = 30) -> None:
                         'Notification %d delivery failed: %s', notification.id, e,
                         exc_info=True,
                     )
-
-            # Refresh heartbeat only after a fully successful iteration --
-            # i.e. the DB poll returned and any per-notification work either
-            # succeeded or was caught and recorded as failed.
-            _write_heartbeat(heartbeat_path)
+                # Refresh after each notification regardless of outcome -- a
+                # long but progressing batch of slow Slack calls must not be
+                # mistaken for a hang.
+                _write_heartbeat(heartbeat_path)
 
         except Exception:
             consecutive_poll_failures += 1

--- a/esb/services/notification_service.py
+++ b/esb/services/notification_service.py
@@ -4,6 +4,7 @@ import logging
 import signal
 import time
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 from esb.extensions import db
 from esb.models.pending_notification import PendingNotification
@@ -23,6 +24,17 @@ VALID_NOTIFICATION_TYPES = {'slack_message', 'static_page_push'}
 
 # Default batch size for polling queries
 DEFAULT_BATCH_SIZE = 100
+
+
+def _write_heartbeat(path: Path) -> None:
+    """Touch the worker heartbeat file. Logged-but-swallowed on OSError so a
+    transient filesystem hiccup cannot abort the loop."""
+    try:
+        path.touch()
+    except OSError:
+        logger.warning(
+            'Failed to update worker heartbeat at %s', path, exc_info=True,
+        )
 
 
 def queue_notification(
@@ -196,7 +208,9 @@ def _deliver_slack_message(notification: PendingNotification) -> None:
 
     from slack_sdk import WebClient
 
-    client = WebClient(token=token)
+    # timeout caps each Slack HTTP call so a hung connection cannot wedge the
+    # worker loop indefinitely.
+    client = WebClient(token=token, timeout=15)
     payload = notification.payload or {}
     text, blocks = _format_slack_message(payload)
 
@@ -315,6 +329,8 @@ def run_worker_loop(poll_interval: int = 30) -> None:
     Args:
         poll_interval: Seconds between polling cycles (default 30).
     """
+    from flask import current_app
+
     _shutdown = False
 
     def _handle_signal(signum, frame):
@@ -325,7 +341,19 @@ def run_worker_loop(poll_interval: int = 30) -> None:
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)
 
-    logger.info('Worker started, polling every %d seconds', poll_interval)
+    heartbeat_path = Path(current_app.config['WORKER_HEARTBEAT_PATH'])
+
+    # Write an initial heartbeat so the file exists for the Docker healthcheck
+    # before the first iteration completes. After this, the heartbeat is only
+    # refreshed after a full iteration successfully returns -- so a hang inside
+    # get_pending_notifications() or process_notification() leaves the file
+    # stale and the healthcheck (and autoheal) will catch it.
+    _write_heartbeat(heartbeat_path)
+
+    logger.info(
+        'Worker started, polling every %d seconds (heartbeat=%s)',
+        poll_interval, heartbeat_path,
+    )
 
     consecutive_poll_failures = 0
 
@@ -356,6 +384,11 @@ def run_worker_loop(poll_interval: int = 30) -> None:
                         'Notification %d delivery failed: %s', notification.id, e,
                         exc_info=True,
                     )
+
+            # Refresh heartbeat only after a fully successful iteration --
+            # i.e. the DB poll returned and any per-notification work either
+            # succeeded or was caught and recorded as failed.
+            _write_heartbeat(heartbeat_path)
 
         except Exception:
             consecutive_poll_failures += 1

--- a/esb/services/user_service.py
+++ b/esb/services/user_service.py
@@ -262,7 +262,9 @@ def _deliver_temp_password_via_slack(
         return False
 
     try:
-        client = WebClient(token=token)
+        # timeout caps each Slack HTTP call so a hung connection cannot block
+        # the request handler indefinitely.
+        client = WebClient(token=token, timeout=15)
         resp = client.users_lookupByEmail(email=user.email)
         slack_user_id = resp['user']['id']
 

--- a/esb/services/user_service.py
+++ b/esb/services/user_service.py
@@ -262,9 +262,12 @@ def _deliver_temp_password_via_slack(
         return False
 
     try:
-        # timeout caps each Slack HTTP call so a hung connection cannot block
-        # the request handler indefinitely.
-        client = WebClient(token=token, timeout=15)
+        # 8s per call (rather than 15s like the worker) because this path
+        # makes three sequential calls -- users_lookupByEmail,
+        # conversations_open, chat_postMessage -- and runs synchronously in a
+        # web request. 3 * 8s = 24s stays comfortably under gunicorn's default
+        # 30s worker_timeout.
+        client = WebClient(token=token, timeout=8)
         resp = client.users_lookupByEmail(email=user.email)
         slack_user_id = resp['user']['id']
 

--- a/esb/slack/__init__.py
+++ b/esb/slack/__init__.py
@@ -33,8 +33,13 @@ def init_slack(app):
         return
 
     from slack_bolt import App
+    from slack_sdk import WebClient
 
-    _bolt_app = App(token=token)
+    # Pin the Bolt-managed WebClient to the same 15s timeout used by the
+    # service-layer call sites. Without this, slash-command handlers receive a
+    # WebClient with slack_sdk's default timeout=30, which is too long for the
+    # request path -- a Slack outage could wedge a handler thread.
+    _bolt_app = App(token=token, client=WebClient(token=token, timeout=15))
 
     # Register command and view submission handlers
     from esb.slack.handlers import register_handlers

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pyzbar>=0.1.9
 boto3>=1.35.0
 google-cloud-storage>=2.18.0
 newrelic>=10.0.0
+prometheus_client>=0.20.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,86 @@
+"""Tests for esb.config -- focused on engine option wiring.
+
+The engine options were introduced to fix a worker hang caused by silently
+dropped DB connections; a regression here would silently re-introduce the
+bug, so explicit tests guard the wiring.
+"""
+
+from esb.config import (
+    Config,
+    ProductionConfig,
+    ScreenshotConfig,
+    TestingConfig,
+    build_engine_options,
+)
+
+
+class TestBuildEngineOptions:
+    def test_mysql_url_includes_socket_timeouts(self):
+        opts = build_engine_options('mysql+pymysql://root:x@db/esb')
+        assert opts['pool_pre_ping'] is True
+        assert opts['pool_recycle'] == 1800
+        assert opts['connect_args'] == {
+            'connect_timeout': 10,
+            'read_timeout': 30,
+            'write_timeout': 30,
+        }
+
+    def test_mariadb_url_includes_socket_timeouts(self):
+        opts = build_engine_options('mariadb+pymysql://root:x@db/esb')
+        assert 'connect_args' in opts
+        assert opts['connect_args']['read_timeout'] == 30
+
+    def test_sqlite_url_omits_connect_args(self):
+        # Critical: sqlite would raise TypeError on connect_timeout etc.
+        opts = build_engine_options('sqlite:///:memory:')
+        assert opts['pool_pre_ping'] is True
+        assert opts['pool_recycle'] == 1800
+        assert 'connect_args' not in opts
+
+    def test_postgres_url_omits_connect_args(self):
+        # Defensive: any non-MariaDB driver should not get MariaDB kwargs.
+        opts = build_engine_options('postgresql://x@db/esb')
+        assert 'connect_args' not in opts
+
+
+class TestConfigEngineOptions:
+    def test_production_config_has_engine_options(self):
+        # ProductionConfig inherits from Config which builds options from the
+        # default DATABASE_URL (mysql+pymysql://...) so connect_args must be present.
+        opts = ProductionConfig.SQLALCHEMY_ENGINE_OPTIONS
+        assert opts['pool_pre_ping'] is True
+        assert opts['pool_recycle'] == 1800
+        assert opts['connect_args']['connect_timeout'] == 10
+
+    def test_base_config_engine_options_match_uri(self):
+        # The base Config's options are computed from its URI.
+        assert Config.SQLALCHEMY_ENGINE_OPTIONS == build_engine_options(
+            Config.SQLALCHEMY_DATABASE_URI,
+        )
+
+    def test_testing_config_omits_connect_args(self):
+        # SQLite -- must not have MariaDB kwargs.
+        opts = TestingConfig.SQLALCHEMY_ENGINE_OPTIONS
+        assert 'connect_args' not in opts
+
+    def test_screenshot_config_omits_connect_args(self):
+        opts = ScreenshotConfig.SQLALCHEMY_ENGINE_OPTIONS
+        assert 'connect_args' not in opts
+
+
+class TestEngineOptionsAppliedToApp:
+    def test_pool_pre_ping_applied_to_engine(self, app):
+        """The configured pool options reach the SQLAlchemy engine.
+
+        Tests with TestingConfig (sqlite); the relevant assertion is that
+        the options dict actually flows through Flask-SQLAlchemy to the
+        engine, not the specific MariaDB kwargs.
+        """
+        engine = app.extensions['sqlalchemy'].engine
+        # pool_pre_ping is implemented as an event listener on the pool;
+        # SQLAlchemy exposes it via the engine's pool's _pre_ping attr.
+        assert engine.pool._pre_ping is True
+
+    def test_pool_recycle_applied_to_engine(self, app):
+        engine = app.extensions['sqlalchemy'].engine
+        assert engine.pool._recycle == 1800

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,13 +44,21 @@ class TestBuildEngineOptions:
 
 
 class TestConfigEngineOptions:
-    def test_production_config_has_engine_options(self):
-        # ProductionConfig inherits from Config which builds options from the
-        # default DATABASE_URL (mysql+pymysql://...) so connect_args must be present.
-        opts = ProductionConfig.SQLALCHEMY_ENGINE_OPTIONS
-        assert opts['pool_pre_ping'] is True
-        assert opts['pool_recycle'] == 1800
-        assert opts['connect_args']['connect_timeout'] == 10
+    def test_production_config_options_match_its_uri(self):
+        # ProductionConfig's options must be the same as build_engine_options()
+        # would produce for its DATABASE_URI -- whatever that URI happens to be
+        # (CI sets it to sqlite via env). This guards the wiring without
+        # depending on environment.
+        assert ProductionConfig.SQLALCHEMY_ENGINE_OPTIONS == build_engine_options(
+            ProductionConfig.SQLALCHEMY_DATABASE_URI,
+        )
+
+    def test_pool_options_always_present(self):
+        # Pool options should be present regardless of driver.
+        for cfg in (Config, ProductionConfig, TestingConfig, ScreenshotConfig):
+            opts = cfg.SQLALCHEMY_ENGINE_OPTIONS
+            assert opts['pool_pre_ping'] is True
+            assert opts['pool_recycle'] == 1800
 
     def test_base_config_engine_options_match_uri(self):
         # The base Config's options are computed from its URI.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,9 @@ dropped DB connections; a regression here would silently re-introduce the
 bug, so explicit tests guard the wiring.
 """
 
+import importlib
+import sys
+
 from esb.config import (
     Config,
     ProductionConfig,
@@ -74,6 +77,40 @@ class TestConfigEngineOptions:
     def test_screenshot_config_omits_connect_args(self):
         opts = ScreenshotConfig.SQLALCHEMY_ENGINE_OPTIONS
         assert 'connect_args' not in opts
+
+    def test_production_config_with_mysql_url_includes_connect_args(
+        self, monkeypatch,
+    ):
+        """Reload esb.config under a MariaDB DATABASE_URL and verify that
+        ProductionConfig actually carries the connect_args.
+
+        The cheaper "options match build_engine_options(uri)" test passes
+        trivially in CI (where DATABASE_URL is sqlite), so this reload-based
+        test is what actually catches a regression that drops the wiring on
+        the production path.
+        """
+        monkeypatch.setenv(
+            'DATABASE_URL', 'mysql+pymysql://root:x@db/esb',
+        )
+        # esb/__init__.py does `from esb.config import config`, which
+        # overrides the package's `.config` attribute with the dict, so
+        # `esb.config` no longer points at the module. Reach for the module
+        # via sys.modules instead.
+        config_module = sys.modules['esb.config']
+        reloaded = importlib.reload(config_module)
+        try:
+            opts = reloaded.ProductionConfig.SQLALCHEMY_ENGINE_OPTIONS
+            assert opts['pool_pre_ping'] is True
+            assert opts['pool_recycle'] == 1800
+            assert opts['connect_args'] == {
+                'connect_timeout': 10,
+                'read_timeout': 30,
+                'write_timeout': 30,
+            }
+        finally:
+            # Restore the module under the original env so other tests are
+            # not disturbed (monkeypatch restores the env var itself).
+            importlib.reload(config_module)
 
 
 class TestEngineOptionsAppliedToApp:

--- a/tests/test_services/test_metrics_service.py
+++ b/tests/test_services/test_metrics_service.py
@@ -1,0 +1,100 @@
+"""Tests for the Prometheus metrics service."""
+
+import re
+from datetime import UTC, datetime, timedelta
+
+from esb.extensions import db as _db
+from esb.models.pending_notification import PendingNotification
+from esb.services import metrics_service
+
+
+def _extract_metric(text: str, name: str) -> float | None:
+    """Extract the value of an unlabelled metric from exposition text."""
+    match = re.search(rf'^{re.escape(name)} (\S+)$', text, re.MULTILINE)
+    return float(match.group(1)) if match else None
+
+
+def _make_pending(created_at, status='pending'):
+    n = PendingNotification(
+        notification_type='slack_message',
+        target='#test',
+        payload={'msg': 'x'},
+        status=status,
+        created_at=created_at,
+    )
+    _db.session.add(n)
+    _db.session.commit()
+    return n
+
+
+class TestQueryPendingStats:
+    def test_empty_table_returns_zero_and_none(self, app):
+        count, oldest_ts = metrics_service._query_pending_stats()
+        assert count == 0
+        assert oldest_ts is None
+
+    def test_only_delivered_rows_returns_zero_and_none(self, app):
+        _make_pending(datetime.now(UTC) - timedelta(minutes=5), status='delivered')
+        _make_pending(datetime.now(UTC) - timedelta(minutes=2), status='failed')
+        count, oldest_ts = metrics_service._query_pending_stats()
+        assert count == 0
+        assert oldest_ts is None
+
+    def test_counts_only_pending(self, app):
+        _make_pending(datetime.now(UTC), status='pending')
+        _make_pending(datetime.now(UTC), status='pending')
+        _make_pending(datetime.now(UTC), status='delivered')
+        count, _ = metrics_service._query_pending_stats()
+        assert count == 2
+
+    def test_oldest_timestamp_is_min_created_at(self, app):
+        oldest = datetime.now(UTC) - timedelta(minutes=10)
+        middle = datetime.now(UTC) - timedelta(minutes=5)
+        newest = datetime.now(UTC)
+        _make_pending(middle)
+        _make_pending(oldest)
+        _make_pending(newest)
+        _, oldest_ts = metrics_service._query_pending_stats()
+        # Allow a tiny float tolerance, but values come from datetime.timestamp()
+        # so should match exactly.
+        assert oldest_ts == oldest.timestamp()
+
+    def test_oldest_timestamp_ignores_non_pending(self, app):
+        # An older delivered row must not affect the oldest pending value.
+        _make_pending(datetime.now(UTC) - timedelta(hours=1), status='delivered')
+        pending_at = datetime.now(UTC) - timedelta(minutes=2)
+        _make_pending(pending_at)
+        _, oldest_ts = metrics_service._query_pending_stats()
+        assert oldest_ts == pending_at.timestamp()
+
+
+class TestRenderMetrics:
+    def test_content_type_is_prometheus_exposition(self, app):
+        _, content_type = metrics_service.render_metrics()
+        assert 'text/plain' in content_type
+
+    def test_empty_table_omits_oldest_metric(self, app):
+        body, _ = metrics_service.render_metrics()
+        text = body.decode()
+        assert 'esb_pending_notifications_count 0.0' in text
+        assert 'esb_oldest_pending_notification_timestamp_seconds' not in text
+
+    def test_populated_table_includes_both_metrics(self, app):
+        oldest = datetime.now(UTC) - timedelta(minutes=7)
+        _make_pending(oldest)
+        _make_pending(datetime.now(UTC))
+
+        body, _ = metrics_service.render_metrics()
+        text = body.decode()
+        assert _extract_metric(text, 'esb_pending_notifications_count') == 2.0
+        # prometheus_client formats large floats in scientific notation, so
+        # parse the value rather than matching the literal.
+        ts = _extract_metric(text, 'esb_oldest_pending_notification_timestamp_seconds')
+        assert ts is not None
+        assert abs(ts - oldest.timestamp()) < 0.001
+
+    def test_help_and_type_lines_present(self, app):
+        body, _ = metrics_service.render_metrics()
+        text = body.decode()
+        assert '# HELP esb_pending_notifications_count' in text
+        assert '# TYPE esb_pending_notifications_count gauge' in text

--- a/tests/test_services/test_notification_service.py
+++ b/tests/test_services/test_notification_service.py
@@ -546,6 +546,147 @@ class TestRunWorkerLoop:
         # Second call: success, normal poll_interval (5s)
         assert sleep_calls[1] == 5
 
+    def test_writes_initial_heartbeat_before_first_iteration(self, app, tmp_path):
+        """Heartbeat file exists for the Docker healthcheck before any work runs."""
+        heartbeat = tmp_path / 'hb'
+        app.config['WORKER_HEARTBEAT_PATH'] = str(heartbeat)
+
+        # Force shutdown inside get_pending_notifications, BEFORE the post-work
+        # heartbeat refresh, to prove the initial heartbeat is what's writing.
+        def shutdown_and_raise(batch_size=100):
+            raise KeyboardInterrupt
+
+        with patch.object(notification_service, 'get_pending_notifications',
+                          side_effect=shutdown_and_raise), \
+             patch('esb.services.notification_service.signal'), \
+             patch('esb.services.notification_service.time'):
+            try:
+                run_worker_loop(poll_interval=1)
+            except KeyboardInterrupt:
+                pass
+
+        assert heartbeat.exists()
+
+    def test_refreshes_heartbeat_after_iteration(self, app, tmp_path):
+        """Heartbeat mtime advances on each successful iteration, not before."""
+        heartbeat = tmp_path / 'hb'
+        app.config['WORKER_HEARTBEAT_PATH'] = str(heartbeat)
+        # Pre-create the file with an ancient mtime so we can detect the refresh.
+        heartbeat.touch()
+        import os
+        os.utime(heartbeat, (1000, 1000))
+        ancient = heartbeat.stat().st_mtime
+        assert ancient == 1000
+
+        with patch.object(notification_service, 'get_pending_notifications',
+                          return_value=[]), \
+             patch('esb.services.notification_service.signal'), \
+             patch('esb.services.notification_service.time') as mock_time:
+            mock_time.sleep.side_effect = KeyboardInterrupt
+            try:
+                run_worker_loop(poll_interval=1)
+            except KeyboardInterrupt:
+                pass
+
+        assert heartbeat.stat().st_mtime > ancient
+
+    def test_heartbeat_not_refreshed_when_iteration_hangs(self, app, tmp_path):
+        """If get_pending_notifications hangs (raises), the post-iteration
+        heartbeat refresh does NOT run, so the file stays stale and the
+        Docker healthcheck will catch the hang."""
+        heartbeat = tmp_path / 'hb'
+        app.config['WORKER_HEARTBEAT_PATH'] = str(heartbeat)
+
+        # Hang -> the polling-error path runs time.sleep(backoff). Trigger
+        # shutdown there before the next iteration.
+        with patch.object(notification_service, 'get_pending_notifications',
+                          side_effect=RuntimeError('DB hung')), \
+             patch('esb.services.notification_service.signal'), \
+             patch('esb.services.notification_service.time') as mock_time:
+            mock_time.sleep.side_effect = KeyboardInterrupt
+            try:
+                run_worker_loop(poll_interval=1)
+            except KeyboardInterrupt:
+                pass
+
+        # Initial heartbeat was written; capture that mtime.
+        initial_mtime = heartbeat.stat().st_mtime
+
+        # Now run a second time without the failing poll, but pre-set the
+        # heartbeat to an old mtime, then enter the failing path -- the mtime
+        # should NOT advance because the post-iteration refresh is skipped
+        # when the inner try block raised.
+        import os
+        os.utime(heartbeat, (initial_mtime - 100, initial_mtime - 100))
+        old_mtime = heartbeat.stat().st_mtime
+
+        with patch.object(notification_service, 'get_pending_notifications',
+                          side_effect=RuntimeError('DB hung')), \
+             patch('esb.services.notification_service.signal'), \
+             patch('esb.services.notification_service.time') as mock_time:
+            mock_time.sleep.side_effect = KeyboardInterrupt
+            try:
+                run_worker_loop(poll_interval=1)
+            except KeyboardInterrupt:
+                pass
+
+        # The initial-heartbeat write at the top of run_worker_loop() will
+        # have refreshed it, but the post-iteration refresh did NOT run.
+        # We assert the difference relative to the post-loop value: we know
+        # only one write happened (the startup write), not two.
+        # Hardest part to test directly is "did the loop end-of-iter run", so
+        # use a counter via _write_heartbeat.
+        # See test_write_heartbeat_count_per_iteration for that assertion.
+        assert heartbeat.stat().st_mtime >= old_mtime
+
+    def test_write_heartbeat_count_per_iteration(self, app, tmp_path):
+        """_write_heartbeat is called twice per successful iteration in the
+        steady state: once at startup, once at the end of each iteration."""
+        heartbeat = tmp_path / 'hb'
+        app.config['WORKER_HEARTBEAT_PATH'] = str(heartbeat)
+
+        with patch.object(notification_service, 'get_pending_notifications',
+                          return_value=[]), \
+             patch.object(notification_service, '_write_heartbeat',
+                          wraps=notification_service._write_heartbeat) as mock_hb, \
+             patch('esb.services.notification_service.signal'), \
+             patch('esb.services.notification_service.time') as mock_time:
+            calls_done = []
+
+            def stop_after_two_iterations(_):
+                calls_done.append(1)
+                if len(calls_done) >= 2:
+                    raise KeyboardInterrupt
+
+            mock_time.sleep.side_effect = stop_after_two_iterations
+
+            try:
+                run_worker_loop(poll_interval=1)
+            except KeyboardInterrupt:
+                pass
+
+        # 1 startup + 2 end-of-iteration = 3
+        assert mock_hb.call_count == 3
+
+    def test_heartbeat_oserror_swallowed(self, app, tmp_path, caplog):
+        """A failed heartbeat write logs a warning but does not abort the loop."""
+        # Point at a path that cannot be created.
+        heartbeat = tmp_path / 'nope' / 'nested' / 'hb'
+        app.config['WORKER_HEARTBEAT_PATH'] = str(heartbeat)
+
+        with patch.object(notification_service, 'get_pending_notifications',
+                          return_value=[]), \
+             patch('esb.services.notification_service.signal'), \
+             patch('esb.services.notification_service.time') as mock_time:
+            mock_time.sleep.side_effect = KeyboardInterrupt
+            with caplog.at_level('WARNING', logger='esb.services.notification_service'):
+                try:
+                    run_worker_loop(poll_interval=1)
+                except KeyboardInterrupt:
+                    pass
+
+        assert any('heartbeat' in r.getMessage().lower() for r in caplog.records)
+
 
 class TestDeliverSlackMessage:
     """Tests for _deliver_slack_message()."""
@@ -744,7 +885,7 @@ class TestDeliverSlackMessage:
                    return_value=mock_client) as mock_cls:
             notification_service._deliver_slack_message(n)
 
-        mock_cls.assert_called_once_with(token='xoxb-test-token')
+        mock_cls.assert_called_once_with(token='xoxb-test-token', timeout=15)
 
     def test_oops_network_error_does_not_fail_delivery(self, app):
         """Non-SlackApiError exceptions from #oops post don't fail delivery."""

--- a/tests/test_services/test_notification_service.py
+++ b/tests/test_services/test_notification_service.py
@@ -567,7 +567,7 @@ class TestRunWorkerLoop:
 
         assert heartbeat.exists()
 
-    def test_refreshes_heartbeat_after_iteration(self, app, tmp_path):
+    def test_refreshes_heartbeat_after_db_poll(self, app, tmp_path):
         """Heartbeat mtime advances on each successful iteration, not before."""
         heartbeat = tmp_path / 'hb'
         app.config['WORKER_HEARTBEAT_PATH'] = str(heartbeat)
@@ -639,9 +639,9 @@ class TestRunWorkerLoop:
         # See test_write_heartbeat_count_per_iteration for that assertion.
         assert heartbeat.stat().st_mtime >= old_mtime
 
-    def test_write_heartbeat_count_per_iteration(self, app, tmp_path):
-        """_write_heartbeat is called twice per successful iteration in the
-        steady state: once at startup, once at the end of each iteration."""
+    def test_write_heartbeat_count_per_iteration_empty(self, app, tmp_path):
+        """With no pending notifications, _write_heartbeat is called once at
+        startup, plus once after the DB poll in each iteration."""
         heartbeat = tmp_path / 'hb'
         app.config['WORKER_HEARTBEAT_PATH'] = str(heartbeat)
 
@@ -665,8 +665,39 @@ class TestRunWorkerLoop:
             except KeyboardInterrupt:
                 pass
 
-        # 1 startup + 2 end-of-iteration = 3
+        # 1 startup + 2 post-poll = 3 (no per-notification writes since batch was empty)
         assert mock_hb.call_count == 3
+
+    def test_write_heartbeat_per_notification(self, app, tmp_path):
+        """Heartbeat is refreshed after each notification, not just per iteration --
+        a long batch of slow Slack calls must not falsely trip the healthcheck."""
+        heartbeat = tmp_path / 'hb'
+        app.config['WORKER_HEARTBEAT_PATH'] = str(heartbeat)
+        # Three pending notifications.
+        n1 = _create_notification()
+        n2 = _create_notification()
+        n3 = _create_notification()
+
+        with patch.object(notification_service, 'process_notification') as mock_proc, \
+             patch.object(notification_service, '_write_heartbeat',
+                          wraps=notification_service._write_heartbeat) as mock_hb, \
+             patch('esb.services.notification_service.signal'), \
+             patch('esb.services.notification_service.time') as mock_time:
+            mock_proc.return_value = None  # All deliveries "succeed"
+            mock_time.sleep.side_effect = KeyboardInterrupt
+
+            try:
+                run_worker_loop(poll_interval=1)
+            except KeyboardInterrupt:
+                pass
+
+        # 1 startup + 1 post-poll + 3 per-notification = 5
+        assert mock_hb.call_count == 5
+        # Sanity: all three were processed.
+        assert mock_proc.call_count == 3
+        for n in (n1, n2, n3):
+            _db.session.expire(n)
+            assert _db.session.get(PendingNotification, n.id).status == 'delivered'
 
     def test_heartbeat_oserror_swallowed(self, app, tmp_path, caplog):
         """A failed heartbeat write logs a warning but does not abort the loop."""

--- a/tests/test_services/test_notification_service.py
+++ b/tests/test_services/test_notification_service.py
@@ -591,16 +591,18 @@ class TestRunWorkerLoop:
         assert heartbeat.stat().st_mtime > ancient
 
     def test_heartbeat_not_refreshed_when_iteration_hangs(self, app, tmp_path):
-        """If get_pending_notifications hangs (raises), the post-iteration
-        heartbeat refresh does NOT run, so the file stays stale and the
-        Docker healthcheck will catch the hang."""
+        """If get_pending_notifications raises, the in-iteration refreshes
+        (post-poll, per-notification) do NOT run -- only the startup write
+        happens. The Docker healthcheck will then catch the hang once the
+        startup mtime ages past 180s.
+        """
         heartbeat = tmp_path / 'hb'
         app.config['WORKER_HEARTBEAT_PATH'] = str(heartbeat)
 
-        # Hang -> the polling-error path runs time.sleep(backoff). Trigger
-        # shutdown there before the next iteration.
         with patch.object(notification_service, 'get_pending_notifications',
                           side_effect=RuntimeError('DB hung')), \
+             patch.object(notification_service, '_write_heartbeat',
+                          wraps=notification_service._write_heartbeat) as mock_hb, \
              patch('esb.services.notification_service.signal'), \
              patch('esb.services.notification_service.time') as mock_time:
             mock_time.sleep.side_effect = KeyboardInterrupt
@@ -609,35 +611,11 @@ class TestRunWorkerLoop:
             except KeyboardInterrupt:
                 pass
 
-        # Initial heartbeat was written; capture that mtime.
-        initial_mtime = heartbeat.stat().st_mtime
-
-        # Now run a second time without the failing poll, but pre-set the
-        # heartbeat to an old mtime, then enter the failing path -- the mtime
-        # should NOT advance because the post-iteration refresh is skipped
-        # when the inner try block raised.
-        import os
-        os.utime(heartbeat, (initial_mtime - 100, initial_mtime - 100))
-        old_mtime = heartbeat.stat().st_mtime
-
-        with patch.object(notification_service, 'get_pending_notifications',
-                          side_effect=RuntimeError('DB hung')), \
-             patch('esb.services.notification_service.signal'), \
-             patch('esb.services.notification_service.time') as mock_time:
-            mock_time.sleep.side_effect = KeyboardInterrupt
-            try:
-                run_worker_loop(poll_interval=1)
-            except KeyboardInterrupt:
-                pass
-
-        # The initial-heartbeat write at the top of run_worker_loop() will
-        # have refreshed it, but the post-iteration refresh did NOT run.
-        # We assert the difference relative to the post-loop value: we know
-        # only one write happened (the startup write), not two.
-        # Hardest part to test directly is "did the loop end-of-iter run", so
-        # use a counter via _write_heartbeat.
-        # See test_write_heartbeat_count_per_iteration for that assertion.
-        assert heartbeat.stat().st_mtime >= old_mtime
+        # Exactly one write -- the startup write. The polling-error path
+        # intentionally does NOT refresh the heartbeat (so a sustained DB
+        # outage will eventually flip the container unhealthy, which is the
+        # documented behavior).
+        assert mock_hb.call_count == 1
 
     def test_write_heartbeat_count_per_iteration_empty(self, app, tmp_path):
         """With no pending notifications, _write_heartbeat is called once at

--- a/tests/test_views/test_metrics_view.py
+++ b/tests/test_views/test_metrics_view.py
@@ -34,6 +34,14 @@ class TestMetricsEndpoint:
         response = client.get('/metrics')
         assert 'text/plain' in response.content_type
 
+    def test_content_type_preserves_version_parameter(self, client):
+        """The Content-Type header must carry Prometheus's version and charset
+        parameters verbatim. Catches a regression to Response(..., mimetype=...)
+        which strips parameters from the header."""
+        response = client.get('/metrics')
+        assert 'version=' in response.content_type
+        assert 'charset=utf-8' in response.content_type
+
     def test_empty_table_emits_zero_count_and_omits_oldest(self, client):
         response = client.get('/metrics')
         text = response.data.decode()

--- a/tests/test_views/test_metrics_view.py
+++ b/tests/test_views/test_metrics_view.py
@@ -1,0 +1,62 @@
+"""Tests for the /metrics endpoint."""
+
+import re
+from datetime import UTC, datetime, timedelta
+
+from esb.extensions import db as _db
+from esb.models.pending_notification import PendingNotification
+
+
+def _extract_metric(text: str, name: str) -> float | None:
+    match = re.search(rf'^{re.escape(name)} (\S+)$', text, re.MULTILINE)
+    return float(match.group(1)) if match else None
+
+
+def _make_pending(created_at, status='pending'):
+    n = PendingNotification(
+        notification_type='slack_message',
+        target='#test',
+        payload={'msg': 'x'},
+        status=status,
+        created_at=created_at,
+    )
+    _db.session.add(n)
+    _db.session.commit()
+    return n
+
+
+class TestMetricsEndpoint:
+    def test_unauthenticated_access_returns_200(self, client):
+        response = client.get('/metrics')
+        assert response.status_code == 200
+
+    def test_returns_prometheus_content_type(self, client):
+        response = client.get('/metrics')
+        assert 'text/plain' in response.content_type
+
+    def test_empty_table_emits_zero_count_and_omits_oldest(self, client):
+        response = client.get('/metrics')
+        text = response.data.decode()
+        assert 'esb_pending_notifications_count 0.0' in text
+        assert 'esb_oldest_pending_notification_timestamp_seconds' not in text
+
+    def test_populated_table_emits_both_metrics(self, app, client):
+        oldest = datetime.now(UTC) - timedelta(minutes=3)
+        _make_pending(oldest)
+        _make_pending(datetime.now(UTC))
+
+        response = client.get('/metrics')
+        text = response.data.decode()
+        assert _extract_metric(text, 'esb_pending_notifications_count') == 2.0
+        ts = _extract_metric(text, 'esb_oldest_pending_notification_timestamp_seconds')
+        assert ts is not None
+        assert abs(ts - oldest.timestamp()) < 0.001
+
+    def test_only_pending_status_counted(self, app, client):
+        _make_pending(datetime.now(UTC), status='delivered')
+        _make_pending(datetime.now(UTC), status='failed')
+        _make_pending(datetime.now(UTC), status='pending')
+
+        response = client.get('/metrics')
+        text = response.data.decode()
+        assert 'esb_pending_notifications_count 1.0' in text


### PR DESCRIPTION
## Summary

- **Resilience:** SQLAlchemy `pool_pre_ping` + `pool_recycle` + PyMySQL socket timeouts; Slack `WebClient(..., timeout=15)` everywhere; worker heartbeat file written at startup and after every successful iteration. Catches the silent-DB-disconnect case that had wedged the worker for 2+ weeks at a time.
- **Container supervision:** Docker healthchecks on both `app` and `worker`, `start_period=120s` on worker, `willfarrell/autoheal` sidecar (Docker on its own does not restart unhealthy containers), `PYTHONUNBUFFERED=1` so worker logs reach journald in real time.
- **Observability:** New unauthenticated `/metrics` endpoint exposing `esb_pending_notifications_count` (always) and `esb_oldest_pending_notification_timestamp_seconds` (omitted when queue is empty — use `absent()` in alert rules). Intended for trusted-network deployment only.

## Why

The worker held a single SQLAlchemy connection idle between 30 s polls. With no `pool_pre_ping` and no socket-level timeout, a silently dropped TCP connection (NAT / conntrack / firewall) left the next `SELECT` blocked on `recv()` indefinitely — no exception, no log, no retry. Restarting the container was the only fix. The Slack `WebClient` had the same exposure with no per-call timeout. This change addresses the root cause and adds the supervision and metrics needed to catch any future regression promptly.

## Test plan

- [x] Run full suite: `make test` — 1126 passed (+29 net)
- [x] Lint: `make lint` — clean
- [ ] Build & start the stack: `docker compose up -d --build`
- [ ] Verify worker is healthy: `docker inspect --format '{{.State.Health.Status}}' equipment-status-board-worker-1` returns `healthy` after ~2 minutes
- [ ] Verify autoheal sidecar is running: `docker compose ps autoheal`
- [ ] Verify `/metrics`: `curl http://localhost:5000/metrics` shows `esb_pending_notifications_count 0.0` and **does not** show `esb_oldest_pending_notification_timestamp_seconds` when queue is empty
- [ ] Trigger a problem report, verify the queue gauge bumps and the oldest-timestamp metric appears, then disappears once the worker drains it
- [ ] (optional) Simulate worker hang: `docker compose exec worker kill -STOP 1` (or stop the heartbeat thread) and verify the container goes unhealthy within ~3 minutes and autoheal restarts it
- [ ] Verify `/health` healthcheck on app container: `docker inspect --format '{{.State.Health.Status}}' equipment-status-board-app-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)