### PR TITLE
Fixes #39: CloudFront invalidation on S3 static-page push

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,16 @@ SLACK_APP_TOKEN=
 STATIC_PAGE_PUSH_METHOD=local
 STATIC_PAGE_PUSH_TARGET=
 
+# CloudFront distribution ID (only meaningful when STATIC_PAGE_PUSH_METHOD=s3)
+# When set, a CloudFront invalidation is issued for the uploaded key after every
+# successful S3 upload, so the CDN serves the just-uploaded content immediately.
+# Requires the IAM principal used by the worker to have:
+#   - s3:PutObject on the target bucket/key
+#   - cloudfront:CreateInvalidation on the distribution
+# Note: the AWS Free Tier covers 1000 invalidation paths per month; pushes more
+# frequent than that will incur per-invalidation charges.
+# CLOUDFRONT_DISTRIBUTION_ID=
+
 # Google Cloud credentials (only needed if STATIC_PAGE_PUSH_METHOD=gcs and not using instance metadata/Workload Identity)
 # GOOGLE_APPLICATION_CREDENTIALS=
 

--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ STATIC_PAGE_PUSH_TARGET=
 #   - s3:PutObject on the target bucket/key
 #   - cloudfront:CreateInvalidation on the distribution
 # Note: the AWS Free Tier covers 1000 invalidation paths per month; pushes more
-# frequent than that will incur per-invalidation charges.
+# frequently than that will incur per-invalidation charges.
 # CLOUDFRONT_DISTRIBUTION_ID=
 
 # Google Cloud credentials (only needed if STATIC_PAGE_PUSH_METHOD=gcs and not using instance metadata/Workload Identity)

--- a/docs/administrators.md
+++ b/docs/administrators.md
@@ -85,6 +85,7 @@ Open `http://localhost:5000` in a browser (or the server's IP/hostname on port 5
 | `SLACK_OOPS_CHANNEL` | Slack channel for cross-area notifications. Can be set in `.env` (not included in `.env.example` by default). | No | `#oops` | `#equipment-alerts` |
 | `STATIC_PAGE_PUSH_METHOD` | How to publish the static status page. Options: `local` (write to directory), `s3` (upload to S3 bucket via boto3), or `gcs` (upload to Google Cloud Storage bucket). | No | `local` | `s3` |
 | `STATIC_PAGE_PUSH_TARGET` | Target for static page push. For `local`: a directory path. For `s3` and `gcs`: `bucket-name/optional/key/path` (key defaults to `index.html`). | No | _(empty)_ | `my-status-bucket/index.html` |
+| `CLOUDFRONT_DISTRIBUTION_ID` | CloudFront distribution ID. Only meaningful when `STATIC_PAGE_PUSH_METHOD=s3`. When set, a CloudFront invalidation is issued for the uploaded key after every successful S3 upload, so the CDN serves the just-uploaded content immediately. Requires the IAM principal to have `cloudfront:CreateInvalidation` on the distribution. The AWS Free Tier covers 1000 invalidation paths per month; pushes more frequently than that will incur per-invalidation charges. | No | _(empty)_ | `EDFDVBD6EXAMPLE` |
 | `FLASK_APP` | Flask application entry point. Do not change. | No | `esb:create_app` | `esb:create_app` |
 | `FLASK_DEBUG` | Enable Flask debug mode. Set to `0` in production. | No | `1` | `0` |
 | `AWS_ACCESS_KEY_ID` | AWS access key for S3 static page push. Only needed if `STATIC_PAGE_PUSH_METHOD=s3` and not using an IAM role. | No | _(empty)_ | `AKIAIOSFODNN7EXAMPLE` |
@@ -236,7 +237,7 @@ The static status page provides a lightweight, externally accessible version of 
 Set the push method via the `STATIC_PAGE_PUSH_METHOD` environment variable:
 
 - **`local`** — Writes the static page to a local directory specified by `STATIC_PAGE_PUSH_TARGET`. Useful for serving from a local web server or shared drive.
-- **`s3`** — Uploads the static page to an S3 bucket specified by `STATIC_PAGE_PUSH_TARGET`. Requires AWS credentials configured in the environment (via `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` or an IAM role).
+- **`s3`** — Uploads the static page to an S3 bucket specified by `STATIC_PAGE_PUSH_TARGET`. Requires AWS credentials configured in the environment (via `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` or an IAM role). Optionally set `CLOUDFRONT_DISTRIBUTION_ID` to also issue a CloudFront invalidation for the uploaded key after every successful upload (requires `cloudfront:CreateInvalidation` on the distribution).
 - **`gcs`** — Uploads the static page to a Google Cloud Storage bucket specified by `STATIC_PAGE_PUSH_TARGET`. Uses Google's default credential chain (`GOOGLE_APPLICATION_CREDENTIALS` environment variable, GCE instance metadata, or Workload Identity). When using Docker with a service account key file, add a volume mount for the credentials file in `docker-compose.yml` (e.g., `- ./service-account.json:/app/service-account.json:ro`) and set `GOOGLE_APPLICATION_CREDENTIALS=/app/service-account.json`.
 
 The static page is pushed by the background worker whenever it detects a status change during its polling cycle.

--- a/esb/config.py
+++ b/esb/config.py
@@ -48,6 +48,7 @@ class Config:
     SLACK_SOCKET_MODE_CONNECT = os.environ.get('SLACK_SOCKET_MODE_CONNECT', '')
     STATIC_PAGE_PUSH_METHOD = os.environ.get('STATIC_PAGE_PUSH_METHOD', 'local')
     STATIC_PAGE_PUSH_TARGET = os.environ.get('STATIC_PAGE_PUSH_TARGET', '')
+    CLOUDFRONT_DISTRIBUTION_ID = os.environ.get('CLOUDFRONT_DISTRIBUTION_ID', '')
     NEW_RELIC_LICENSE_KEY = os.environ.get('NEW_RELIC_LICENSE_KEY', '')
     NEW_RELIC_APP_NAME = os.environ.get('NEW_RELIC_APP_NAME', 'Equipment Status Board')
 

--- a/esb/services/static_page_service.py
+++ b/esb/services/static_page_service.py
@@ -94,11 +94,9 @@ def _push_s3(html_content: str, target: str) -> str | None:
     Target format: "bucket-name/optional/key/path" (key defaults to index.html
     if target ends with / or has no key component).
 
-    If the CLOUDFRONT_DISTRIBUTION_ID config is set, a CloudFront invalidation
-    is issued for the uploaded key after each successful upload, and the
-    invalidation ID is returned so the caller can include it in the audit log.
-    On the worker's retry path this guarantees the invalidation is re-attempted
-    until it succeeds (a fragile pre-upload diff would mask the retry signal).
+    Invalidation is unconditional (no pre-upload diff guard) so that a worker
+    retry after a CloudFront failure re-attempts the invalidation instead of
+    short-circuiting because the bucket already holds the new bytes.
 
     Args:
         html_content: Rendered HTML string.
@@ -160,19 +158,14 @@ def _create_cloudfront_invalidation(distribution_id: str, key: str) -> str:
         The CloudFront invalidation ID.
 
     Raises:
-        RuntimeError: if boto3 is missing, AWS credentials are not configured,
-            or the CreateInvalidation API call fails.
+        RuntimeError: if AWS credentials are not configured, or the
+            CreateInvalidation API call fails.
     """
     import uuid
     from urllib.parse import quote
 
-    try:
-        import boto3
-        from botocore.exceptions import ClientError, NoCredentialsError
-    except ImportError as e:
-        raise RuntimeError(
-            'boto3 is required for CloudFront invalidation. Install it with: pip install boto3'
-        ) from e
+    import boto3
+    from botocore.exceptions import ClientError, NoCredentialsError
 
     path = '/' + quote(key.lstrip('/'), safe='/')
     try:

--- a/esb/services/static_page_service.py
+++ b/esb/services/static_page_service.py
@@ -32,7 +32,9 @@ def push(html_content: str) -> None:
     """Push the rendered static page to the configured destination.
 
     Dispatches to _push_local(), _push_s3(), or _push_gcs() based on
-    STATIC_PAGE_PUSH_METHOD config value.
+    STATIC_PAGE_PUSH_METHOD config value. For the s3 backend, when the
+    CLOUDFRONT_DISTRIBUTION_ID config is set, a CloudFront invalidation
+    is issued for the uploaded key after each successful upload.
 
     Args:
         html_content: The rendered HTML string to push.
@@ -46,19 +48,20 @@ def push(html_content: str) -> None:
     if not target:
         raise RuntimeError('STATIC_PAGE_PUSH_TARGET is not configured')
 
+    invalidation_id: str | None = None
     if method == 'local':
         _push_local(html_content, target)
     elif method == 's3':
-        _push_s3(html_content, target)
+        invalidation_id = _push_s3(html_content, target)
     elif method == 'gcs':
         _push_gcs(html_content, target)
     else:
         raise RuntimeError(f'Unknown STATIC_PAGE_PUSH_METHOD: {method!r}')
 
-    log_mutation('static_page.pushed', 'system', {
-        'method': method,
-        'target': target,
-    })
+    mutation_data: dict = {'method': method, 'target': target}
+    if invalidation_id:
+        mutation_data['cloudfront_invalidation_id'] = invalidation_id
+    log_mutation('static_page.pushed', 'system', mutation_data)
 
     logger.info('Static page pushed via %s to %s', method, target)
 
@@ -85,18 +88,28 @@ def _push_local(html_content: str, target_path: str) -> None:
         raise RuntimeError(f'Failed to write static page to {target_path}: {e}') from e
 
 
-def _push_s3(html_content: str, target: str) -> None:
+def _push_s3(html_content: str, target: str) -> str | None:
     """Upload the static page HTML to an S3 bucket.
 
     Target format: "bucket-name/optional/key/path" (key defaults to index.html
     if target ends with / or has no key component).
 
+    If the CLOUDFRONT_DISTRIBUTION_ID config is set, a CloudFront invalidation
+    is issued for the uploaded key after each successful upload, and the
+    invalidation ID is returned so the caller can include it in the audit log.
+    On the worker's retry path this guarantees the invalidation is re-attempted
+    until it succeeds (a fragile pre-upload diff would mask the retry signal).
+
     Args:
         html_content: Rendered HTML string.
         target: S3 target in format "bucket/key".
 
+    Returns:
+        CloudFront invalidation ID, or None if no distribution was configured.
+
     Raises:
-        RuntimeError: if S3 upload fails.
+        RuntimeError: if boto3 is missing, the target is malformed, the S3
+            upload fails, or the CloudFront invalidation fails.
     """
     try:
         import boto3
@@ -127,6 +140,62 @@ def _push_s3(html_content: str, target: str) -> None:
         error_code = e.response['Error']['Code']
         error_msg = e.response['Error']['Message']
         raise RuntimeError(f'S3 upload failed ({error_code}): {error_msg}') from e
+
+    distribution_id = current_app.config.get('CLOUDFRONT_DISTRIBUTION_ID', '')
+    if distribution_id:
+        return _create_cloudfront_invalidation(distribution_id, key)
+    return None
+
+
+def _create_cloudfront_invalidation(distribution_id: str, key: str) -> str:
+    """Create a CloudFront invalidation for the given object key.
+
+    Args:
+        distribution_id: CloudFront distribution ID.
+        key: S3 object key. The invalidation path is `/` + URL-encoded key
+            (so keys with spaces or special characters invalidate the path
+            CloudFront actually serves).
+
+    Returns:
+        The CloudFront invalidation ID.
+
+    Raises:
+        RuntimeError: if boto3 is missing, AWS credentials are not configured,
+            or the CreateInvalidation API call fails.
+    """
+    import uuid
+    from urllib.parse import quote
+
+    try:
+        import boto3
+        from botocore.exceptions import ClientError, NoCredentialsError
+    except ImportError as e:
+        raise RuntimeError(
+            'boto3 is required for CloudFront invalidation. Install it with: pip install boto3'
+        ) from e
+
+    path = '/' + quote(key.lstrip('/'), safe='/')
+    try:
+        cf = boto3.client('cloudfront')
+        response = cf.create_invalidation(
+            DistributionId=distribution_id,
+            InvalidationBatch={
+                'Paths': {'Quantity': 1, 'Items': [path]},
+                'CallerReference': f'esb-{uuid.uuid4()}',
+            },
+        )
+        invalidation_id = response['Invalidation']['Id']
+        logger.info(
+            'Created CloudFront invalidation %s for distribution %s path %s',
+            invalidation_id, distribution_id, path,
+        )
+        return invalidation_id
+    except NoCredentialsError as e:
+        raise RuntimeError('AWS credentials not configured for CloudFront invalidation') from e
+    except ClientError as e:
+        error_code = e.response['Error']['Code']
+        error_msg = e.response['Error']['Message']
+        raise RuntimeError(f'CloudFront invalidation failed ({error_code}): {error_msg}') from e
 
 
 def _push_gcs(html_content: str, target: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,10 @@ def capture():
 def app():
     """Create a Flask application configured for testing."""
     app = create_app('testing')
+    # Clear env-driven config that would otherwise leak in from the host shell
+    # (e.g. a developer with CLOUDFRONT_DISTRIBUTION_ID set could see S3 push
+    # tests start hitting the CloudFront client unexpectedly).
+    app.config['CLOUDFRONT_DISTRIBUTION_ID'] = ''
     with app.app_context():
         _db.create_all()
         yield app

--- a/tests/test_services/test_static_page_service.py
+++ b/tests/test_services/test_static_page_service.py
@@ -228,6 +228,172 @@ class TestPushS3:
             assert call_kwargs['Key'] == 'index.html'
 
 
+class TestPushS3CloudFrontInvalidation:
+    """Tests for CloudFront invalidation triggered by push() with method='s3'."""
+
+    @staticmethod
+    def _boto_client_factory(s3_mock, cf_mock):
+        def factory(service):
+            if service == 's3':
+                return s3_mock
+            if service == 'cloudfront':
+                return cf_mock
+            raise ValueError(f'unexpected boto3 client {service!r}')
+        return factory
+
+    def test_no_invalidation_when_distribution_id_unset(self, app):
+        """No CloudFront client used when CLOUDFRONT_DISTRIBUTION_ID is empty."""
+        app.config['STATIC_PAGE_PUSH_METHOD'] = 's3'
+        app.config['STATIC_PAGE_PUSH_TARGET'] = 'my-bucket/index.html'
+        app.config['CLOUDFRONT_DISTRIBUTION_ID'] = ''
+
+        import boto3
+        mock_s3 = MagicMock()
+        mock_cf = MagicMock()
+
+        with patch.object(boto3, 'client', side_effect=self._boto_client_factory(mock_s3, mock_cf)):
+            static_page_service.push('<html>test</html>')
+
+        mock_cf.create_invalidation.assert_not_called()
+
+    def test_invalidates_after_successful_push(self, app):
+        """CloudFront invalidation created after every successful S3 upload when distribution set."""
+        app.config['STATIC_PAGE_PUSH_METHOD'] = 's3'
+        app.config['STATIC_PAGE_PUSH_TARGET'] = 'my-bucket/status/index.html'
+        app.config['CLOUDFRONT_DISTRIBUTION_ID'] = 'EDFDVBD6EXAMPLE'
+
+        import boto3
+        mock_s3 = MagicMock()
+        mock_cf = MagicMock()
+        mock_cf.create_invalidation.return_value = {'Invalidation': {'Id': 'I1234'}}
+
+        with patch.object(boto3, 'client', side_effect=self._boto_client_factory(mock_s3, mock_cf)):
+            static_page_service.push('<html>x</html>')
+
+        mock_s3.put_object.assert_called_once()
+        mock_cf.create_invalidation.assert_called_once()
+        call_kwargs = mock_cf.create_invalidation.call_args[1]
+        assert call_kwargs['DistributionId'] == 'EDFDVBD6EXAMPLE'
+        assert call_kwargs['InvalidationBatch']['Paths'] == {
+            'Quantity': 1, 'Items': ['/status/index.html'],
+        }
+        assert call_kwargs['InvalidationBatch']['CallerReference'].startswith('esb-')
+
+    def test_invalidation_path_url_encodes_special_characters(self, app):
+        """Invalidation path URL-encodes special characters in the S3 key."""
+        app.config['STATIC_PAGE_PUSH_METHOD'] = 's3'
+        app.config['STATIC_PAGE_PUSH_TARGET'] = 'my-bucket/status pages/page+v2.html'
+        app.config['CLOUDFRONT_DISTRIBUTION_ID'] = 'EDFDVBD6EXAMPLE'
+
+        import boto3
+        mock_s3 = MagicMock()
+        mock_cf = MagicMock()
+        mock_cf.create_invalidation.return_value = {'Invalidation': {'Id': 'I1'}}
+
+        with patch.object(boto3, 'client', side_effect=self._boto_client_factory(mock_s3, mock_cf)):
+            static_page_service.push('<html>x</html>')
+
+        items = mock_cf.create_invalidation.call_args[1]['InvalidationBatch']['Paths']['Items']
+        # Slash in the key is preserved, but space and `+` are percent-encoded.
+        assert items == ['/status%20pages/page%2Bv2.html']
+
+    def test_caller_reference_unique_across_calls(self, app):
+        """Successive invalidations get distinct CallerReference values (uuid-based)."""
+        app.config['STATIC_PAGE_PUSH_METHOD'] = 's3'
+        app.config['STATIC_PAGE_PUSH_TARGET'] = 'my-bucket/index.html'
+        app.config['CLOUDFRONT_DISTRIBUTION_ID'] = 'EDFDVBD6EXAMPLE'
+
+        import boto3
+        mock_s3 = MagicMock()
+        mock_cf = MagicMock()
+        mock_cf.create_invalidation.side_effect = [
+            {'Invalidation': {'Id': 'I1'}},
+            {'Invalidation': {'Id': 'I2'}},
+        ]
+
+        with patch.object(boto3, 'client', side_effect=self._boto_client_factory(mock_s3, mock_cf)):
+            static_page_service.push('<html>x</html>')
+            static_page_service.push('<html>x</html>')
+
+        refs = [
+            call.kwargs['InvalidationBatch']['CallerReference']
+            for call in mock_cf.create_invalidation.call_args_list
+        ]
+        assert refs[0] != refs[1]
+
+    def test_invalidation_client_error_raises_runtime_error(self, app):
+        """CloudFront ClientError surfaces as RuntimeError."""
+        app.config['STATIC_PAGE_PUSH_METHOD'] = 's3'
+        app.config['STATIC_PAGE_PUSH_TARGET'] = 'my-bucket/index.html'
+        app.config['CLOUDFRONT_DISTRIBUTION_ID'] = 'EDFDVBD6EXAMPLE'
+
+        import boto3
+        from botocore.exceptions import ClientError
+
+        mock_s3 = MagicMock()
+        mock_cf = MagicMock()
+        mock_cf.create_invalidation.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'denied'}}, 'CreateInvalidation'
+        )
+
+        with patch.object(boto3, 'client', side_effect=self._boto_client_factory(mock_s3, mock_cf)):
+            with pytest.raises(RuntimeError, match='CloudFront invalidation failed'):
+                static_page_service.push('<html>x</html>')
+
+    def test_invalidation_no_credentials_raises_runtime_error(self, app):
+        """CloudFront NoCredentialsError surfaces as RuntimeError."""
+        app.config['STATIC_PAGE_PUSH_METHOD'] = 's3'
+        app.config['STATIC_PAGE_PUSH_TARGET'] = 'my-bucket/index.html'
+        app.config['CLOUDFRONT_DISTRIBUTION_ID'] = 'EDFDVBD6EXAMPLE'
+
+        import boto3
+        from botocore.exceptions import NoCredentialsError
+
+        mock_s3 = MagicMock()
+        mock_cf = MagicMock()
+        mock_cf.create_invalidation.side_effect = NoCredentialsError()
+
+        with patch.object(boto3, 'client', side_effect=self._boto_client_factory(mock_s3, mock_cf)):
+            with pytest.raises(RuntimeError, match='AWS credentials not configured for CloudFront invalidation'):
+                static_page_service.push('<html>x</html>')
+
+    def test_audit_log_includes_invalidation_id(self, app, capture):
+        """The static_page.pushed audit event records the CloudFront invalidation ID."""
+        app.config['STATIC_PAGE_PUSH_METHOD'] = 's3'
+        app.config['STATIC_PAGE_PUSH_TARGET'] = 'my-bucket/index.html'
+        app.config['CLOUDFRONT_DISTRIBUTION_ID'] = 'EDFDVBD6EXAMPLE'
+
+        import boto3
+        mock_s3 = MagicMock()
+        mock_cf = MagicMock()
+        mock_cf.create_invalidation.return_value = {'Invalidation': {'Id': 'IABCDEF'}}
+
+        with patch.object(boto3, 'client', side_effect=self._boto_client_factory(mock_s3, mock_cf)):
+            static_page_service.push('<html>x</html>')
+
+        assert len(capture.records) == 1
+        log_data = json.loads(capture.records[0].message)
+        assert log_data['event'] == 'static_page.pushed'
+        assert log_data['data']['method'] == 's3'
+        assert log_data['data']['cloudfront_invalidation_id'] == 'IABCDEF'
+
+    def test_audit_log_omits_invalidation_id_when_distribution_unset(self, app, capture):
+        """The audit event does not include cloudfront_invalidation_id when distribution is unset."""
+        app.config['STATIC_PAGE_PUSH_METHOD'] = 's3'
+        app.config['STATIC_PAGE_PUSH_TARGET'] = 'my-bucket/index.html'
+        app.config['CLOUDFRONT_DISTRIBUTION_ID'] = ''
+
+        import boto3
+        mock_s3 = MagicMock()
+        mock_cf = MagicMock()
+
+        with patch.object(boto3, 'client', side_effect=self._boto_client_factory(mock_s3, mock_cf)):
+            static_page_service.push('<html>x</html>')
+
+        log_data = json.loads(capture.records[0].message)
+        assert 'cloudfront_invalidation_id' not in log_data['data']
+
+
 class TestPushGCS:
     """Tests for push() with method='gcs'."""
 


### PR DESCRIPTION
## Summary
- Adds optional `CLOUDFRONT_DISTRIBUTION_ID` env var; when set with `STATIC_PAGE_PUSH_METHOD=s3`, every successful upload is followed by a CloudFront `CreateInvalidation` for the uploaded key so the CDN serves the new content immediately.
- Invalidation path is URL-encoded (handles keys with spaces / special chars), `CallerReference` uses `uuid4` (avoids CloudFront silently dropping bursty/retried invalidations as duplicates), and the invalidation ID is recorded in the existing `static_page.pushed` audit event.
- Failures raise `RuntimeError` so the notification worker's existing retry/backoff re-attempts — a transient invalidation failure cannot leave the CDN stale indefinitely. `.env.example` documents the required IAM (`s3:PutObject`, `cloudfront:CreateInvalidation`) and the 1000-paths/month free-tier limit.

## Test plan
- [x] `make lint` clean
- [x] Full unit suite passes (1231 tests, including 8 new CloudFront-related tests)
- [ ] Manual smoke: deploy with `CLOUDFRONT_DISTRIBUTION_ID` unset → behaves exactly as before (no CloudFront client used, audit log unchanged)
- [ ] Manual smoke: deploy with `CLOUDFRONT_DISTRIBUTION_ID` set → after a worker push, observe an invalidation in the CloudFront console and the `cloudfront_invalidation_id` field in the `static_page.pushed` mutation log
- [ ] Manual smoke: confirm IAM principal used by the worker has both `s3:PutObject` and `cloudfront:CreateInvalidation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)