### PR TITLE
Issue #44: Static status page export improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,14 @@ FROM python:3.14-slim
 
 WORKDIR /app
 
-# Install system dependencies for MariaDB client
+# Install system dependencies for MariaDB client.
+# tzdata is a defensive pin: python:3.14-slim already ships it, but pinning
+# guards against future base-image variants dropping the package, which would
+# break the static status page's local-timezone generation timestamp.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libzbar0 \
+    tzdata \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies

--- a/_bmad-output/implementation-artifacts/tech-spec-static-status-page-export-improvements.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-static-status-page-export-improvements.md
@@ -4,7 +4,7 @@ slug: 'static-status-page-export-improvements'
 created: '2026-05-11'
 status: 'ready-for-dev'
 stepsCompleted: [1, 2, 3, 4]
-tech_stack: ['Python 3.14', 'Flask', 'Jinja2', 'pytest']
+tech_stack: ['Python 3.14', 'Flask', 'Jinja2', 'pytest', 'Docker (python:3.14-slim)']
 files_to_modify:
   - 'esb/services/static_page_service.py'
   - 'esb/services/status_service.py'
@@ -12,6 +12,7 @@ files_to_modify:
   - 'tests/test_services/test_static_page_service.py'
   - 'tests/test_services/test_status_service.py'
   - 'docker-compose.yml'
+  - 'Dockerfile'
   - 'docs/administrators.md'
 code_patterns:
   - 'esb.services.status_service.get_area_status_dashboard() returns areas with computed status only — needs extension to expose ALL open repair records per equipment'
@@ -20,16 +21,17 @@ code_patterns:
   - 'esb.slack.forms.format_status_summary and format_area_status_detail consume the dashboard dict shape'
 test_patterns:
   - 'tests/test_services/test_static_page_service.py uses make_area, make_equipment, make_repair_record fixtures; asserts on substrings in generated HTML'
-  - 'fixtures: make_repair_record(equipment, status, description, **kwargs) — kwargs become RepairRecord column values (severity, eta, created_at, etc.)'
+  - 'fixtures: make_repair_record(equipment=None, status="New", description="Test issue", **kwargs) — kwargs become RepairRecord column values (severity, eta, created_at, etc.). NOTE: if equipment is omitted, the fixture auto-creates a fresh Area+Equipment.'
 revision_history:
   - '2026-05-11 — initial spec'
-  - '2026-05-11 — applied 20 adversarial-review findings (F1–F20)'
+  - '2026-05-11 — applied 20 adversarial-review findings (R1F1–R1F20)'
+  - '2026-05-11 — applied real findings from round-2 adversarial review (R2F1–R2F19)'
 ---
 
 # Tech-Spec: Static status page export improvements
 
 **Created:** 2026-05-11
-**Revised:** 2026-05-11 (post-adversarial-review)
+**Revised:** 2026-05-11 (post-R1 adversarial review, post-R2 adversarial review)
 
 GitHub Issue: [#44](https://github.com/jantman/equipment-status-board/issues/44)
 
@@ -40,24 +42,25 @@ GitHub Issue: [#44](https://github.com/jantman/equipment-status-board/issues/44)
 The static status page (`esb/services/static_page_service.py` → `esb/templates/public/static_page.html`) — exported to local disk / S3 / GCS for public-facing display when the live Flask site is unavailable — has two presentation gaps:
 
 1. **No repair detail for non-green equipment.** It lists each equipment item by area with a status dot (green/yellow/red), a label, and (for the highest-severity record only) an ETA. When equipment is Degraded or Down, the page does not enumerate the **open repair records** with their per-record status, ETA, and description, so a reader cannot see *why* equipment is impaired or *what is being done about it*.
-2. **Generation metadata is inconsistent and visually weak.** A small "Generated: YYYY-MM-DD HH:MM UTC" line at the very bottom is the only branding/footer content. The live site uses a richer copyright/license footer (`esb/templates/components/_footer.html`). The static export should match the live look-and-feel, and the generation timestamp should be more prominent and in local/system timezone (not UTC).
+2. **Generation metadata is inconsistent and visually weak.** A small "Generated: YYYY-MM-DD HH:MM UTC" line at the very bottom is the only branding/footer content. The live site uses a richer copyright/license footer (`esb/templates/components/_footer.html`). The static export should match the live look-and-feel (including its accessibility attributes), and the generation timestamp should be more prominent and in local/system timezone (not UTC).
 
 ### Solution
 
-Update `static_page_service.generate()` to pass through (a) the open repair records per non-green equipment item (sorted by severity priority, then `created_at` ASC) and (b) a generation timestamp in the system's local timezone (with seconds). Update `esb/templates/public/static_page.html` to (i) render a list of open repair records — with each record's status, severity, ETA, and description — nested under each non-green equipment item; (ii) add a generation-time sub-heading immediately under the `<h1>Equipment Status</h1>` title, right-aligned, in local timezone; (iii) replace the bottom "Generated:" line with the site's copyright/license footer text (inlined — the static page must remain CSP-locked and have no external **sub-resources**, though anchor links to external sites are permitted). Configure the `worker` container to use `America/New_York` as the default timezone via `docker-compose.yml`, with deployment instructions added to `docs/administrators.md`.
+Update `static_page_service.generate()` to pass through (a) the open repair records per non-green equipment item (sorted by severity priority, then `created_at` ASC) and (b) a generation timestamp in the system's local timezone (with seconds). Update `esb/templates/public/static_page.html` to (i) render a list of open repair records — with each record's status, severity, ETA, and description — nested under each non-green equipment item; (ii) add a generation-time sub-heading immediately under the `<h1>Equipment Status</h1>` title, right-aligned, in local timezone; (iii) replace the bottom "Generated:" line with the site's copyright/license footer text (inlined verbatim including the `aria-label` attributes and `<small>` wrapper — the static page must remain CSP-locked and have no external **sub-resources**, though anchor links to external sites are permitted). Configure the `worker` container's `TZ` env via `docker-compose.yml` AND install the `tzdata` package in the `Dockerfile` so the configured zone actually resolves; document the env var in `docs/administrators.md`.
 
 **Note on scope additions beyond issue #44's literal text:** The issue lists status, ETA, and description as required per-record fields. This spec additionally includes (a) a textual severity badge `[Down]` / `[Degraded]` / `[Not Sure]` per record — for accessibility, since color alone (the left-border indicator) is a WCAG concern; (b) sort-by-severity-priority — so the most urgent records bubble to the top at a glance, since this is the fallback view when the live site is down. These are explicitly called out as enhancements.
 
 ### Scope
 
 **In Scope:**
-- `esb/services/status_service.py` — extend `get_area_status_dashboard()` to include per-equipment `open_records` list, sorted by severity priority then `created_at` ASC.
+- `esb/services/status_service.py` — extend `get_area_status_dashboard()` to include per-equipment `open_records` list, sorted by severity priority then `created_at` ASC. Unknown severities (and `None`) sort at "Not Sure" priority, matching the equipment-level fallback behavior.
 - `esb/services/static_page_service.py` — compute local-tz generation timestamp (with seconds), pass local-tz year to the template.
-- `esb/templates/public/static_page.html` — repair-record list under non-green items, top sub-heading with generated time, replace bottom footer with inlined copyright text.
-- Inline the copyright footer markup/text into the static template (the static page must have no external sub-resources — same self-contained / `default-src 'none'` CSP rule).
-- `docker-compose.yml` — set `TZ=America/New_York` as the default `worker`-service environment variable (overridable via `.env` for non-EST/EDT deployments).
+- `esb/templates/public/static_page.html` — repair-record list under non-green items, top sub-heading with generated time, replace bottom footer with inlined copyright text + a11y attributes.
+- Inline the copyright footer markup/text into the static template, including the live footer's `aria-label` attributes and `<small>` wrapper (the static page must have no external sub-resources — same self-contained / `default-src 'none'` CSP rule).
+- `docker-compose.yml` — set `TZ=${TZ:-America/New_York}` as the default `worker`-service environment variable.
+- `Dockerfile` — add `tzdata` to the `apt-get install` line so the configured `TZ` env var actually resolves against `/usr/share/zoneinfo/`.
 - `docs/administrators.md` — document the `TZ` environment variable in the Environment Variable Reference table.
-- `tests/test_services/test_static_page_service.py` — cover the new repair list, footer, generation-time placement, XSS escape, and CSP directive integrity.
+- `tests/test_services/test_static_page_service.py` — cover the new repair list, footer, generation-time placement, XSS escape, CSP directive integrity, pre-wrap CSS, footer a11y attributes.
 - `tests/test_services/test_status_service.py` — regression test for the new `open_records` key in `get_area_status_dashboard()`.
 
 **Out of Scope:**
@@ -68,35 +71,36 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 - Reuse of `_footer.html` via `{% include %}` — static export must remain self-contained.
 - Pagination / cap on the number of open records displayed per equipment (explicit decision — see Notes).
 - `get_single_area_status_dashboard()` extension (per-area kiosk static export).
+- Empty-`tzname()` fallback in `_compute_generated_at()` — CPython 3.11+ always emits a non-empty tzname; the fallback branch added in v2 was unreachable in production and is dropped (see Decision #3).
 
 ## Context for Development
 
 ### Codebase Patterns
 
-- **Self-contained static page.** `static_page.html` declares `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'` and uses only inline `<style>`. The page must continue to render with no external **sub-resources** — no `<link>`, no `<script src=>`, no `<img src=…>` to external hosts. Anchor links (`<a href="…">`) to external sites are user-initiated navigation, not auto-fetched sub-resources, and are permitted under this CSP (which has no `connect-src` / `navigate-to` restrictions). Existing test `test_produces_self_contained_html` enforces no `<link>` / `<script src=>`.
-- **Status derivation lives in `esb/services/status_service.py`.** `get_area_status_dashboard()` currently emits one `status` dict per equipment (computed from the highest-severity open record). The new requirement needs **all open repair records** per non-green equipment. Approach: extend `get_area_status_dashboard()` to additionally include the per-equipment list of `RepairRecord` instances in each entry (e.g., `open_records: list[RepairRecord]`). The records are already prefetched and grouped by `equipment_id` in the existing implementation (`records_by_equipment` dict). The new key is sorted by `(severity priority ASC, created_at ASC)` using `_SEVERITY_STATUS`; the prefetch query is already ordered by `(created_at ASC, id ASC)` so the secondary sort is stable. Existing callers ignoring the new key continue to work.
+- **Self-contained static page.** `static_page.html` declares `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'` and uses only inline `<style>`. The page must continue to render with no external **sub-resources** — no `<link>`, no `<script src=>`, no `<img src=…>` to external hosts. Anchor links (`<a href="…">`) to external sites are user-initiated navigation, not auto-fetched sub-resources, and are permitted under this CSP. Existing test `test_produces_self_contained_html` enforces no `<link>` / `<script src=>`.
+- **Status derivation lives in `esb/services/status_service.py`.** `get_area_status_dashboard()` currently emits one `status` dict per equipment (computed from the highest-severity open record). The new requirement needs **all open repair records** per non-green equipment. Approach: extend `get_area_status_dashboard()` to additionally include the per-equipment list of `RepairRecord` instances in each entry (e.g., `open_records: list[RepairRecord]`). The records are already prefetched and grouped by `equipment_id` in the existing implementation (`records_by_equipment` dict). The new key is sorted by `(severity priority ASC, created_at ASC)` using `_SEVERITY_STATUS`; the prefetch query is already ordered by `(created_at ASC, id ASC)` and Python's `list.sort()` is stable, so the `id`-ASC tiebreak is preserved naturally without being in the sort key. Existing callers ignoring the new key continue to work.
 - **Consumers of `get_area_status_dashboard()` return value** (audited 2026-05-11):
   - `esb/templates/public/status_dashboard.html` — iterates `area_data.equipment[*].equipment` and `.status` only.
   - `esb/templates/public/kiosk.html` — same.
-  - `esb/views/public.py:40-54` `kiosk_area()` route — passes a single-area dict (from `get_single_area_status_dashboard()`, not changed here) into `public/kiosk.html`.
+  - `esb/views/public.py` `kiosk_area()` route — passes a single-area dict (from `get_single_area_status_dashboard()`, not changed here) into `public/kiosk.html`.
   - `esb/slack/forms.py` `format_status_summary(dashboard_data)` and `format_area_status_detail(area_data)` — iterate `equipment` and `status` only.
-  - `esb/slack/handlers.py:288` — calls `format_status_summary()` from the `/esb-status` command path.
-  - None of the above reference `open_records`, so the additive key change does not require any caller updates. The full test suite (Task 6) is the regression net.
-- **`current_year` is injected via `app.context_processor` in `esb/__init__.py`** (`esb/__init__.py:75-76`); that processor works for `render_template()` calls so it is available to the static template without explicit kwargs. **However**, it is derived from `datetime.now(timezone.utc).year`, which can disagree with the static page's local-tz generation timestamp for a few hours either side of midnight Dec 31. Spec passes a local-tz year as a separate template var (`generated_year`) and the footer uses that, not `current_year`, to keep the two timestamps consistent (see Decision #7).
-- **Jinja filter `format_date`** (in `esb/utils/filters.py:13-30`) is registered on the app's Jinja env and usable from any template, including the static one.
+  - `esb/slack/handlers.py` `/esb-status` command path — calls `format_status_summary()`.
+  - None of the above reference `open_records`, so the additive key change does not require any caller updates. The full test suite (Task 9) is the regression net.
+- **`current_year` is injected via `app.context_processor` in `esb/__init__.py`** (`inject_current_year`); that processor works for `render_template()` calls so it is available to the static template without explicit kwargs. **However**, it is derived from `datetime.now(timezone.utc).year`, which can disagree with the static page's local-tz generation timestamp for a few hours either side of midnight Dec 31. Spec passes a local-tz year as a separate template var (`generated_year`) and the footer uses that, not `current_year`, to keep the two timestamps consistent (see Decision #7).
+- **Jinja filter `format_date`** (in `esb/utils/filters.py`) is registered on the app's Jinja env and usable from any template, including the static one.
 - **`RepairRecord` model fields** (confirmed in `esb/models/repair_record.py`):
   - `status: str` from `REPAIR_STATUSES = ['New', 'Assigned', 'In Progress', 'Parts Needed', 'Parts Ordered', 'Parts Received', 'Needs Specialist', 'Resolved', 'Closed - No Issue Found', 'Closed - Duplicate']`. Non-closed = anything not in `CLOSED_STATUSES = ('Resolved', 'Closed - No Issue Found', 'Closed - Duplicate')`.
-  - `severity: str | None` from `REPAIR_SEVERITIES = ['Down', 'Degraded', 'Not Sure']`.
+  - `severity: str | None` from `REPAIR_SEVERITIES = ['Down', 'Degraded', 'Not Sure']`. Column has **no DB-level CHECK constraint** — unknown strings are possible in legacy/future data.
   - `description: str` (Text, non-null). Can be multi-line and effectively unbounded.
   - `eta: date | None`.
   - `created_at: datetime` (UTC).
-- **Severity → color map** (`status_service._SEVERITY_STATUS`): `Down`→red (priority 0), `Degraded`→yellow (priority 1), `Not Sure`→yellow (priority 2), no severity → gray (priority 3, treated as last for sort purposes). Use this same mapping for per-record styling AND per-record sort.
-- **Local-timezone formatting.** No existing helper. Place the implementation in a module-level helper `_compute_generated_at()` (NOT inline in `generate()`) so tests can monkey-patch it directly. Format: `'%Y-%m-%d %H:%M:%S %Z'` → `2026-05-11 14:32:15 EDT`. If `dt.tzname()` returns `None` or an empty string (fixed-offset zone), fall back to `'%Y-%m-%d %H:%M:%S %z'` → `2026-05-11 14:32:15 -0400`. **Detect the fallback by inspecting `dt.tzname()` directly**, not by parsing the result of `strftime('%Z')` for trailing whitespace.
-- **Reference precedent.** `esb/templates/public/equipment_page.html:29-46` already renders an `open_repairs` list with severity-derived `status-card-*` styling. Static page repair list follows the same conceptual layout (record per `<li>`, severity styling, description visible, ETA shown when set) but using *inline* CSS classes defined within `static_page.html` (Bootstrap is unavailable in the export).
-- **Test fixtures** (`tests/conftest.py:118-160`):
-  - `make_area(name=…)` → `Area` (the only accepted kwarg shape).
-  - `make_equipment(name=…, area=…, **kwargs)` → `Equipment` (extra kwargs forwarded to model constructor).
-  - `make_repair_record(equipment=…, status='New', description='X', **kwargs)` → `RepairRecord`. Extra kwargs (`severity`, `eta`, `created_at`, `assignee_id`, `reporter_name`, etc.) are forwarded to the `RepairRecord` constructor; **the fixture does NOT accept `area` or `name`**.
+- **Severity → color map** (`status_service._SEVERITY_STATUS`): `Down`→red (priority 0), `Degraded`→yellow (priority 1), `Not Sure`→yellow (priority 2). For records whose severity is `None` or any *unknown* string, both the equipment-level status derivation (`status_service.py` `_derive_status_from_records`, "fall through to yellow/Degraded" branch) and the new sort key fall back to the **`Not Sure` priority (2)**. This keeps equipment-level rendering and record-list ordering consistent — a yellow-coded equipment cannot contain a record that sorts beneath a Not-Sure record (Round-2 finding R2F8). Per-record visual styling (`open-record-gray` left border) is independent of the sort priority.
+- **Local-timezone formatting.** No existing helper. Place the implementation in a module-level helper `_compute_generated_at()` in `static_page_service.py` (NOT inline in `generate()`) so tests can monkey-patch it directly. Format: `'%Y-%m-%d %H:%M:%S %Z'` → `2026-05-11 14:32:15 EDT`. Build the string by concatenation of `dt.strftime('%Y-%m-%d %H:%M:%S ')` and `dt.tzname()` (rather than using `%Z`) so the trailing token is explicit and never an empty trailing space. No fallback branch — under CPython 3.11+ with `tzdata` available in the runtime, `datetime.now().astimezone()` always returns a `datetime` whose `tzinfo` produces a non-empty `tzname()`. The Dockerfile change (Task 8) ensures `tzdata` is present.
+- **Reference data shape only** (not visual precedent): `esb/templates/public/equipment_page.html`'s `open_repairs` list shows the conceptual shape (one row per open record, severity-styled, description visible, ETA when set). The actual styling cannot be copied — `equipment_page.html` uses Bootstrap classes (`card`, `card-body`, `mb-2`, etc.) which are unavailable in the static export. The static page reimplements the layout in inline CSS.
+- **Test fixtures** (`tests/conftest.py`):
+  - `make_area(name='Test Area', slack_channel='#test-area')` → `Area`.
+  - `make_equipment(name='Test Equipment', manufacturer='TestCo', model='Model X', area=None, **kwargs)` → `Equipment` (extra kwargs forwarded to model constructor). If `area=None`, the fixture auto-creates a fresh area.
+  - `make_repair_record(equipment=None, status='New', description='Test issue', **kwargs)` → `RepairRecord`. Extra kwargs (`severity`, `eta`, `created_at`, `assignee_id`, `reporter_name`, etc.) are forwarded to the `RepairRecord` constructor. **The fixture does NOT accept `area` or `name` kwargs.** **If `equipment` is omitted, the fixture auto-creates a fresh Area + Equipment** — always pass `equipment=…` explicitly in the new tests to avoid surprise side-effects.
 
 ### Files to Reference
 
@@ -104,29 +108,30 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 | ---- | ------- |
 | `esb/services/static_page_service.py` | Modify `generate()`; add `_compute_generated_at()` module-level helper. |
 | `esb/services/status_service.py` | Extend `get_area_status_dashboard()` with the new `open_records` key. |
-| `esb/templates/public/static_page.html` | Render repair list, top-right generation timestamp, inline copyright footer. |
-| `esb/templates/components/_footer.html` | Source of truth for the copyright/license text and link targets (used as reference; not included). |
+| `esb/templates/public/static_page.html` | Render repair list, top-right generation timestamp, inline a11y-attributed copyright footer. |
+| `esb/templates/components/_footer.html` | Source of truth for the copyright/license text, link targets, and a11y attributes (used as reference; not included via `{% include %}`). |
 | `esb/__init__.py` | `inject_current_year` context processor (already wired; not modified — local-tz year is passed separately). |
 | `esb/utils/filters.py` | `format_date` Jinja filter. |
 | `esb/slack/forms.py`, `esb/slack/handlers.py` | Existing consumers of `get_area_status_dashboard()`; verified not affected by the additive `open_records` key. |
-| `docker-compose.yml` | Add `TZ=America/New_York` to the `worker` service. |
+| `docker-compose.yml` | Add `TZ=${TZ:-America/New_York}` to the `worker` service. |
+| `Dockerfile` | Add `tzdata` to the `apt-get install` line so the configured `TZ` resolves against `/usr/share/zoneinfo/`. **Without `tzdata`, `python:3.14-slim` falls back to UTC silently regardless of the `TZ` env var.** |
 | `docs/administrators.md` | Document the `TZ` env var in the Environment Variable Reference section. |
-| `tests/test_services/test_static_page_service.py` | Existing test class `TestGenerate`; add cases for repair list, top-right timestamp, inline footer, footer-drift pin, XSS escape, CSP directive integrity. |
+| `tests/test_services/test_static_page_service.py` | Existing test class `TestGenerate`; add cases for repair list, top-right timestamp, inline footer, footer-text pin, XSS escape, CSP directive integrity, pre-wrap CSS, footer a11y attributes. |
 | `tests/test_services/test_status_service.py` | Add regression test for `open_records` key. |
 | `tests/conftest.py` | Fixture definitions (`make_area`, `make_equipment`, `make_repair_record`). |
 
 ### Technical Decisions
 
-1. **Extend `get_area_status_dashboard()` to include an `open_records` list per equipment.** Records are already prefetched and grouped in `records_by_equipment`; threading the list through is a one-line change. Rejected the "new helper" option to avoid duplicating ~40 lines of prefetch code. Existing callers (live dashboard, kiosk, Slack formatters) ignore the new key (verified — see "Consumers" bullet above).
-2. **Sort open records by severity priority, then `created_at` ASC.** Rationale: the static page is the fallback at-a-glance view. Sorting by severity ensures `Down` records bubble above `Degraded`/`Not Sure`/no-severity within each equipment's record list, supporting quick triage. Sort key: `(_SEVERITY_STATUS.get(rec.severity, (..., ..., 999))[2], rec.created_at, rec.id)`. The `999` default places no-severity records last. Apply the sort inside `get_area_status_dashboard()` after grouping by equipment.
-3. **Local-timezone generation timestamp.** Implemented in module-level helper `_compute_generated_at()` in `static_page_service.py` (so tests can patch it). Uses `datetime.now().astimezone()` (no `tzinfo` argument) — Python picks up the host system's TZ from `TZ` env / `/etc/localtime`. Format: `'%Y-%m-%d %H:%M:%S %Z'` → `2026-05-11 14:32:15 EDT`. **Seconds are included** for debugging value when multiple pushes happen within a minute. If `dt.tzname()` returns `None` or `''`, fall back to `'%Y-%m-%d %H:%M:%S %z'` → `2026-05-11 14:32:15 -0400`. Detection is via `dt.tzname()`, not via post-hoc string inspection of the formatted output.
-4. **Footer text is inlined verbatim** from `_footer.html` (copyright line + GitHub link + MIT license link) into `static_page.html`, NOT included via `{% include %}`. Reasons: (a) the static page must remain self-contained (no external sub-resources); (b) an include couples the export to a fragment used by the live site, which is brittle if that fragment later pulls in Bootstrap classes or external icons; (c) copyright text is short and stable. **Drift mitigation:** Task 4 adds a unit test that reads `_footer.html` and asserts its three key substrings (owner name, GitHub URL, MIT URL) appear verbatim in the rendered static page. The test fails loudly when either file diverges, forcing the implementer to keep the static-page footer in sync. Footer markup uses inline styles defined in `static_page.html` (no Bootstrap class dependency).
+1. **Extend `get_area_status_dashboard()` to include an `open_records` list per equipment.** Records are already prefetched and grouped in `records_by_equipment`; threading the list through is a one-line change. Rejected the "new helper" option to avoid duplicating ~40 lines of prefetch code. Existing callers (live dashboard, kiosk, Slack formatters) ignore the new key.
+2. **Sort open records by `(severity priority, created_at)` ASC.** Rationale: the static page is the fallback at-a-glance view. Sorting by severity ensures `Down` records bubble above `Degraded`/`Not Sure`/unknown within each equipment's record list. Sort key: `(priority, rec.created_at)` where `priority = _SEVERITY_STATUS.get(rec.severity, (..., ..., _SEVERITY_STATUS['Not Sure'][2]))[2]`. **No `id` in the sort key** — Python's `list.sort()` is stable and the prefetch query order (`created_at ASC, id ASC`) is preserved on ties. **Unknown severity strings and `None` both fall back to the `Not Sure` priority (2)** — same as the equipment-level status derivation — to avoid an inversion where the equipment dot says yellow but the unknown-severity record sorts beneath Not-Sure records (R2F8).
+3. **Local-timezone generation timestamp.** Implemented in module-level helper `_compute_generated_at()` in `static_page_service.py` (so tests can patch it). Uses `datetime.now().astimezone()` (no `tzinfo` argument) — Python picks up the host system's TZ from `TZ` env / `/etc/localtime`. Format: `'%Y-%m-%d %H:%M:%S '` + `dt.tzname()` → `2026-05-11 14:32:15 EDT`. Seconds are included for debugging value when multiple pushes happen within a minute. **No empty-tzname fallback branch** — under CPython 3.11+ with `tzdata` present (Dockerfile Task 8), `astimezone()` always returns a tzinfo whose `tzname()` is non-empty. If a future runtime change ever produces `None`/empty, the code will fail loudly with a `TypeError` on string concatenation — which is the correct loud-failure mode for an invariant violation, vs. a silent fallback that masks a deployment problem.
+4. **Footer text is inlined verbatim** from `_footer.html` (copyright line + GitHub link + MIT license link, INCLUDING `<small>` wrapper and all `aria-label` attributes) into `static_page.html`, NOT included via `{% include %}`. Reasons: (a) the static page must remain self-contained (no external sub-resources); (b) an include couples the export to a fragment used by the live site, which is brittle if that fragment later pulls in Bootstrap classes; (c) copyright text is short and stable. **Drift mitigation:** Task 4 case 13 adds a unit test that loads `_footer.html` through Flask's Jinja loader and asserts its **three load-bearing substrings** (`Jason Antman`, the GitHub URL, the MIT URL) appear in the rendered static page. The test is explicitly named `test_footer_text_pin` (not "drift detector") — it pins owner + URLs only, NOT year-token markup or `<small>`/aria attribute wrapping. Those are covered by their own ACs (AC 9 / AC 9a).
 5. **Per-record styling**. Repair-record `<li>` items use a small inline left-border indicator color-coded by severity using the same mapping as the equipment-level dot (`Down`→red, `Degraded`/`Not Sure`→yellow, no severity → gray). Display order within the record: `[status badge] [severity badge if set] description …ETA: …`. Severity text badge is **retained** (e.g., `[Down]`) as an accessibility/redundancy feature — color alone is a WCAG concern, and the text badge gives the same information non-visually. This is called out as a spec-added enhancement beyond issue #44's literal ask.
-6. **Description wrap, not truncate.** `RepairRecord.description` is unbounded Text. Apply inline CSS `white-space: pre-wrap; overflow-wrap: anywhere;` to `.record-description` so multi-line descriptions render correctly and long un-broken strings (URLs, etc.) wrap rather than overflow the page. **No truncation** — the static page is a fallback view and full text is more useful than an ellipsis; visual clutter from a long description is acceptable for that rare case.
-7. **Local-tz year for the footer.** Compute the footer year from the same `datetime` used by `_compute_generated_at()` and pass it to the template as a separate kwarg `generated_year`. The footer renders `&copy; {{ generated_year }} Jason Antman`. The `current_year` context processor (UTC) is left alone so the live site is unaffected. This avoids the ~5-hour disagreement window around midnight Dec 31 where footer year and generation-timestamp year could differ by one.
+6. **Description wrap, not truncate.** `RepairRecord.description` is unbounded Text. Apply inline CSS `white-space: pre-wrap; overflow-wrap: anywhere;` to `.record-description` so multi-line descriptions render correctly and long un-broken strings (URLs, etc.) wrap rather than overflow the page. **No truncation** — the static page is a fallback view and full text is more useful than an ellipsis.
+7. **Local-tz year for the footer.** Compute the footer year from the same `datetime` used by `_compute_generated_at()` (Python's `datetime.astimezone()` returns a `datetime` whose `.year` is the converted local-tz year, not the source UTC year — verified empirically). Pass it to the template as a separate kwarg `generated_year`. The footer renders `&copy; {{ generated_year }} Jason Antman`. The `current_year` context processor (UTC) is left alone so the live site is unaffected. This avoids the ~5-hour disagreement window around midnight Dec 31.
 8. **Generation sub-heading placement.** Below the `<h1>Equipment Status</h1>` block, right-aligned via `text-align: right` on a `.generated-at` div (new CSS rule).
-9. **Equipment-row layout wrapper.** Existing `.equipment-item` uses `display: flex` to lay out dot/name/label/eta on one line. Adding a nested `<ul>` for open records inside the same `<li>` would make the `<ul>` a flex sibling. Spec wraps the existing four spans into a new `<div class="equipment-row">` (with `display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem;`) and changes `.equipment-item` to `display: block`. The new `<ul class="open-records-list">` lays out beneath the row naturally. The full template diff is spelled out in Task 3.
-10. **TZ default in `docker-compose.yml`.** Set `TZ=${TZ:-America/New_York}` in the `worker` service `environment:` block so the makerspace timezone is the out-of-the-box default. Operators in other zones override via `TZ=...` in `.env`. The `app` service does not need `TZ` because it does not invoke `generate()`; the worker is the sole producer of static pages via `generate_and_push()`.
+9. **Equipment-row layout wrapper.** Existing `.equipment-item` uses `display: flex` to lay out dot/name/label/eta on one line. Adding a nested `<ul>` for open records inside the same `<li>` would make the `<ul>` a flex sibling. Spec wraps the existing four spans into a new `<div class="equipment-row">` (with `display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem;`) and changes `.equipment-item` to `display: block`. The new `<ul class="open-records-list">` lays out beneath the row with `margin-top: 0.4rem` for visual separation. The full template diff is spelled out in Task 3.
+10. **TZ default in `docker-compose.yml` AND `tzdata` in Dockerfile.** Set `TZ=${TZ:-America/New_York}` in the `worker` service `environment:` block. Add `tzdata` to the `apt-get install` line in `Dockerfile` — this is the **load-bearing change** for the local-tz feature to work at all in production. Without `tzdata`, the `python:3.14-slim` base image has no `/usr/share/zoneinfo/America/New_York`, so glibc's `tzset()` falls back to UTC and the env var is effectively ignored. The `app` service does not need either change because it does not render the static page; the worker is the sole producer via `generate_and_push()`.
 11. **Module-level datetime import in `static_page_service.py`.** Hoist `from datetime import datetime` to module top (it is currently function-scoped). This is required for the `_compute_generated_at()` helper to exist at module scope, and it lets tests patch `static_page_service._compute_generated_at` directly.
 
 ## Implementation Plan
@@ -136,44 +141,46 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 - [ ] **Task 1: Extend `get_area_status_dashboard()` to include sorted per-equipment open repair records.**
   - File: `esb/services/status_service.py`
   - Action:
-    1. In `_SEVERITY_STATUS` (line 17-21), the priority for each known severity is the third tuple element. Add a module-level constant `_NO_SEVERITY_SORT_PRIORITY = 999` (or inline `999` with a comment) to use for records with `severity=None`.
-    2. Inside `get_area_status_dashboard()`, after the `records_by_equipment` grouping (lines 232-235), add a sort: for each list of records in `records_by_equipment.values()`, sort in place by `(severity_priority, created_at, id)`. Helper:
+    1. Inside `get_area_status_dashboard()`, after the `records_by_equipment` grouping, add a sort: for each list in `records_by_equipment.values()`, sort in place by `(priority, created_at)`. Helper:
        ```python
-       def _sort_key(rec):
-           sev = _SEVERITY_STATUS.get(rec.severity)
-           priority = sev[2] if sev else _NO_SEVERITY_SORT_PRIORITY
-           return (priority, rec.created_at, rec.id)
+       _NOT_SURE_PRIORITY = _SEVERITY_STATUS['Not Sure'][2]
+
+       def _open_records_sort_key(rec):
+           sev_entry = _SEVERITY_STATUS.get(rec.severity)
+           priority = sev_entry[2] if sev_entry else _NOT_SURE_PRIORITY
+           return (priority, rec.created_at)
+
        for records in records_by_equipment.values():
-           records.sort(key=_sort_key)
+           records.sort(key=_open_records_sort_key)
        ```
-    3. In the loop that builds `equip_statuses` (currently lines 238-246), add `'open_records': equip_records` to the dict appended for each equipment.
-    4. Update the function's docstring (lines 170-186) to document the new `open_records` key — list of `RepairRecord` instances, sorted by `(severity priority, created_at, id)` so highest-severity oldest-first.
-  - Notes: Existing live-page templates (`public/status_dashboard.html`, `public/kiosk.html`) and Slack formatters (`esb/slack/forms.py`) iterate `area_data.equipment` but reference only `item.equipment` and `item.status` — none touch `open_records`. The additive key is safe. `get_single_area_status_dashboard()` is **not** changed (out of scope per Scope section).
+       Define `_NOT_SURE_PRIORITY` and `_open_records_sort_key` at module level (right after the `_SEVERITY_STATUS` dict definition near line 17-21). Do **not** introduce a separate `999` sentinel — unknown severities and `None` both map to `Not Sure` priority for sort purposes, matching the equipment-level fallback (R2F7, R2F8).
+    2. In the loop that builds `equip_statuses`, add `'open_records': equip_records` to the dict appended for each equipment.
+    3. Update the function's docstring to document the new `open_records` key — list of `RepairRecord` instances, sorted by `(severity priority, created_at)` with unknown severities folded to `Not Sure` priority; ties on those fields preserve the prefetch query's `(created_at, id)` ASC order (stable sort).
+  - Notes: Existing live-page templates (`public/status_dashboard.html`, `public/kiosk.html`) and Slack formatters (`esb/slack/forms.py`) iterate `area_data.equipment` but reference only `item.equipment` and `item.status`. The additive key is safe. `get_single_area_status_dashboard()` is **not** changed.
 
 - [ ] **Task 2: Add `_compute_generated_at()` helper and hoist `datetime` import in `static_page_service.py`.**
   - File: `esb/services/static_page_service.py`
   - Action:
-    1. Move `from datetime import UTC, datetime` from inside `generate()` (line 22) to the module-level imports at the top of the file. Remove the now-unused `UTC` if not referenced elsewhere in the module.
-    2. Add a module-level helper function:
+    1. Move `from datetime import UTC, datetime` from inside `generate()` to the module-level imports. Remove the unused `UTC` if not referenced elsewhere.
+    2. Add a module-level helper:
        ```python
        def _compute_generated_at() -> tuple[str, int]:
            """Compute the generation timestamp string and year in the system's local timezone.
 
            Returns:
                (timestamp_str, year) where timestamp_str is formatted like
-               '2026-05-11 14:32:15 EDT' (or '2026-05-11 14:32:15 -0400' when
-               the local tz has no tzname). year is the local-tz year of the
-               same instant.
+               '2026-05-11 14:32:15 EDT'. year is the local-tz year of the
+               same instant (datetime.astimezone() returns a datetime whose
+               .year reflects the converted zone, not the source UTC year).
+
+           Requires the runtime to have a non-empty tzname for the local
+           zone — production deployments must include the tzdata package
+           in the base image (see Dockerfile).
            """
            dt = datetime.now().astimezone()
-           tzname = dt.tzname()
-           if tzname:
-               timestamp_str = dt.strftime('%Y-%m-%d %H:%M:%S ') + tzname
-           else:
-               timestamp_str = dt.strftime('%Y-%m-%d %H:%M:%S %z')
-           return timestamp_str, dt.year
+           return (dt.strftime('%Y-%m-%d %H:%M:%S ') + dt.tzname(), dt.year)
        ```
-       (Note: build `timestamp_str` via concatenation, not `%Z`, because some Python builds emit a trailing space when `tzname()` is non-empty — being explicit avoids the ambiguity.)
+       Build the string by concatenation (not `%Z`) so the trailing token is explicit. **No fallback branch** — if `dt.tzname()` is `None`, this fails loudly with a `TypeError`, which is the correct response to a deployment that violates the tzdata invariant.
     3. Update `generate()`:
        ```python
        def generate() -> str:
@@ -187,7 +194,6 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
                generated_year=generated_year,
            )
        ```
-       (Remove the docstring "Uses status_service.get_area_status_dashboard() for data" line about `generated_at` format being UTC.)
   - Notes: No new external deps. Tests patch `esb.services.static_page_service._compute_generated_at` to inject deterministic timestamps regardless of host TZ.
 
 - [ ] **Task 3: Update `static_page.html` template structure.**
@@ -229,7 +235,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
             .record-severity { color: #6c757d; }
             .record-description { white-space: pre-wrap; overflow-wrap: anywhere; }
             .record-eta { color: #6c757d; margin-left: 0.25rem; }
-            .site-footer { text-align: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #dee2e6; font-size: 0.8rem; color: #6c757d; }
+            .site-footer { text-align: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #dee2e6; font-size: 0.8rem; color: #6c757d; word-break: break-word; }
             .site-footer a { color: #6c757d; }
         </style>
     </head>
@@ -266,84 +272,97 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
             {% endif %}
         </div>
         {% endfor %}
-        <footer class="site-footer" role="contentinfo">&copy; {{ generated_year }} Jason Antman. <a href="https://github.com/jantman/equipment-status-board" rel="noopener noreferrer">github.com/jantman/equipment-status-board</a> <a href="https://opensource.org/license/mit" rel="noopener noreferrer">MIT licensed</a>.</footer>
+        <footer class="site-footer" role="contentinfo" aria-label="Site copyright and license">
+            <small>&copy; {{ generated_year }} Jason Antman. <a href="https://github.com/jantman/equipment-status-board" rel="noopener noreferrer" aria-label="Source code on GitHub">github.com/jantman/equipment-status-board</a> <a href="https://opensource.org/license/mit" rel="noopener noreferrer" aria-label="MIT License (opensource.org)">MIT licensed</a>.</small>
+        </footer>
     </body>
     </html>
     ```
 
-  - Key changes vs. previous template: `.equipment-item` becomes `display: block`; the existing dot/name/label/eta row is wrapped in `<div class="equipment-row">`; new `<ul class="open-records-list">` rendered only when equipment is non-green AND has open records; old `<div class="footer">Generated: …</div>` replaced by `<footer class="site-footer">` with copyright/license; new `.generated-at` sub-heading directly under the `<h1>`. The footer uses `generated_year` (local-tz, from `_compute_generated_at()`), NOT `current_year`. The CSP directive is unchanged.
+  - Key changes vs. previous template: `.equipment-item` becomes `display: block`; the existing dot/name/label/eta row is wrapped in `<div class="equipment-row">`; new `<ul class="open-records-list">` rendered only when equipment is non-green AND has open records; old `<div class="footer">Generated: …</div>` replaced by `<footer class="site-footer" role="contentinfo" aria-label="Site copyright and license">` with a `<small>` wrapper and `aria-label` on the GitHub and MIT anchors (mirrors `_footer.html`); new `.generated-at` sub-heading directly under the `<h1>`. The footer uses `generated_year` (local-tz, from `_compute_generated_at()`), NOT `current_year`. The CSP directive is unchanged.
 
 - [ ] **Task 4: Add tests in `tests/test_services/test_static_page_service.py`.**
   - File: `tests/test_services/test_static_page_service.py`
-  - Add the following tests (inside `class TestGenerate` unless noted):
+  - Add the following tests (inside `class TestGenerate` unless noted). Always pass `equipment=…` explicitly to `make_repair_record` to avoid the fixture auto-creating its own area/equipment.
 
-    1. `test_generated_at_subheading_renders_above_areas` — Given an area with one equipment item, when `generate()` runs, then the HTML contains `<div class="generated-at">` and that string's `find()` index is less than the index of the first `<div class="area">` AND greater than the index of `</h1>`.
+    1. `test_generated_at_subheading_renders_above_areas` — Given an area with one equipment item, when `generate()` runs, then the HTML contains `<div class="generated-at">` and its `find()` index is greater than the index of `</h1>` and less than the index of the first `<div class="area">`.
 
-    2. `test_generated_at_uses_local_timezone_helper` (covers AC 7) — Monkey-patch `esb.services.static_page_service._compute_generated_at` to return `('2026-05-11 14:32:15 EDT', 2026)`. Call `generate()`. Assert HTML contains `Generated: 2026-05-11 14:32:15 EDT`. This bypasses the host TZ entirely and verifies the wiring between the helper and the template.
+    2. `test_generated_at_uses_local_timezone_helper` (covers AC 7a) — Monkey-patch `esb.services.static_page_service._compute_generated_at` to return `('2026-05-11 14:32:15 EDT', 2026)`. Call `generate()`. Assert HTML contains `Generated: 2026-05-11 14:32:15 EDT` and footer contains `2026`.
 
-    3. `test_compute_generated_at_uses_tzname_when_present` (covers AC 7, helper-level) — Use `unittest.mock.patch` on `esb.services.static_page_service.datetime` to make `datetime.now().astimezone()` return a real `datetime` with `tzinfo=ZoneInfo('America/New_York')` set to a specific UTC instant (e.g., `2026-07-15 14:32:15` US Eastern). Call `_compute_generated_at()` directly. Assert returned timestamp ends with ` EDT` and year is `2026`.
+    3. `test_compute_generated_at_formats_tzname` (covers AC 7b, helper-level) — Use `unittest.mock.patch.object(static_page_service, 'datetime')` to make `datetime.now().astimezone()` return a real `datetime` with `tzinfo=ZoneInfo('America/New_York')` set to `2026-07-15 14:32:15` US Eastern. Call `_compute_generated_at()` directly. Assert returned tuple is `('2026-07-15 14:32:15 EDT', 2026)`.
 
-    4. `test_compute_generated_at_falls_back_to_offset_when_tzname_empty` (covers AC 8) — Patch `datetime.now().astimezone()` to return a `datetime` whose `tzinfo` is a `timezone(timedelta(hours=-4))` (anonymous offset; `tzname()` returns `'UTC-04:00'` by default in newer Python, but `timezone(timedelta(hours=-4), name=None)` then `tzname()` returns the offset string — verify behavior; if needed, build a custom `tzinfo` subclass whose `tzname()` returns `None`). Assert the returned timestamp ends with `-0400` (i.e., `%z` format), not an empty trailing space.
+    4. `test_open_records_listed_for_non_green_equipment` (covers AC 1) — Create equipment with one record `make_repair_record(equipment=eq, status='In Progress', severity='Down', description='Belt slipping', eta=date(2026, 6, 1))`. Call `generate()`. Assert HTML contains `'In Progress'`, `'[Down]'`, `'Belt slipping'`, and `'ETA: ' + date(2026, 6, 1).strftime('%b %d, %Y')`, AND contains the substring `class="open-record open-record-red"`.
 
-    5. `test_open_records_listed_for_non_green_equipment` (covers AC 1) — Create equipment with one record `make_repair_record(equipment=eq, status='In Progress', severity='Down', description='Belt slipping', eta=date(2026, 6, 1))`. Call `generate()`. Assert HTML contains `'In Progress'`, `'[Down]'`, `'Belt slipping'`, and `'ETA: ' + date(2026, 6, 1).strftime('%b %d, %Y')`, AND contains the substring `class="open-record open-record-red"`.
+    5. `test_open_records_omitted_for_green_equipment` (covers AC 2) — Create equipment with no repair records. Assert HTML does NOT contain `'open-records-list'`.
 
-    6. `test_open_records_omitted_for_green_equipment` (covers AC 2) — Create equipment with no repair records. Assert HTML does NOT contain `'open-records-list'`.
+    6. `test_open_records_uses_yellow_class_for_degraded_and_not_sure` (covers AC 4) — Create two equipment items in the same area, one with `severity='Degraded'`, one with `severity='Not Sure'`. Assert HTML contains at least two occurrences of `'open-record-yellow'`.
 
-    7. `test_open_records_uses_yellow_class_for_degraded_and_not_sure` (covers AC 4) — Create two equipment items in the same area, one with `severity='Degraded'`, one with `severity='Not Sure'`. Assert HTML contains at least two occurrences of `'open-record-yellow'`.
+    7. `test_open_records_uses_gray_class_for_no_severity` (covers AC 4 None branch) — Create a repair record passing `severity=None`. Assert HTML contains `'open-record-gray'` AND does NOT contain `'<span class="record-severity">'` for that record.
 
-    8. `test_open_records_uses_gray_class_for_no_severity` (covers AC 4 None branch) — Create a repair record passing `severity=None` (note: this requires inserting via the fixture; the model column is nullable). Assert HTML contains `'open-record-gray'` AND does NOT contain `'<span class="record-severity">'` for that record.
+    8. `test_open_records_omits_eta_when_unset` (covers AC 5) — In a fresh test fixture, create exactly one equipment with one record `make_repair_record(equipment=eq, severity='Down', eta=None)`. Assert HTML does NOT contain `'record-eta'`. (Scoped to a single equipment so the global assertion is safe — no substring splitting required.)
 
-    9. `test_open_records_omits_eta_when_unset` (covers AC 5) — Create a repair record with `eta=None`. Within its `<li class="open-record …">` block, the rendered HTML must not contain `'record-eta'`. Use a sliced substring (e.g., split on `open-record open-record-`) to isolate the relevant `<li>` for the assertion.
+    9. `test_open_records_sorted_by_severity_priority_then_created_at` (covers AC 3) — Create one equipment with three records: `(severity='Down', created_at=datetime(2026, 5, 1, tzinfo=UTC), description='down-newer')`, `(severity='Not Sure', created_at=datetime(2026, 4, 1, tzinfo=UTC), description='notsure-older')`, `(severity='Degraded', created_at=datetime(2026, 4, 15, tzinfo=UTC), description='degraded-mid')`. Insert in mixed order. Call `generate()`. Assert `html.find('down-newer') < html.find('degraded-mid') < html.find('notsure-older')`.
 
-    10. `test_open_records_sorted_by_severity_priority_then_created_at` (covers AC 3) — Create one equipment with three records: `(severity='Down', created_at=datetime(2026, 5, 1, tzinfo=UTC), description='down-newer')`, `(severity='Not Sure', created_at=datetime(2026, 4, 1, tzinfo=UTC), description='notsure-older')`, `(severity='Degraded', created_at=datetime(2026, 4, 15, tzinfo=UTC), description='degraded-mid')`. Insert in mixed insertion order. Call `generate()`. Assert the HTML substring index of `'down-newer'` < `'degraded-mid'` < `'notsure-older'` (severity priority order: Down(0) < Degraded(1) < Not Sure(2)).
+    10. `test_site_footer_replaces_old_generated_line` (covers AC 9) — Call `generate()`. Assert HTML contains `'<footer class="site-footer"'`, `'role="contentinfo"'`, `'aria-label="Site copyright and license"'`, `'<small>'`, `'Jason Antman'`, `'aria-label="Source code on GitHub"'`, `'aria-label="MIT License (opensource.org)"'`, `'github.com/jantman/equipment-status-board'`, `'MIT licensed'`, AND does NOT contain `'<div class="footer">'` (the old class).
 
-    11. `test_site_footer_replaces_old_generated_line` (covers AC 9) — Call `generate()`. Assert HTML contains `'Jason Antman'`, `'github.com/jantman/equipment-status-board'`, and `'MIT licensed'`, AND contains `'<footer class="site-footer"'`, AND does NOT contain `'<div class="footer">'` (the old class).
+    11. `test_footer_renders_local_tz_year_as_entity` (covers AC 10) — Monkey-patch `_compute_generated_at` to return `(..., 2027)`. Assert HTML footer contains the literal substring `&copy; 2027 Jason Antman` (HTML-entity form — Jinja does NOT decode `&copy;`).
 
-    12. `test_footer_renders_local_tz_year` (covers AC 10) — Monkey-patch `_compute_generated_at` to return `(..., 2027)`. Assert HTML footer contains `'&copy; 2027 Jason Antman'` (or `'© 2027 Jason Antman'` after Jinja unescaping — use the literal-byte form Jinja emits; in practice `&copy;` is emitted verbatim because the template uses the entity).
+    12. `test_footer_text_pin` (covers AC 12 — footer-text pin against `_footer.html`) — Load `_footer.html` source via Flask's Jinja loader: `source = app.jinja_env.loader.get_source(app.jinja_env, 'components/_footer.html')[0]`. From that source, extract three load-bearing substrings: `'Jason Antman'`, `'https://github.com/jantman/equipment-status-board'`, and `'https://opensource.org/license/mit'`. Assert each appears in the rendered static page HTML. Scope: this test ONLY pins owner + URLs — it does NOT detect changes to year-token markup, `<small>` wrapping, or aria-label text (those have dedicated assertions in case 10). If a future edit to `_footer.html` changes the owner name or a link URL, this test fails loudly and the static page must be updated in lockstep.
 
-    13. `test_footer_pins_to_live_footer_text` (covers F9 drift mitigation) — Read `esb/templates/components/_footer.html` from disk. Extract the three load-bearing substrings: `'Jason Antman'`, the GitHub URL `https://github.com/jantman/equipment-status-board`, and the MIT URL `https://opensource.org/license/mit`. Assert each appears in the rendered static page HTML. If the live footer ever changes its owner name or link targets, this test fails and forces the static page to be updated in lockstep.
+    13. `test_description_is_html_escaped` (covers AC 11 / XSS defense) — Create a repair record with `description='<script>alert(1)</script><img src=x onerror=y>'`. Call `generate()`. Assert HTML contains `'&lt;script&gt;'` (escaped) AND does NOT contain the literal `'<script>alert(1)</script>'`.
 
-    14. `test_description_is_html_escaped` (covers F11 XSS defense) — Create a repair record with `description='<script>alert(1)</script><img src=x onerror=y>'`. Call `generate()`. Assert HTML contains `'&lt;script&gt;'` (escaped) AND does NOT contain the literal `'<script>alert(1)</script>'`.
+    14. `test_csp_meta_tag_directive_unchanged` (strengthens existing `test_includes_csp_meta_tag`) — Replace the existing test (or add a sibling) that asserts only `'Content-Security-Policy' in html` with: `assert "default-src 'none'; style-src 'unsafe-inline'" in html` (verbatim directive contents).
 
-    15. `test_csp_meta_tag_directive_unchanged` (covers AC 11; strengthen existing test) — Update existing `test_includes_csp_meta_tag` (or add a sibling) to assert the verbatim substring `"default-src 'none'; style-src 'unsafe-inline'"` appears in the HTML, not just `'Content-Security-Policy'`.
+    15. `test_equipment_row_keeps_dot_name_label_on_one_line` (covers AC 14 layout) — Assert HTML contains `<div class="equipment-row">` and within that wrapper (slice to its closing tag), the order of substrings is `status-dot`, `equipment-name`, `status-label`.
 
-    16. `test_equipment_row_keeps_dot_name_label_on_one_line` (covers AC re. F8 layout) — Assert HTML contains `<div class="equipment-row">` and within that wrapper, the order of substrings is `status-dot`, `equipment-name`, `status-label` (i.e., the existing single-line composition is preserved structurally).
+    16. `test_description_uses_prewrap_styles` (covers AC 13 wrap CSS) — Assert HTML contains the substring `.record-description { white-space: pre-wrap; overflow-wrap: anywhere; }` inside the `<style>` block.
 
-    17. **Update existing `test_includes_generated_timestamp`** (covers AC 12) — Replace `assert 'UTC' in html` with `assert 'Generated:' in html`. The timezone token now depends on host TZ / patched helper; pinning to `UTC` is no longer correct.
+    17. **Update existing `test_includes_generated_timestamp`** — Replace `assert 'UTC' in html` with `assert 'Generated:' in html`. The timezone token now depends on host TZ / patched helper.
 
   - Notes:
-    - Use `from datetime import UTC, datetime` (Python 3.11+) for the `created_at` kwarg values.
-    - The fixture `make_repair_record(equipment, status='New', description='X', **kwargs)` — pass `created_at`, `severity`, `eta` via kwargs.
-    - For `test_compute_generated_at_falls_back_to_offset_when_tzname_empty`, the cleanest approach is a tiny custom `tzinfo` subclass: `class _NamelessTZ(tzinfo): utcoffset = lambda self, dt: timedelta(hours=-4); tzname = lambda self, dt: None; dst = lambda self, dt: timedelta(0)`. Then patch `datetime.now().astimezone()` to return a datetime with that `tzinfo`.
+    - Use `from datetime import UTC, datetime` (Python 3.11+) for `created_at` kwarg values.
+    - The fixture `make_repair_record(equipment=None, status='New', description='Test issue', **kwargs)` — pass `equipment=…` explicitly to avoid auto-create side effects; pass `severity`, `eta`, `created_at` via kwargs.
 
 - [ ] **Task 5: Add a regression test for the new `open_records` key in `tests/test_services/test_status_service.py`.**
   - File: `tests/test_services/test_status_service.py`
-  - Add (in an existing `TestGetAreaStatusDashboard` class, or create one if missing):
+  - Add (in an existing `TestGetAreaStatusDashboard` class, or create one):
 
-    1. `test_includes_open_records_list_per_equipment` — Create one area with one equipment item and two non-closed repair records and one closed record (`status='Resolved'`). Call `get_area_status_dashboard()`. Assert `result[0]['equipment'][0]` has key `'open_records'` whose value is a `list` of length 2 (the two non-closed). Assert the closed record is excluded. Assert each entry is a `RepairRecord` instance.
+    1. `test_includes_open_records_list_per_equipment` — Create one area with one equipment item and two non-closed repair records and one closed record (`status='Resolved'`). Call `get_area_status_dashboard()`. Assert `result[0]['equipment'][0]['open_records']` is a `list` of length 2; the closed record is excluded; each entry is a `RepairRecord` instance.
 
-    2. `test_open_records_sorted_by_severity_then_created_at` — Create one equipment with `Down/2026-05-01`, `Not Sure/2026-04-01`, `Degraded/2026-04-15`, `None/2026-03-01`. Call the dashboard. Assert the `open_records` list order is: `Down`, `Degraded`, `Not Sure`, `None`-severity (severity-priority sort, ties broken by `created_at`).
+    2. `test_open_records_sorted_by_severity_then_created_at` — Create one equipment with `Down/2026-05-01`, `Not Sure/2026-04-01`, `Degraded/2026-04-15`, `None/2026-03-01`, `'Critical'` (unknown severity) `/2026-02-01`. Call the dashboard. Assert the `open_records` list order is: `Down`, `Degraded`, then within priority-2 (`Not Sure`/`None`/`'Critical'`) sorted by `created_at` ASC — so `'Critical'` (oldest), then `None`, then `Not Sure`.
 
     3. `test_empty_open_records_list_for_green_equipment` — Create equipment with zero non-closed records. Assert `equipment[0]['open_records'] == []`.
 
-  - Notes: Verify existing tests in the file still pass — the new key is additive but make sure no existing assertion uses `set(equipment[0].keys())` style equality.
+  - Notes: Verify existing tests still pass — the new key is additive.
 
 - [ ] **Task 6: Configure default TZ in `docker-compose.yml` worker service.**
   - File: `docker-compose.yml`
-  - Action: In the `worker:` service's `environment:` block (lines 53-60), add a new line: `      - TZ=${TZ:-America/New_York}`. Place it adjacent to the existing `PYTHONUNBUFFERED=1` and `WORKER_HEARTBEAT_PATH=…` entries.
+  - Action: In the `worker:` service's `environment:` block, add a new line: `      - TZ=${TZ:-America/New_York}`. Place it adjacent to the existing `PYTHONUNBUFFERED=1` and `WORKER_HEARTBEAT_PATH=…` entries.
   - Notes: The `${TZ:-America/New_York}` syntax means "use the `TZ` env var if set in `.env` or shell, otherwise default to `America/New_York`." This matches the makerspace location (Decatur Makers) while letting other deployments override. The `app` service does **not** need TZ — only the worker calls `generate()`.
 
 - [ ] **Task 7: Document the `TZ` environment variable in `docs/administrators.md`.**
   - File: `docs/administrators.md`
-  - Action: In the Environment Variable Reference table (line 72 onward), add a new row:
+  - Action: In the Environment Variable Reference table, add a new row:
     ```markdown
-    | `TZ` | IANA timezone name for the worker container. Controls the timezone displayed in the static status page's generation timestamp (sub-heading near top of page and the copyright year in the footer). Set this to your local timezone for accurate display. The `app` service does not use this variable. | No | `America/New_York` | `America/Chicago` |
+    | `TZ` | IANA timezone name for the worker container. Controls the timezone displayed in the static status page's generation timestamp (sub-heading near top of page) and the year used in the footer. Set this to your local timezone for accurate display. The `app` service does not use this variable. Requires the `tzdata` package in the Docker image (included by default — see Dockerfile). | No | `America/New_York` | `America/Chicago` |
     ```
-  - Notes: Place the row alphabetically or near other deployment-configuration variables. The default reflects what's in `docker-compose.yml`. Also add a short paragraph in the "Static Status Page Setup" section (line 245+) noting that the static page's generation timestamp reflects the `worker` container's `TZ`, and that operators should set `TZ` in `.env` to match their local timezone.
+  - Also add a short paragraph in the "Static Status Page Setup" section noting that the static page's generation timestamp reflects the `worker` container's `TZ` and that operators should set `TZ` in `.env` to match their local timezone. Add a sentence: "Note: the Docker image installs the `tzdata` package; without it, the `TZ` env var has no effect and timestamps render in UTC."
 
-- [ ] **Task 8: Run lint and full test suite.**
+- [ ] **Task 8: Add `tzdata` to the Dockerfile so `TZ` actually resolves.**
+  - File: `Dockerfile`
+  - Action: In the existing `apt-get install` line, add `tzdata` alongside `gcc` and `libzbar0`:
+    ```dockerfile
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc \
+        libzbar0 \
+        tzdata \
+        && rm -rf /var/lib/apt/lists/*
+    ```
+  - Notes: Without `tzdata`, the `python:3.14-slim` base image has no `/usr/share/zoneinfo/` database, so glibc's `tzset()` cannot resolve `TZ=America/New_York` and falls back to UTC. This task is the load-bearing change for the whole local-tz feature; setting the env var in compose without this Dockerfile change is a no-op (Round-2 finding R2F1). `apt-get` non-interactive install of `tzdata` does not require additional `DEBIAN_FRONTEND=noninteractive` because Debian's bookworm-based slim images configure non-interactive apt by default in `Dockerfile` contexts; if the build prompts for tz selection, prepend `ENV DEBIAN_FRONTEND=noninteractive` before the `RUN` line.
+
+- [ ] **Task 9: Run lint and full test suite.**
   - Commands: `make lint` then `make test`.
-  - Expected: All green. Existing test `test_includes_generated_timestamp` was updated in Task 4 case 17; `test_produces_self_contained_html` continues to pass (no new `<link>` or `<script src=>`); existing `test_includes_csp_meta_tag` may need rename/strengthen per Task 4 case 15. The full suite covers Slack formatter tests (`tests/test_slack/`) which exercise consumers of `get_area_status_dashboard()` — confirms no regression.
+  - Expected: All green. Existing test `test_includes_generated_timestamp` was updated in Task 4 case 17; `test_produces_self_contained_html` continues to pass; existing `test_includes_csp_meta_tag` is replaced/strengthened per Task 4 case 14. The full suite covers Slack formatter tests (`tests/test_slack/`) which exercise consumers of `get_area_status_dashboard()` — confirms no regression.
 
 ### Acceptance Criteria
 
@@ -351,53 +370,57 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 
 - [ ] **AC 2 (green equipment — no list):** Given a non-archived equipment item with zero open repair records, when `generate()` is called, then the HTML for that equipment contains no `open-records-list` element.
 
-- [ ] **AC 3 (severity-priority sort):** Given one equipment item with three open repair records (`severity='Down', created_at=2026-05-01`; `severity='Not Sure', created_at=2026-04-01`; `severity='Degraded', created_at=2026-04-15`), when `generate()` is called, then in the HTML the `Down` record appears before the `Degraded` record, which appears before the `Not Sure` record (severity-priority ascending; ties broken by older `created_at` first).
+- [ ] **AC 3 (severity-priority sort, unknown folds to Not Sure):** Given one equipment item with five open repair records — `(severity='Down', created_at=2026-05-01)`, `(severity='Degraded', created_at=2026-04-15)`, `(severity='Not Sure', created_at=2026-04-01)`, `(severity=None, created_at=2026-03-01)`, `(severity='Critical', created_at=2026-02-01)` — when `generate()` is called, then in the HTML the records appear in the order: Down, Degraded, `'Critical'` (priority-2 tie, oldest `created_at`), None (priority-2 tie), Not Sure (priority-2 tie). Unknown severities and `None` both sort at the `Not Sure` priority; ties are broken by `created_at` ASC.
 
 - [ ] **AC 4 (severity color mapping):** Given open repair records with severities `'Down'`, `'Degraded'`, `'Not Sure'`, and `None`, when `generate()` is called, then their `<li class="open-record …">` elements receive classes `open-record-red`, `open-record-yellow`, `open-record-yellow`, and `open-record-gray` respectively, and the `None`-severity record does **not** render a `<span class="record-severity">[…]</span>` badge.
 
-- [ ] **AC 5 (ETA optional):** Given an open repair record with `eta=None`, when `generate()` is called, then its rendered `<li class="open-record …">` does not include a `record-eta` span and contains no `ETA:` substring within that record's `<li>`.
+- [ ] **AC 5 (ETA optional):** Given an open repair record with `eta=None`, when `generate()` is called for an area containing only that record's equipment, then the rendered HTML contains no `record-eta` substring.
 
-- [ ] **AC 6 (top sub-heading present and positioned):** Given any non-empty status dashboard, when `generate()` is called, then the HTML contains exactly one element matching `<div class="generated-at">` whose `find()` position in the document is greater than the position of `</h1>` and less than the position of the first `<div class="area">`. Its inner text starts with `Generated: ` followed by a `YYYY-MM-DD HH:MM:SS ` (including seconds) and a non-empty timezone token.
+- [ ] **AC 6 (top sub-heading present and positioned):** Given any non-empty status dashboard, when `generate()` is called, then the HTML contains exactly one element matching `<div class="generated-at">` whose `find()` position is greater than the position of `</h1>` and less than the position of the first `<div class="area">`. Its inner text starts with `Generated: ` followed by a `YYYY-MM-DD HH:MM:SS ` (including seconds) and a non-empty timezone token.
 
-- [ ] **AC 7 (local-timezone helper, monkey-patchable):** Given the helper `_compute_generated_at()` is patched to return `('2026-05-11 14:32:15 EDT', 2026)`, when `generate()` is called, then the HTML contains the exact substring `Generated: 2026-05-11 14:32:15 EDT` in the `<div class="generated-at">`. The helper's source uses `datetime.now().astimezone()` with no explicit `UTC` argument, and detects the no-tzname case via `dt.tzname()` (not via string inspection of the formatted output).
+- [ ] **AC 7a (helper-wiring):** Given `_compute_generated_at()` is patched to return `('2026-05-11 14:32:15 EDT', 2026)`, when `generate()` is called, then the rendered HTML contains the exact substring `Generated: 2026-05-11 14:32:15 EDT` inside the `<div class="generated-at">`, and the footer year is `2026`.
 
-- [ ] **AC 8 (timezone fallback for unnamed offsets):** Given a `datetime` whose `tzinfo.tzname(dt)` returns `None` or `''`, when `_compute_generated_at()` is called, then the returned timestamp string contains an ISO offset like `+0000` or `-0400` (no empty trailing space, no `None` token).
+- [ ] **AC 7b (helper formats tzname correctly):** Given a `datetime` whose `tzinfo` is `ZoneInfo('America/New_York')` set to `2026-07-15 14:32:15` local time, when `_compute_generated_at()` is called (with `datetime.now().astimezone()` patched to return that instance), then the helper returns exactly `('2026-07-15 14:32:15 EDT', 2026)`.
 
-- [ ] **AC 9 (site footer replaces "Generated:" line):** Given any rendering, when `generate()` is called, then the HTML contains a `<footer class="site-footer">` element whose text includes `© <YEAR> Jason Antman`, an anchor to `https://github.com/jantman/equipment-status-board`, and an anchor to `https://opensource.org/license/mit` (text `MIT licensed`), AND the HTML does NOT contain the old `<div class="footer">` element.
+- [ ] **AC 8 (site footer with a11y attributes):** Given any rendering, when `generate()` is called, then the HTML contains a `<footer class="site-footer" role="contentinfo" aria-label="Site copyright and license">` element wrapping a `<small>` that contains: the entity sequence `&copy; <YEAR> Jason Antman`, an anchor `<a href="https://github.com/jantman/equipment-status-board" …>` with `aria-label="Source code on GitHub"`, and an anchor `<a href="https://opensource.org/license/mit" …>` with `aria-label="MIT License (opensource.org)"` and link text `MIT licensed`. The HTML does NOT contain `<div class="footer">` (the old element).
 
-- [ ] **AC 10 (footer year matches generation timestamp year):** Given the helper `_compute_generated_at()` is patched to return year `2027`, when `generate()` is called, then the rendered footer contains `© 2027 Jason Antman` (the local-tz year, not `current_year` UTC).
+- [ ] **AC 9 (footer year matches generation timestamp year):** Given `_compute_generated_at()` is patched to return year `2027`, when `generate()` is called, then the rendered footer contains the literal substring `&copy; 2027 Jason Antman` (HTML-entity form — Jinja does NOT decode `&copy;`).
 
-- [ ] **AC 11 (still self-contained — no external sub-resources):** When `generate()` is called, then the HTML contains no `<link …>`, no `<script src="…">`, and no `<img src="http…">` or other external sub-resource references. Anchor (`<a href="…">`) links to external sites are permitted. The meta CSP tag's full directive `default-src 'none'; style-src 'unsafe-inline'` is unchanged.
+- [ ] **AC 10 (still self-contained — no external sub-resources):** When `generate()` is called, then the HTML contains no `<link …>`, no `<script src="…">`, and no `<img src="http…">` or other external sub-resource references. Anchor (`<a href="…">`) links to external sites are permitted. The meta CSP tag's full directive `default-src 'none'; style-src 'unsafe-inline'` appears verbatim.
 
-- [ ] **AC 12 (existing tests preserved):** Existing tests in `tests/test_services/test_static_page_service.py` continue to pass after Task 4 case 17's adjustment (drop the `'UTC' in html` assertion in `test_includes_generated_timestamp`; replace with `'Generated:' in html`).
+- [ ] **AC 11 (XSS defense — description is HTML-escaped):** Given a repair record with `description='<script>alert(1)</script><img src=x onerror=y>'`, when `generate()` is called, then the HTML contains `&lt;script&gt;` (escaped) and does NOT contain the literal `<script>alert(1)</script>` as a tag.
 
-- [ ] **AC 13 (XSS defense — description is HTML-escaped):** Given a repair record with `description='<script>alert(1)</script><img src=x onerror=y>'`, when `generate()` is called, then the HTML contains `&lt;script&gt;` (escaped) and does NOT contain the literal `<script>alert(1)</script>` as a tag.
+- [ ] **AC 12 (footer-text pin against `_footer.html`):** Given the source of `esb/templates/components/_footer.html` loaded via Flask's Jinja loader (`app.jinja_env.loader.get_source(app.jinja_env, 'components/_footer.html')[0]`), when `generate()` is called, then the three load-bearing substrings from `_footer.html` (`Jason Antman`, `https://github.com/jantman/equipment-status-board`, `https://opensource.org/license/mit`) all appear in the rendered static page HTML. Scope clarification: this AC pins owner + URLs only. Year-token markup, `<small>` wrapping, and aria-label texts are covered by AC 8 / AC 9 — not by this AC.
 
-- [ ] **AC 14 (description preserves newlines and wraps long text):** Given a repair record with a multi-line `description` containing `\n`, when `generate()` is called, then the rendered `.record-description` span carries inline CSS `white-space: pre-wrap; overflow-wrap: anywhere;` (verified by asserting the rule appears in the page's `<style>` block — no DOM rendering check required).
+- [ ] **AC 13 (description preserves newlines and wraps long text):** Given any rendering, when `generate()` is called, then the rendered HTML's `<style>` block contains the verbatim substring `.record-description { white-space: pre-wrap; overflow-wrap: anywhere; }`.
 
-- [ ] **AC 15 (footer-text drift detector):** Given the source file `esb/templates/components/_footer.html`, when `generate()` is called, then the three load-bearing substrings from `_footer.html` (`Jason Antman`, `https://github.com/jantman/equipment-status-board`, `https://opensource.org/license/mit`) all appear in the rendered static page HTML. If the live footer changes any of these, this AC fails and the static page must be updated.
+- [ ] **AC 14 (single-line equipment row preserved):** When `generate()` is called for an area with at least one equipment item, then the HTML contains a `<div class="equipment-row">` wrapper, and within that wrapper the substrings `status-dot`, `equipment-name`, and `status-label` appear in that order. The new `<ul class="open-records-list">` (when rendered) is outside this wrapper but inside the parent `<li class="equipment-item">`.
 
-- [ ] **AC 16 (single-line equipment row preserved):** When `generate()` is called for an area with at least one equipment item, then the HTML contains a `<div class="equipment-row">` wrapper, and within that wrapper the substrings `status-dot`, `equipment-name`, and `status-label` appear in that order. The new `<ul class="open-records-list">` (when rendered) is outside this wrapper but inside the parent `<li class="equipment-item">`.
+- [ ] **AC 15 (`get_area_status_dashboard()` returns `open_records`):** Given an equipment item with two non-closed repair records and one record with `status='Resolved'`, when `get_area_status_dashboard()` is called, then `result[0]['equipment'][0]['open_records']` is a `list` of exactly 2 `RepairRecord` instances (the non-closed ones), in `(severity priority ASC, created_at ASC)` order, with unknown severities folded to the `Not Sure` priority.
 
-- [ ] **AC 17 (`get_area_status_dashboard()` returns `open_records`):** Given an equipment item with two non-closed repair records and one record with `status='Resolved'`, when `get_area_status_dashboard()` is called, then `result[0]['equipment'][0]['open_records']` is a `list` of exactly 2 `RepairRecord` instances (the non-closed ones), in `(severity priority ASC, created_at ASC, id ASC)` order.
+- [ ] **AC 16 (existing tests preserved):** Existing tests in `tests/test_services/test_static_page_service.py` continue to pass after Task 4 case 17's adjustment (drop the `'UTC' in html` assertion in `test_includes_generated_timestamp`; replace with `'Generated:' in html`).
 
-- [ ] **AC 18 (deployment-default TZ wired):** Given `docker-compose.yml` defines the `worker` service, when the file is read, then its `environment:` block includes a `TZ=${TZ:-America/New_York}` entry. (Verified by reading the YAML in a test or by visual inspection during code review; not a Python unit test.)
+### Documentation Checklist
 
-- [ ] **AC 19 (admin docs include TZ row):** Given `docs/administrators.md`, when grepped for `| \`TZ\` |`, then a row exists in the Environment Variable Reference table documenting the variable, its default, and an example value.
+These items are verified by code review at PR time, not by automated tests:
+
+- [ ] **DC 1 (`docker-compose.yml` worker has TZ default):** The `worker` service's `environment:` block contains a `TZ=${TZ:-America/New_York}` entry.
+- [ ] **DC 2 (`Dockerfile` installs `tzdata`):** The `apt-get install` line includes `tzdata`.
+- [ ] **DC 3 (admin docs document `TZ`):** `docs/administrators.md` Environment Variable Reference table contains a row for `TZ` with description, default, and example. The Static Status Page Setup section mentions that the `worker` container's `TZ` controls the generation-timestamp display and that the Dockerfile installs `tzdata` to make the env var effective.
 
 ## Additional Context
 
 ### Dependencies
 
-None new — uses existing `datetime`, `zoneinfo` (stdlib), Flask, Jinja2. No DB migration. No new Python packages.
+No new Python packages. Adds the OS-level `tzdata` package to the Docker image. No DB migration.
 
 ### Testing Strategy
 
 **Unit tests (pytest, SQLite in-memory per `TestingConfig`):**
 
-All new tests live in `tests/test_services/test_static_page_service.py` (HTML-level) and `tests/test_services/test_status_service.py` (service-level). Use the existing fixtures: `app`, `make_area`, `make_equipment`, `make_repair_record`. The `make_repair_record(equipment, status='New', description='X', **kwargs)` signature accepts `RepairRecord` column kwargs (`severity`, `eta`, `created_at`, etc.); it does NOT accept `area` or `name`.
+All new tests live in `tests/test_services/test_static_page_service.py` (HTML-level) and `tests/test_services/test_status_service.py` (service-level). Use the existing fixtures: `app`, `make_area`, `make_equipment`, `make_repair_record`. The `make_repair_record(equipment=None, status='New', description='Test issue', **kwargs)` signature accepts `RepairRecord` column kwargs (`severity`, `eta`, `created_at`, etc.); it does NOT accept `area` or `name`. **Always pass `equipment=…` explicitly** to avoid the fixture's auto-create-area+equipment side effect.
 
-Strategy for tz-sensitive tests: **never** assert on the unpatched host clock. Either patch `_compute_generated_at()` to return a known string, or patch `datetime.now().astimezone()` to return a fixed `datetime` with a known `tzinfo`. This keeps tests deterministic on UTC CI runners.
+Strategy for tz-sensitive tests: **never** assert on the unpatched host clock. Either patch `_compute_generated_at()` to return a known string, or patch `datetime` inside `static_page_service` so `datetime.now().astimezone()` returns a fixed `datetime` with a known `tzinfo` (`ZoneInfo('America/New_York')` for the helper-level test). This keeps tests deterministic on UTC CI runners.
 
 | Test | Covers AC |
 | ---- | --------- |
@@ -408,52 +431,52 @@ Strategy for tz-sensitive tests: **never** assert on the unpatched host clock. E
 | `test_open_records_uses_gray_class_for_no_severity` | AC 4 (None branch) |
 | `test_open_records_omits_eta_when_unset` | AC 5 |
 | `test_generated_at_subheading_renders_above_areas` | AC 6 |
-| `test_generated_at_uses_local_timezone_helper` | AC 7 |
-| `test_compute_generated_at_uses_tzname_when_present` | AC 7 (helper) |
-| `test_compute_generated_at_falls_back_to_offset_when_tzname_empty` | AC 8 |
-| `test_site_footer_replaces_old_generated_line` | AC 9 |
-| `test_footer_renders_local_tz_year` | AC 10 |
-| (modified) `test_produces_self_contained_html` and `test_csp_meta_tag_directive_unchanged` | AC 11 |
-| (modified) `test_includes_generated_timestamp` | AC 12 |
-| `test_description_is_html_escaped` | AC 13 |
-| (assert CSS rule in `<style>`) `test_description_has_prewrap_styles` | AC 14 |
-| `test_footer_pins_to_live_footer_text` | AC 15 |
-| `test_equipment_row_keeps_dot_name_label_on_one_line` | AC 16 |
-| `test_status_service.test_includes_open_records_list_per_equipment` | AC 17 |
-| `test_status_service.test_open_records_sorted_by_severity_then_created_at` | AC 17 (sort) |
+| `test_generated_at_uses_local_timezone_helper` | AC 7a |
+| `test_compute_generated_at_formats_tzname` | AC 7b |
+| `test_site_footer_replaces_old_generated_line` | AC 8 |
+| `test_footer_renders_local_tz_year_as_entity` | AC 9 |
+| (existing, modified) `test_produces_self_contained_html` + `test_csp_meta_tag_directive_unchanged` | AC 10 |
+| `test_description_is_html_escaped` | AC 11 |
+| `test_footer_text_pin` | AC 12 |
+| `test_description_uses_prewrap_styles` | AC 13 |
+| `test_equipment_row_keeps_dot_name_label_on_one_line` | AC 14 |
+| `test_status_service.test_includes_open_records_list_per_equipment` | AC 15 |
+| `test_status_service.test_open_records_sorted_by_severity_then_created_at` | AC 15 (sort) |
+| (existing, modified) `test_includes_generated_timestamp` | AC 16 |
 
-AC 18 and AC 19 are configuration/documentation criteria verified by code review (or trivially by `grep` in a CI step).
+DC 1, DC 2, DC 3 are verified by code review at PR time.
 
 **Manual / smoke testing:**
 
 1. Apply the changes locally.
-2. `make db-up && make migrate && make run` and create at least one Area, two Equipment items, and one open `RepairRecord` per equipment (one `Down`, one `Degraded`, one `Not Sure` or `None`) via the staff UI. Include one long-text description and one multi-line description to verify wrap behavior.
+2. `make db-up && make migrate && make run` and create at least one Area, two Equipment items, and one open `RepairRecord` per equipment (one `Down`, one `Degraded`, one `Not Sure` or `None`) via the staff UI. Include one long-text description (200+ chars) and one multi-line description (with embedded newlines) to verify wrap behavior. Add a fourth equipment with 5+ open records on a long-named equipment to verify visual spacing under the equipment row.
 3. Set `TZ=America/New_York` in shell before running `flask shell`, then `from esb.services import static_page_service; print(static_page_service.generate())` (or hit the export path on disk via `STATIC_PAGE_PUSH_METHOD=local`).
 4. Open the resulting `index.html` in a browser. Verify:
    - Top right under the title: `Generated: 2026-05-11 14:32:15 EDT` (or local zone).
    - Equipment header (dot + name + label + ETA) on a single line under each area.
    - Under each non-green equipment item: a list with one row per open record, colored by severity, showing status + `[severity]` badge + description (multi-line / long text wrapping correctly) + ETA (when set). Records sorted with `Down` records on top.
-   - Bottom: centered copyright footer with the GitHub and MIT license links; year matches the generation sub-heading year.
-   - View source: no `<link>`, no `<script src=...>`, no external `<img>`; CSP meta tag value is `default-src 'none'; style-src 'unsafe-inline'` verbatim.
-5. Repeat with `TZ=UTC` to verify the UTC fallback rendering matches expectations.
+   - Bottom: centered copyright footer with `<small>` wrapper, GitHub and MIT license anchors, aria-labels present (verifiable in DevTools); year matches the generation sub-heading year.
+   - View source: no `<link>`, no `<script src=...>`, no external `<img>`; CSP meta tag value is `default-src 'none'; style-src 'unsafe-inline'` verbatim; `<footer>` has `role="contentinfo"` and `aria-label="Site copyright and license"`.
+5. **End-to-end Docker smoke (verifies R2F1 Dockerfile change):** Build the image with the Dockerfile change applied. Run `docker compose run --rm worker python -c "from datetime import datetime; print(datetime.now().astimezone().tzname())"`. Confirm output is `EDT`/`EST` (not `UTC`) when `TZ=America/New_York` is in `.env`. This catches the silent UTC fallback that occurs if `tzdata` is missing from the image.
 
 ### Notes
 
-**Production timezone configuration.** The default `docker-compose.yml` now sets `TZ=America/New_York` on the `worker` service to match the makerspace's location. Operators in other zones override via the `TZ` env var in `.env` (e.g., `TZ=America/Chicago`). Documented in `docs/administrators.md` Environment Variable Reference. `app` service does not need TZ (does not render the static page).
+**Production timezone configuration.** The default `docker-compose.yml` sets `TZ=America/New_York` on the `worker` service AND the `Dockerfile` installs `tzdata`. Both changes are required — `TZ` without `tzdata` is a silent no-op. Operators in other zones override via the `TZ` env var in `.env`. Documented in `docs/administrators.md`. The `app` service does not need TZ.
 
-**Risk: timezone test flakiness.** Mitigated. All tz-sensitive tests patch either `_compute_generated_at()` or `datetime.now().astimezone()`. No test depends on the runner's `TZ` env var. Avoid asserting raw `EDT`/`EST` against an unpatched clock.
+**Risk: timezone test flakiness.** Mitigated. All tz-sensitive tests patch either `_compute_generated_at()` or `datetime.now().astimezone()`. No test depends on the runner's `TZ` env var.
 
-**Risk: live dashboard / Slack regression.** Task 1 adds an `open_records` key to the dict returned by `get_area_status_dashboard()`. Audited consumers: `public/status_dashboard.html`, `public/kiosk.html`, `public/equipment_page.html` (different route, not affected), `esb/slack/forms.py::format_status_summary`, `esb/slack/forms.py::format_area_status_detail`, `esb/slack/handlers.py:288`. None iterate or reference `open_records`. Task 8 runs the full suite — including `tests/test_slack/` — to confirm.
+**Risk: live dashboard / Slack regression.** Task 1 adds an `open_records` key to the dict returned by `get_area_status_dashboard()`. Audited consumers: `public/status_dashboard.html`, `public/kiosk.html`, `esb/slack/forms.py::format_status_summary`, `esb/slack/forms.py::format_area_status_detail`, `esb/slack/handlers.py` `/esb-status` path. None iterate or reference `open_records`. Task 9 runs the full suite to confirm.
 
-**Risk: severity-priority sort change.** Spec changes the sort from "created_at ASC oldest-first" to "severity priority then created_at ASC." This is the right call for the static fallback view but is a visible behavior change vs. the previously-shipped behavior of the highest-severity-only display. The change affects only the static page's repair list (a new feature), not the equipment-level status dot which was already severity-derived. No callers depend on the old "created_at order" because the `open_records` list itself is new.
+**Risk: severity-priority sort change.** Spec changes the sort from "created_at ASC oldest-first" (round-1 default) to "severity priority then `created_at` ASC" with unknown severities folded to `Not Sure` priority. This is the right call for the static fallback view AND it matches the equipment-level status-fallback behavior, eliminating the inversion bug where a yellow-coded equipment could contain a record sorting below Not Sure (R2F8).
 
-**Risk: footer drift detector test could become flaky.** AC 15 / Task 4 case 13 reads `_footer.html` from disk and asserts substrings. If someone edits `_footer.html` to change the owner name, the test fails. That is **intentional** — the failure prompts the implementer to also update the static-page footer. Not a flake; it's a coupling alarm.
+**Risk: footer-text pin is narrowly scoped.** AC 12 / Task 4 case 12 pins owner + URLs only — not year-token markup, `<small>`, or aria-labels. Those are covered by AC 8/9. If a future edit to `_footer.html` swaps `<small>` for `<span>`, AC 12 will NOT fire; the static page will visually diverge silently. Acceptable trade-off: the alternative (full markup pin) would require rendering `_footer.html` through Jinja with mocked context, which complicates the test and over-couples the static page to the live one. The aria-label / `<small>` invariants are pinned directly against the static page in AC 8 instead.
 
-**Risk: `severity=None` repair records.** Repair creation paths set severity by default, but the column is nullable. Spec handles `None` explicitly in (a) sort key (priority `999` → sorted last), (b) template class mapping (`open-record-gray`), (c) severity-badge rendering (`{% if rec.severity %}…{% endif %}` guards the `[…]` text). Tests cover this branch.
+**Risk: `severity=None` and unknown severity strings.** Repair creation paths set severity by default, but the column is nullable AND unconstrained. Spec handles both cases identically in the sort (priority 2 = Not Sure), in the template class mapping (`open-record-gray` for None, would also be `gray` for any unknown string — see template `{% if rec.severity == 'Down' %}…{% elif rec.severity in ('Degraded', 'Not Sure') %}…{% else %}gray{% endif %}`), and in severity-badge rendering (the `{% if rec.severity %}` guard hides the `[…]` text for None but shows it for unknown strings). Tests cover the None branch in case 7 and the sort behavior in case 9 / Task 5 case 2.
 
 **Explicit non-decisions:**
-- **No cap on records displayed per equipment.** Static page is the fallback view; full information takes priority over visual tidiness in the rare worst case. (F20 decision.)
-- **Severity text badge `[Down]` retained** as accessibility/redundancy for color-coding. (F19 decision.)
+- **No cap on records displayed per equipment.** Static page is the fallback view; full information takes priority over visual tidiness in the rare worst case.
+- **Severity text badge `[Down]` retained** as accessibility/redundancy for color-coding.
+- **No empty-tzname fallback in `_compute_generated_at`.** CPython 3.11+ with `tzdata` installed always yields non-empty `tzname()`. If a future deployment violates that invariant, the helper fails loudly with `TypeError` (concatenating `str` and `None`) — preferable to a silent UTC-offset fallback that masks a Dockerfile regression.
 
 **Future / out of scope (do not implement now):**
 - Per-area kiosk static export (would require extending `get_single_area_status_dashboard()` similarly).
@@ -466,27 +489,25 @@ GitHub issue #44 text:
 
 ### Adversarial Review Resolution
 
-Findings F1–F20 from the 2026-05-11 adversarial review applied:
+**Round 1 (2026-05-11):** 20 findings (R1F1–R1F20), all addressed in the second revision. Resolution table previously included; see commit history for full audit trail.
 
-| ID | Resolution |
-| --- | --- |
-| F1 (AC 7 unenforceable) | Rewrote AC 7 to assert via monkey-patched `_compute_generated_at()`, not host env. |
-| F2 (function-scoped `datetime` defeats patch) | Hoisted import to module top; added `_compute_generated_at()` helper at module scope (Task 2). |
-| F3 (worker TZ broken by default) | Added `TZ=${TZ:-America/New_York}` to `docker-compose.yml` worker (Task 6); documented in `docs/administrators.md` (Task 7). |
-| F4 (hallucinated `kiosk_area.html`) | Removed; corrected consumer list to actual files audited. |
-| F5 (Slack consumers missed) | Audited and listed: `esb/slack/forms.py`, `esb/slack/handlers.py`. None affected by additive key. |
-| F6 (trailing-space fallback brittle) | Detect fallback via `dt.tzname()` directly; build timestamp by concatenation, not `%Z` format. |
-| F7 (description wrap policy) | Decision: CSS `white-space: pre-wrap; overflow-wrap: anywhere;` on `.record-description`. AC 14 added. |
-| F8 (CSS layout non-atomic) | Spec now contains the full template diff in Task 3. AC 16 added. |
-| F9 (footer drift) | Added test that pins static-page footer to `_footer.html` substrings (Task 4 case 13, AC 15). |
-| F10 (no service-level test) | Added `tests/test_services/test_status_service.py` cases (Task 5, AC 17). |
-| F11 (XSS escape not asserted) | Added `test_description_is_html_escaped` (Task 4 case 14, AC 13). |
-| F12 (fixture kwargs doc) | Corrected: `make_repair_record(equipment, status, description, **kwargs)`; `area`/`name` not accepted. |
-| F13 (sort policy) | Decision: severity priority then `created_at` ASC. (Task 1, AC 3.) |
-| F14 (ordering test fragile) | Task 4 case 10 specifies explicit `datetime(…, tzinfo=UTC)` values. |
-| F15 (CSP test weak) | Strengthened to assert verbatim directive contents (Task 4 case 15). |
-| F16 (no seconds) | Decision: include seconds → `%Y-%m-%d %H:%M:%S`. |
-| F17 ("self-contained" wording) | Clarified: "no external sub-resources" vs. anchor links to external sites permitted (AC 11). |
-| F18 (year mismatch) | Decision: pass local-tz `generated_year` to template; footer uses it (Task 2/3, AC 10). |
-| F19 (severity badge beyond ask) | Decision: keep badge for accessibility; called out as enhancement in Overview. |
-| F20 (record cap) | Decision: no cap; documented in Notes/Explicit non-decisions. |
+**Round 2 (2026-05-11):** 21 findings (R2F1–R2F21); fixed all real findings (15 of 21). The 6 "Noise" findings (R2F9 / test scoping nit, R2F16 / general line-number audit reminder, R2F18 / dt.year comment, R2F20 / broader XSS, R2F21 / fixture auto-create) deferred or rolled into adjacent fixes.
+
+| ID | Severity | Resolution |
+| --- | --- | --- |
+| R2F1 | Critical | Added Task 8 (Dockerfile `tzdata`). Without this, the whole local-tz feature is a silent no-op. Added end-to-end Docker smoke step in manual testing. |
+| R2F2 | High | Renamed Task 4 case 12 from "drift detector" to `test_footer_text_pin`. AC 12 explicitly scopes coverage to owner + URLs and documents what it does NOT detect; year/markup/aria covered by AC 8/9. |
+| R2F3 | Med | Added `margin-top` ≥ 0.4rem on `.open-records-list` (already in spec — explicitly called out in Decision #9). Added long-name / many-records manual smoke step. |
+| R2F4 | Med | Dropped the empty-tzname fallback entirely; helper now fails loudly via `TypeError` on `None`-tzname. Decision #3 and Task 2 updated. AC 8 fallback case removed. |
+| R2F5 | Med | Split AC 7 into AC 7a (helper wiring via patched return) and AC 7b (helper formats tzname-present case via patched `datetime`). Dropped "via dt.tzname() not string inspection" — not externally testable. |
+| R2F6 | Low | Dropped `id` from the sort key in Task 1; documented that Python's stable sort + prefetch `(created_at, id)` order provides the tiebreak. |
+| R2F7 | Low | Eliminated the `_NO_SEVERITY_SORT_PRIORITY = 999` constant entirely. Unknown / None severities fold to `_NOT_SURE_PRIORITY` (= `_SEVERITY_STATUS['Not Sure'][2]`), avoiding both magic-number duplication AND the equipment-level inversion (R2F8). |
+| R2F8 | Med | Unknown severities and `None` both sort at `Not Sure` priority (2), matching the equipment-level Degraded fallback. AC 3 expanded to cover the unknown-severity case explicitly. |
+| R2F10 | Med | AC 9 (now AC 9) asserts `&copy; <YEAR> Jason Antman` literal entity. Test case renamed `test_footer_renders_local_tz_year_as_entity`. |
+| R2F11 | Med | Inlined footer now includes `aria-label="Site copyright and license"` on `<footer>`, `<small>` wrapper, and `aria-label` on both anchors — mirrors `_footer.html`. AC 8 pins these. |
+| R2F12 | Low | Task 4 case 12 specifies `app.jinja_env.loader.get_source(app.jinja_env, 'components/_footer.html')[0]` for path resolution. |
+| R2F13 | Low | Moved AC 18/19 to a new **Documentation Checklist** section (DC 1, DC 2, DC 3). Hedge "in a test or" dropped. Explicit owner: PR reviewer. |
+| R2F14 | Low | Corrected `description='X'` → `description='Test issue'` in code patterns, fixture description, and the test_patterns frontmatter. |
+| R2F15 | Low | Removed inaccurate `tests/conftest.py:118-160` line range; cite by file + named fixture instead. Other line-number cites checked. |
+| R2F17 | Med | Added Task 4 case 16 (`test_description_uses_prewrap_styles`) covering AC 13 (pre-wrap CSS). |
+| R2F19 | Low | Tightened `equipment_page.html` precedent note: "shows conceptual data shape only; static page reimplements layout in inline CSS without Bootstrap." |

--- a/_bmad-output/implementation-artifacts/tech-spec-static-status-page-export-improvements.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-static-status-page-export-improvements.md
@@ -7,19 +7,29 @@ stepsCompleted: [1, 2, 3, 4]
 tech_stack: ['Python 3.14', 'Flask', 'Jinja2', 'pytest']
 files_to_modify:
   - 'esb/services/static_page_service.py'
+  - 'esb/services/status_service.py'
   - 'esb/templates/public/static_page.html'
   - 'tests/test_services/test_static_page_service.py'
+  - 'tests/test_services/test_status_service.py'
+  - 'docker-compose.yml'
+  - 'docs/administrators.md'
 code_patterns:
-  - 'esb.services.status_service.get_area_status_dashboard() returns areas with computed status only — needs extension or supplementary query to expose ALL open repair records per equipment'
+  - 'esb.services.status_service.get_area_status_dashboard() returns areas with computed status only — needs extension to expose ALL open repair records per equipment'
   - 'esb.templates.components._footer.html is the site copyright footer used on live pages; references current_year context var (injected in esb/__init__.py)'
-  - 'esb.utils.filters.format_date and format_datetime are registered Jinja filters'
+  - 'esb.utils.filters.format_date is a registered Jinja filter'
+  - 'esb.slack.forms.format_status_summary and format_area_status_detail consume the dashboard dict shape'
 test_patterns:
   - 'tests/test_services/test_static_page_service.py uses make_area, make_equipment, make_repair_record fixtures; asserts on substrings in generated HTML'
+  - 'fixtures: make_repair_record(equipment, status, description, **kwargs) — kwargs become RepairRecord column values (severity, eta, created_at, etc.)'
+revision_history:
+  - '2026-05-11 — initial spec'
+  - '2026-05-11 — applied 20 adversarial-review findings (F1–F20)'
 ---
 
 # Tech-Spec: Static status page export improvements
 
 **Created:** 2026-05-11
+**Revised:** 2026-05-11 (post-adversarial-review)
 
 GitHub Issue: [#44](https://github.com/jantman/equipment-status-board/issues/44)
 
@@ -34,15 +44,21 @@ The static status page (`esb/services/static_page_service.py` → `esb/templates
 
 ### Solution
 
-Update `static_page_service.generate()` to pass through (a) the open repair records per non-green equipment item and (b) a generation timestamp in the system's local timezone. Update `esb/templates/public/static_page.html` to (i) render a list of open repair records — with each record's status, ETA, and description — nested under each non-green equipment item; (ii) add a generation-time sub-heading immediately under the `<h1>Equipment Status</h1>` title, right-aligned, in local timezone; (iii) replace the bottom "Generated:" line with the site's copyright/license footer text (inlined — the static page must remain CSP-locked and have no external assets).
+Update `static_page_service.generate()` to pass through (a) the open repair records per non-green equipment item (sorted by severity priority, then `created_at` ASC) and (b) a generation timestamp in the system's local timezone (with seconds). Update `esb/templates/public/static_page.html` to (i) render a list of open repair records — with each record's status, severity, ETA, and description — nested under each non-green equipment item; (ii) add a generation-time sub-heading immediately under the `<h1>Equipment Status</h1>` title, right-aligned, in local timezone; (iii) replace the bottom "Generated:" line with the site's copyright/license footer text (inlined — the static page must remain CSP-locked and have no external **sub-resources**, though anchor links to external sites are permitted). Configure the `worker` container to use `America/New_York` as the default timezone via `docker-compose.yml`, with deployment instructions added to `docs/administrators.md`.
+
+**Note on scope additions beyond issue #44's literal text:** The issue lists status, ETA, and description as required per-record fields. This spec additionally includes (a) a textual severity badge `[Down]` / `[Degraded]` / `[Not Sure]` per record — for accessibility, since color alone (the left-border indicator) is a WCAG concern; (b) sort-by-severity-priority — so the most urgent records bubble to the top at a glance, since this is the fallback view when the live site is down. These are explicitly called out as enhancements.
 
 ### Scope
 
 **In Scope:**
-- `esb/services/static_page_service.py` `generate()` — pass open repair records per equipment + local-timezone timestamp.
+- `esb/services/status_service.py` — extend `get_area_status_dashboard()` to include per-equipment `open_records` list, sorted by severity priority then `created_at` ASC.
+- `esb/services/static_page_service.py` — compute local-tz generation timestamp (with seconds), pass local-tz year to the template.
 - `esb/templates/public/static_page.html` — repair-record list under non-green items, top sub-heading with generated time, replace bottom footer with inlined copyright text.
-- Inline the copyright footer markup/text into the static template (the static page may not depend on `_footer.html` or external CSS — same self-contained / `default-src 'none'` CSP rule).
-- Update `tests/test_services/test_static_page_service.py` to cover the new repair list and footer / generation-time placement.
+- Inline the copyright footer markup/text into the static template (the static page must have no external sub-resources — same self-contained / `default-src 'none'` CSP rule).
+- `docker-compose.yml` — set `TZ=America/New_York` as the default `worker`-service environment variable (overridable via `.env` for non-EST/EDT deployments).
+- `docs/administrators.md` — document the `TZ` environment variable in the Environment Variable Reference table.
+- `tests/test_services/test_static_page_service.py` — cover the new repair list, footer, generation-time placement, XSS escape, and CSP directive integrity.
+- `tests/test_services/test_status_service.py` — regression test for the new `open_records` key in `get_area_status_dashboard()`.
 
 **Out of Scope:**
 - Live `public/status_dashboard.html`, kiosk views, or equipment-info pages.
@@ -50,185 +66,427 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 - Push delivery backends (`_push_local`, `_push_s3`, `_push_gcs`) — unchanged.
 - Changes to `status_service` status derivation (color/label/severity logic stays as-is).
 - Reuse of `_footer.html` via `{% include %}` — static export must remain self-contained.
+- Pagination / cap on the number of open records displayed per equipment (explicit decision — see Notes).
+- `get_single_area_status_dashboard()` extension (per-area kiosk static export).
 
 ## Context for Development
 
 ### Codebase Patterns
 
-- **Self-contained static page.** `static_page.html` declares `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'` and uses only inline `<style>`. The page must continue to render with no external `<link>` or `<script src=>` (existing test `test_produces_self_contained_html` enforces this).
-- **Status derivation lives in `esb/services/status_service.py`.** `get_area_status_dashboard()` currently emits one `status` dict per equipment (computed from the highest-severity open record). The new requirement needs **all open repair records** per non-green equipment. Approach: extend `get_area_status_dashboard()` to additionally include the per-equipment list of `RepairRecord` instances in each entry (e.g., `open_records: list[RepairRecord]`). The records are already prefetched and grouped by `equipment_id` in the existing implementation (`records_by_equipment` dict), so threading the list through to the result dict is a non-disruptive add — existing callers ignoring the new key continue to work, and we avoid a near-duplicate helper. **However**, since the live dashboard uses the same call but should not show the per-record list, the template change is gated on this being the *static page* template — the live `status_dashboard.html` does not iterate `open_records`. Verify no live-page templates accidentally start rendering the new key (none do today).
-- **`current_year` is injected via `app.context_processor` in `esb/__init__.py`** (`esb/__init__.py:75-76`); that processor works for `render_template()` calls so it is available to the static template without explicit kwargs.
-- **Jinja filters `format_date` and `format_datetime`** (in `esb/utils/filters.py:13-32`) are registered on the app's Jinja env and usable from any template, including the static one.
+- **Self-contained static page.** `static_page.html` declares `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'` and uses only inline `<style>`. The page must continue to render with no external **sub-resources** — no `<link>`, no `<script src=>`, no `<img src=…>` to external hosts. Anchor links (`<a href="…">`) to external sites are user-initiated navigation, not auto-fetched sub-resources, and are permitted under this CSP (which has no `connect-src` / `navigate-to` restrictions). Existing test `test_produces_self_contained_html` enforces no `<link>` / `<script src=>`.
+- **Status derivation lives in `esb/services/status_service.py`.** `get_area_status_dashboard()` currently emits one `status` dict per equipment (computed from the highest-severity open record). The new requirement needs **all open repair records** per non-green equipment. Approach: extend `get_area_status_dashboard()` to additionally include the per-equipment list of `RepairRecord` instances in each entry (e.g., `open_records: list[RepairRecord]`). The records are already prefetched and grouped by `equipment_id` in the existing implementation (`records_by_equipment` dict). The new key is sorted by `(severity priority ASC, created_at ASC)` using `_SEVERITY_STATUS`; the prefetch query is already ordered by `(created_at ASC, id ASC)` so the secondary sort is stable. Existing callers ignoring the new key continue to work.
+- **Consumers of `get_area_status_dashboard()` return value** (audited 2026-05-11):
+  - `esb/templates/public/status_dashboard.html` — iterates `area_data.equipment[*].equipment` and `.status` only.
+  - `esb/templates/public/kiosk.html` — same.
+  - `esb/views/public.py:40-54` `kiosk_area()` route — passes a single-area dict (from `get_single_area_status_dashboard()`, not changed here) into `public/kiosk.html`.
+  - `esb/slack/forms.py` `format_status_summary(dashboard_data)` and `format_area_status_detail(area_data)` — iterate `equipment` and `status` only.
+  - `esb/slack/handlers.py:288` — calls `format_status_summary()` from the `/esb-status` command path.
+  - None of the above reference `open_records`, so the additive key change does not require any caller updates. The full test suite (Task 6) is the regression net.
+- **`current_year` is injected via `app.context_processor` in `esb/__init__.py`** (`esb/__init__.py:75-76`); that processor works for `render_template()` calls so it is available to the static template without explicit kwargs. **However**, it is derived from `datetime.now(timezone.utc).year`, which can disagree with the static page's local-tz generation timestamp for a few hours either side of midnight Dec 31. Spec passes a local-tz year as a separate template var (`generated_year`) and the footer uses that, not `current_year`, to keep the two timestamps consistent (see Decision #7).
+- **Jinja filter `format_date`** (in `esb/utils/filters.py:13-30`) is registered on the app's Jinja env and usable from any template, including the static one.
 - **`RepairRecord` model fields** (confirmed in `esb/models/repair_record.py`):
   - `status: str` from `REPAIR_STATUSES = ['New', 'Assigned', 'In Progress', 'Parts Needed', 'Parts Ordered', 'Parts Received', 'Needs Specialist', 'Resolved', 'Closed - No Issue Found', 'Closed - Duplicate']`. Non-closed = anything not in `CLOSED_STATUSES = ('Resolved', 'Closed - No Issue Found', 'Closed - Duplicate')`.
   - `severity: str | None` from `REPAIR_SEVERITIES = ['Down', 'Degraded', 'Not Sure']`.
-  - `description: str` (Text, non-null).
+  - `description: str` (Text, non-null). Can be multi-line and effectively unbounded.
   - `eta: date | None`.
   - `created_at: datetime` (UTC).
-- **Severity → color map** (`status_service._SEVERITY_STATUS`): `Down`→red, `Degraded`→yellow, `Not Sure`→yellow. Use this same mapping for per-record styling in the new repair list to stay consistent.
-- **Local-timezone formatting.** No existing helper. Use `datetime.now().astimezone()` (passing no `tzinfo`) — Python derives the system tz from `TZ` env / `/etc/localtime`. Format with `strftime('%Y-%m-%d %H:%M %Z')` (e.g., `2026-05-11 14:32 EDT`). If `%Z` is empty (rare; happens when `tzinfo` is a fixed offset without a name), fall back to ISO offset `%z`. Compute in the service (not Jinja) so all tz logic stays out of the template.
-- **Reference precedent.** `esb/templates/public/equipment_page.html:29-46` already renders an `open_repairs` list with severity-derived `status-card-*` styling — same data shape, similar visual treatment. The static page repair list should follow the same conceptual layout (record per `<li>`, severity styling, description visible, ETA shown when set) but using *inline* CSS classes already defined in `static_page.html` (Bootstrap is unavailable in the export).
+- **Severity → color map** (`status_service._SEVERITY_STATUS`): `Down`→red (priority 0), `Degraded`→yellow (priority 1), `Not Sure`→yellow (priority 2), no severity → gray (priority 3, treated as last for sort purposes). Use this same mapping for per-record styling AND per-record sort.
+- **Local-timezone formatting.** No existing helper. Place the implementation in a module-level helper `_compute_generated_at()` (NOT inline in `generate()`) so tests can monkey-patch it directly. Format: `'%Y-%m-%d %H:%M:%S %Z'` → `2026-05-11 14:32:15 EDT`. If `dt.tzname()` returns `None` or an empty string (fixed-offset zone), fall back to `'%Y-%m-%d %H:%M:%S %z'` → `2026-05-11 14:32:15 -0400`. **Detect the fallback by inspecting `dt.tzname()` directly**, not by parsing the result of `strftime('%Z')` for trailing whitespace.
+- **Reference precedent.** `esb/templates/public/equipment_page.html:29-46` already renders an `open_repairs` list with severity-derived `status-card-*` styling. Static page repair list follows the same conceptual layout (record per `<li>`, severity styling, description visible, ETA shown when set) but using *inline* CSS classes defined within `static_page.html` (Bootstrap is unavailable in the export).
+- **Test fixtures** (`tests/conftest.py:118-160`):
+  - `make_area(name=…)` → `Area` (the only accepted kwarg shape).
+  - `make_equipment(name=…, area=…, **kwargs)` → `Equipment` (extra kwargs forwarded to model constructor).
+  - `make_repair_record(equipment=…, status='New', description='X', **kwargs)` → `RepairRecord`. Extra kwargs (`severity`, `eta`, `created_at`, `assignee_id`, `reporter_name`, etc.) are forwarded to the `RepairRecord` constructor; **the fixture does NOT accept `area` or `name`**.
 
 ### Files to Reference
 
 | File | Purpose |
 | ---- | ------- |
-| `esb/services/static_page_service.py` | Modify `generate()` to fetch repair records + local-tz timestamp. |
-| `esb/services/status_service.py` | Add (or extend) a helper that returns areas with each equipment's full open-record list. |
+| `esb/services/static_page_service.py` | Modify `generate()`; add `_compute_generated_at()` module-level helper. |
+| `esb/services/status_service.py` | Extend `get_area_status_dashboard()` with the new `open_records` key. |
 | `esb/templates/public/static_page.html` | Render repair list, top-right generation timestamp, inline copyright footer. |
 | `esb/templates/components/_footer.html` | Source of truth for the copyright/license text and link targets (used as reference; not included). |
-| `esb/__init__.py` | `inject_current_year` context processor (already wired). |
-| `esb/utils/filters.py` | `format_date`, `format_datetime` Jinja filters. |
-| `tests/test_services/test_static_page_service.py` | Existing test class `TestGenerate`; add cases for repair list, top-right timestamp, and inline footer. |
+| `esb/__init__.py` | `inject_current_year` context processor (already wired; not modified — local-tz year is passed separately). |
+| `esb/utils/filters.py` | `format_date` Jinja filter. |
+| `esb/slack/forms.py`, `esb/slack/handlers.py` | Existing consumers of `get_area_status_dashboard()`; verified not affected by the additive `open_records` key. |
+| `docker-compose.yml` | Add `TZ=America/New_York` to the `worker` service. |
+| `docs/administrators.md` | Document the `TZ` env var in the Environment Variable Reference section. |
+| `tests/test_services/test_static_page_service.py` | Existing test class `TestGenerate`; add cases for repair list, top-right timestamp, inline footer, footer-drift pin, XSS escape, CSP directive integrity. |
+| `tests/test_services/test_status_service.py` | Add regression test for `open_records` key. |
+| `tests/conftest.py` | Fixture definitions (`make_area`, `make_equipment`, `make_repair_record`). |
 
 ### Technical Decisions
 
-1. **Extend `get_area_status_dashboard()` to include an `open_records` list per equipment.** Records are already prefetched and grouped in `records_by_equipment`; threading the list through is a one-line change. Rejected the "new helper" option to avoid duplicating ~40 lines of prefetch code. Existing callers (live dashboard, kiosk) ignore the new key.
-2. **Render repair records sorted by `created_at` ASC** (matches the prefetch order already used by `status_service` — `.order_by(RepairRecord.created_at, RepairRecord.id)`).
-3. **Local timezone for the generation timestamp.** Use `datetime.now().astimezone()` (no `tzinfo` argument) — Python picks up the host system's TZ from `TZ` / `/etc/localtime`. The container `docker-compose.yml` / production deployment is responsible for setting `TZ`; in absence of `TZ` the default is UTC, which is acceptable. Format string: `'%Y-%m-%d %H:%M %Z'` → `2026-05-11 14:32 EDT`. If `%Z` produces an empty string (fixed-offset zones without names), fall back to `'%Y-%m-%d %H:%M %z'` → `2026-05-11 14:32 -0400`.
-4. **Footer text is inlined verbatim** from `_footer.html` (copyright line + GitHub link + MIT license link) into `static_page.html`, NOT included via `{% include %}`. Reasons: (a) the static page must remain self-contained / asset-free; (b) an include couples the export to a fragment used by the live site, which is brittle if that fragment later pulls in Bootstrap classes or external icons; (c) copyright text is short and stable. Footer markup uses inline styles defined in `static_page.html` (no Bootstrap class dependency).
-5. **Per-record styling**. Repair-record `<li>` items use a small inline left-border indicator color-coded by severity using the same mapping as the equipment-level dot (`Down`→red, `Degraded`/`Not Sure`→yellow, no severity → neutral gray). Display order within the record: `[status badge] [severity badge if set] description …ETA: …`.
-6. **Generation sub-heading placement.** Below the `<h1>Equipment Status</h1>` block, right-aligned via `text-align: right` on a `.generated-at` div (new CSS rule). On narrow screens it remains right-aligned (CSS `text-align: right` is fine in single-column flow at any width).
+1. **Extend `get_area_status_dashboard()` to include an `open_records` list per equipment.** Records are already prefetched and grouped in `records_by_equipment`; threading the list through is a one-line change. Rejected the "new helper" option to avoid duplicating ~40 lines of prefetch code. Existing callers (live dashboard, kiosk, Slack formatters) ignore the new key (verified — see "Consumers" bullet above).
+2. **Sort open records by severity priority, then `created_at` ASC.** Rationale: the static page is the fallback at-a-glance view. Sorting by severity ensures `Down` records bubble above `Degraded`/`Not Sure`/no-severity within each equipment's record list, supporting quick triage. Sort key: `(_SEVERITY_STATUS.get(rec.severity, (..., ..., 999))[2], rec.created_at, rec.id)`. The `999` default places no-severity records last. Apply the sort inside `get_area_status_dashboard()` after grouping by equipment.
+3. **Local-timezone generation timestamp.** Implemented in module-level helper `_compute_generated_at()` in `static_page_service.py` (so tests can patch it). Uses `datetime.now().astimezone()` (no `tzinfo` argument) — Python picks up the host system's TZ from `TZ` env / `/etc/localtime`. Format: `'%Y-%m-%d %H:%M:%S %Z'` → `2026-05-11 14:32:15 EDT`. **Seconds are included** for debugging value when multiple pushes happen within a minute. If `dt.tzname()` returns `None` or `''`, fall back to `'%Y-%m-%d %H:%M:%S %z'` → `2026-05-11 14:32:15 -0400`. Detection is via `dt.tzname()`, not via post-hoc string inspection of the formatted output.
+4. **Footer text is inlined verbatim** from `_footer.html` (copyright line + GitHub link + MIT license link) into `static_page.html`, NOT included via `{% include %}`. Reasons: (a) the static page must remain self-contained (no external sub-resources); (b) an include couples the export to a fragment used by the live site, which is brittle if that fragment later pulls in Bootstrap classes or external icons; (c) copyright text is short and stable. **Drift mitigation:** Task 4 adds a unit test that reads `_footer.html` and asserts its three key substrings (owner name, GitHub URL, MIT URL) appear verbatim in the rendered static page. The test fails loudly when either file diverges, forcing the implementer to keep the static-page footer in sync. Footer markup uses inline styles defined in `static_page.html` (no Bootstrap class dependency).
+5. **Per-record styling**. Repair-record `<li>` items use a small inline left-border indicator color-coded by severity using the same mapping as the equipment-level dot (`Down`→red, `Degraded`/`Not Sure`→yellow, no severity → gray). Display order within the record: `[status badge] [severity badge if set] description …ETA: …`. Severity text badge is **retained** (e.g., `[Down]`) as an accessibility/redundancy feature — color alone is a WCAG concern, and the text badge gives the same information non-visually. This is called out as a spec-added enhancement beyond issue #44's literal ask.
+6. **Description wrap, not truncate.** `RepairRecord.description` is unbounded Text. Apply inline CSS `white-space: pre-wrap; overflow-wrap: anywhere;` to `.record-description` so multi-line descriptions render correctly and long un-broken strings (URLs, etc.) wrap rather than overflow the page. **No truncation** — the static page is a fallback view and full text is more useful than an ellipsis; visual clutter from a long description is acceptable for that rare case.
+7. **Local-tz year for the footer.** Compute the footer year from the same `datetime` used by `_compute_generated_at()` and pass it to the template as a separate kwarg `generated_year`. The footer renders `&copy; {{ generated_year }} Jason Antman`. The `current_year` context processor (UTC) is left alone so the live site is unaffected. This avoids the ~5-hour disagreement window around midnight Dec 31 where footer year and generation-timestamp year could differ by one.
+8. **Generation sub-heading placement.** Below the `<h1>Equipment Status</h1>` block, right-aligned via `text-align: right` on a `.generated-at` div (new CSS rule).
+9. **Equipment-row layout wrapper.** Existing `.equipment-item` uses `display: flex` to lay out dot/name/label/eta on one line. Adding a nested `<ul>` for open records inside the same `<li>` would make the `<ul>` a flex sibling. Spec wraps the existing four spans into a new `<div class="equipment-row">` (with `display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem;`) and changes `.equipment-item` to `display: block`. The new `<ul class="open-records-list">` lays out beneath the row naturally. The full template diff is spelled out in Task 3.
+10. **TZ default in `docker-compose.yml`.** Set `TZ=${TZ:-America/New_York}` in the `worker` service `environment:` block so the makerspace timezone is the out-of-the-box default. Operators in other zones override via `TZ=...` in `.env`. The `app` service does not need `TZ` because it does not invoke `generate()`; the worker is the sole producer of static pages via `generate_and_push()`.
+11. **Module-level datetime import in `static_page_service.py`.** Hoist `from datetime import datetime` to module top (it is currently function-scoped). This is required for the `_compute_generated_at()` helper to exist at module scope, and it lets tests patch `static_page_service._compute_generated_at` directly.
 
 ## Implementation Plan
 
 ### Tasks
 
-- [ ] **Task 1: Extend `get_area_status_dashboard()` to include per-equipment open repair records.**
+- [ ] **Task 1: Extend `get_area_status_dashboard()` to include sorted per-equipment open repair records.**
   - File: `esb/services/status_service.py`
-  - Action: In the loop that builds `equip_statuses` (currently lines 238-246), add `'open_records': equip_records` to the dict appended for each equipment. The list is already on hand as `records_by_equipment.get(equip.id, [])` and is ordered by `(created_at ASC, id ASC)` from the prefetch query.
-  - Update the function's docstring (lines 170-186) to document the new `open_records` key — list of `RepairRecord` instances, ordered oldest-first.
-  - Notes: Existing callers (live `public/status_dashboard.html`, `public/kiosk.html`, `public/kiosk_area.html`) do not iterate `open_records`, so this is additive. Do **not** change `get_single_area_status_dashboard()` for now — it is used by the per-area kiosk view; out of scope.
+  - Action:
+    1. In `_SEVERITY_STATUS` (line 17-21), the priority for each known severity is the third tuple element. Add a module-level constant `_NO_SEVERITY_SORT_PRIORITY = 999` (or inline `999` with a comment) to use for records with `severity=None`.
+    2. Inside `get_area_status_dashboard()`, after the `records_by_equipment` grouping (lines 232-235), add a sort: for each list of records in `records_by_equipment.values()`, sort in place by `(severity_priority, created_at, id)`. Helper:
+       ```python
+       def _sort_key(rec):
+           sev = _SEVERITY_STATUS.get(rec.severity)
+           priority = sev[2] if sev else _NO_SEVERITY_SORT_PRIORITY
+           return (priority, rec.created_at, rec.id)
+       for records in records_by_equipment.values():
+           records.sort(key=_sort_key)
+       ```
+    3. In the loop that builds `equip_statuses` (currently lines 238-246), add `'open_records': equip_records` to the dict appended for each equipment.
+    4. Update the function's docstring (lines 170-186) to document the new `open_records` key — list of `RepairRecord` instances, sorted by `(severity priority, created_at, id)` so highest-severity oldest-first.
+  - Notes: Existing live-page templates (`public/status_dashboard.html`, `public/kiosk.html`) and Slack formatters (`esb/slack/forms.py`) iterate `area_data.equipment` but reference only `item.equipment` and `item.status` — none touch `open_records`. The additive key is safe. `get_single_area_status_dashboard()` is **not** changed (out of scope per Scope section).
 
-- [ ] **Task 2: Compute a local-timezone generation timestamp in `generate()`.**
+- [ ] **Task 2: Add `_compute_generated_at()` helper and hoist `datetime` import in `static_page_service.py`.**
   - File: `esb/services/static_page_service.py`
-  - Action: Replace lines 22-28 (`generated_at` computation and `render_template` call) with logic that builds the timestamp using `datetime.now().astimezone()`. Try `strftime('%Y-%m-%d %H:%M %Z')`; if the resulting `%Z` portion is empty (i.e., string ends with a trailing space), fall back to `strftime('%Y-%m-%d %H:%M %z')`. Pass the string as `generated_at` to `render_template('public/static_page.html', areas=areas, generated_at=generated_at)` (template var name unchanged).
-  - Notes: Keep the import inside the function (existing pattern). No new external deps.
+  - Action:
+    1. Move `from datetime import UTC, datetime` from inside `generate()` (line 22) to the module-level imports at the top of the file. Remove the now-unused `UTC` if not referenced elsewhere in the module.
+    2. Add a module-level helper function:
+       ```python
+       def _compute_generated_at() -> tuple[str, int]:
+           """Compute the generation timestamp string and year in the system's local timezone.
+
+           Returns:
+               (timestamp_str, year) where timestamp_str is formatted like
+               '2026-05-11 14:32:15 EDT' (or '2026-05-11 14:32:15 -0400' when
+               the local tz has no tzname). year is the local-tz year of the
+               same instant.
+           """
+           dt = datetime.now().astimezone()
+           tzname = dt.tzname()
+           if tzname:
+               timestamp_str = dt.strftime('%Y-%m-%d %H:%M:%S ') + tzname
+           else:
+               timestamp_str = dt.strftime('%Y-%m-%d %H:%M:%S %z')
+           return timestamp_str, dt.year
+       ```
+       (Note: build `timestamp_str` via concatenation, not `%Z`, because some Python builds emit a trailing space when `tzname()` is non-empty — being explicit avoids the ambiguity.)
+    3. Update `generate()`:
+       ```python
+       def generate() -> str:
+           from esb.services import status_service
+           areas = status_service.get_area_status_dashboard()
+           generated_at, generated_year = _compute_generated_at()
+           return render_template(
+               'public/static_page.html',
+               areas=areas,
+               generated_at=generated_at,
+               generated_year=generated_year,
+           )
+       ```
+       (Remove the docstring "Uses status_service.get_area_status_dashboard() for data" line about `generated_at` format being UTC.)
+  - Notes: No new external deps. Tests patch `esb.services.static_page_service._compute_generated_at` to inject deterministic timestamps regardless of host TZ.
 
 - [ ] **Task 3: Update `static_page.html` template structure.**
   - File: `esb/templates/public/static_page.html`
-  - Sub-actions:
-    1. **Add top-right generation sub-heading.** Immediately after `<h1>Equipment Status</h1>` (line 28), insert `<div class="generated-at">Generated: {{ generated_at }}</div>`. Add CSS rule `.generated-at { text-align: right; font-size: 0.85rem; color: #6c757d; margin-bottom: 1rem; }` in the inline `<style>` block.
-    2. **Render open-records list under non-green equipment.** Inside the `<li class="equipment-item">` loop (lines 35-40), after the existing inline status row, add a conditional block: `{% if item.status.color != 'green' and item.open_records %}<ul class="open-records-list">{% for rec in item.open_records %}<li class="open-record open-record-{{ 'red' if rec.severity == 'Down' else 'yellow' if rec.severity in ('Degraded', 'Not Sure') else 'gray' }}"><span class="record-status">{{ rec.status }}</span>{% if rec.severity %} <span class="record-severity">[{{ rec.severity }}]</span>{% endif %} <span class="record-description">{{ rec.description }}</span>{% if rec.eta %} <span class="record-eta">ETA: {{ rec.eta|format_date }}</span>{% endif %}</li>{% endfor %}</ul>{% endif %}`. Wrap the existing inline-item content in a span if needed to keep the dot/name/label on one line and push the `<ul>` to a new line — easiest: change `.equipment-item` from `flex` to `block`, wrap the dot+name+label+eta into a header `<div class="equipment-row">` with `display: flex` so the new `<ul>` lays out beneath it naturally.
-    3. **Add inline CSS for the records list.**
-       ```css
-       .open-records-list { list-style: none; margin: 0.4rem 0 0.6rem 1.5rem; }
-       .open-record { font-size: 0.85rem; padding: 0.25rem 0.4rem; margin-bottom: 0.2rem; border-left: 3px solid #6c757d; background: #fff; }
-       .open-record-red { border-left-color: #dc3545; }
-       .open-record-yellow { border-left-color: #ffc107; }
-       .open-record-gray { border-left-color: #6c757d; }
-       .record-status { font-weight: 600; }
-       .record-severity { color: #6c757d; }
-       .record-description { }
-       .record-eta { color: #6c757d; margin-left: 0.25rem; }
-       ```
-    4. **Replace bottom footer.** Delete the existing `<div class="footer">Generated: {{ generated_at }}</div>` block (lines 48-50) and the corresponding `.footer` CSS rule (line 24). Insert in its place: `<footer class="site-footer" role="contentinfo">&copy; {{ current_year }} Jason Antman. <a href="https://github.com/jantman/equipment-status-board" rel="noopener noreferrer">github.com/jantman/equipment-status-board</a> <a href="https://opensource.org/license/mit" rel="noopener noreferrer">MIT licensed</a>.</footer>`. Add CSS: `.site-footer { text-align: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #dee2e6; font-size: 0.8rem; color: #6c757d; } .site-footer a { color: #6c757d; }` — note an `<a>` selector style is required because the document has no CSS framework reset.
-  - Notes: Keep CSP unchanged (`default-src 'none'; style-src 'unsafe-inline'`). All `<a>` tags in the new footer are anchor-only (no scripts); the CSP does not need to allow `connect-src` or anything else.
+  - Below is the full intended template (replace the file's contents). Read the existing file first to confirm no other recent edits.
 
-- [ ] **Task 4: Add tests for the new behaviors.**
+    ```html
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
+        <title>Equipment Status</title>
+        <style>
+            * { margin: 0; padding: 0; box-sizing: border-box; }
+            body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #212529; background: #f8f9fa; padding: 1rem; }
+            h1 { font-size: 1.5rem; margin-bottom: 0.25rem; text-align: center; }
+            .generated-at { text-align: right; font-size: 0.85rem; color: #6c757d; margin-bottom: 1rem; }
+            .area { margin-bottom: 1.5rem; }
+            .area h2 { font-size: 1.1rem; border-bottom: 2px solid #dee2e6; padding-bottom: 0.3rem; margin-bottom: 0.5rem; }
+            .equipment-list { list-style: none; }
+            .equipment-item { display: block; padding: 0.25rem 0; }
+            .equipment-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+            .status-dot { width: 12px; height: 12px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
+            .status-green { background-color: #198754; }
+            .status-yellow { background-color: #ffc107; }
+            .status-red { background-color: #dc3545; }
+            .equipment-name { font-size: 0.95rem; }
+            .status-label { font-size: 0.8rem; color: #6c757d; }
+            .eta-label { font-size: 0.8rem; color: #6c757d; margin-left: 0.25rem; }
+            .no-equipment { color: #6c757d; font-size: 0.9rem; }
+            .open-records-list { list-style: none; margin: 0.4rem 0 0.6rem 1.5rem; }
+            .open-record { font-size: 0.85rem; padding: 0.25rem 0.4rem; margin-bottom: 0.2rem; border-left: 3px solid #6c757d; background: #fff; }
+            .open-record-red { border-left-color: #dc3545; }
+            .open-record-yellow { border-left-color: #ffc107; }
+            .open-record-gray { border-left-color: #6c757d; }
+            .record-status { font-weight: 600; }
+            .record-severity { color: #6c757d; }
+            .record-description { white-space: pre-wrap; overflow-wrap: anywhere; }
+            .record-eta { color: #6c757d; margin-left: 0.25rem; }
+            .site-footer { text-align: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #dee2e6; font-size: 0.8rem; color: #6c757d; }
+            .site-footer a { color: #6c757d; }
+        </style>
+    </head>
+    <body>
+        <h1>Equipment Status</h1>
+        <div class="generated-at">Generated: {{ generated_at }}</div>
+        {% for area_data in areas %}
+        <div class="area">
+            <h2>{{ area_data.area.name }}</h2>
+            {% if area_data.equipment %}
+            <ul class="equipment-list">
+                {% for item in area_data.equipment %}
+                <li class="equipment-item">
+                    <div class="equipment-row">
+                        <span class="status-dot status-{{ item.status.color }}" aria-hidden="true"></span>
+                        <span class="equipment-name">{{ item.equipment.name }}</span>
+                        <span class="status-label">{{ item.status.label }}</span>
+                        {% if item.status.eta %}<span class="eta-label">ETA: {{ item.status.eta|format_date }}</span>{% endif %}
+                    </div>
+                    {% if item.status.color != 'green' and item.open_records %}
+                    <ul class="open-records-list">
+                        {% for rec in item.open_records %}
+                        <li class="open-record open-record-{{ 'red' if rec.severity == 'Down' else 'yellow' if rec.severity in ('Degraded', 'Not Sure') else 'gray' }}">
+                            <span class="record-status">{{ rec.status }}</span>{% if rec.severity %} <span class="record-severity">[{{ rec.severity }}]</span>{% endif %} <span class="record-description">{{ rec.description }}</span>{% if rec.eta %} <span class="record-eta">ETA: {{ rec.eta|format_date }}</span>{% endif %}
+                        </li>
+                        {% endfor %}
+                    </ul>
+                    {% endif %}
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p class="no-equipment">No equipment in this area.</p>
+            {% endif %}
+        </div>
+        {% endfor %}
+        <footer class="site-footer" role="contentinfo">&copy; {{ generated_year }} Jason Antman. <a href="https://github.com/jantman/equipment-status-board" rel="noopener noreferrer">github.com/jantman/equipment-status-board</a> <a href="https://opensource.org/license/mit" rel="noopener noreferrer">MIT licensed</a>.</footer>
+    </body>
+    </html>
+    ```
+
+  - Key changes vs. previous template: `.equipment-item` becomes `display: block`; the existing dot/name/label/eta row is wrapped in `<div class="equipment-row">`; new `<ul class="open-records-list">` rendered only when equipment is non-green AND has open records; old `<div class="footer">Generated: …</div>` replaced by `<footer class="site-footer">` with copyright/license; new `.generated-at` sub-heading directly under the `<h1>`. The footer uses `generated_year` (local-tz, from `_compute_generated_at()`), NOT `current_year`. The CSP directive is unchanged.
+
+- [ ] **Task 4: Add tests in `tests/test_services/test_static_page_service.py`.**
   - File: `tests/test_services/test_static_page_service.py`
-  - Add the following test cases inside `class TestGenerate`:
-    1. `test_generated_at_subheading_renders_above_areas` — Given an area with one equipment item, when `generate()` runs, then the HTML contains `<div class="generated-at">` and that string's index in the HTML is **less than** the index of the first `<div class="area">`.
-    2. `test_generated_at_uses_local_timezone_not_hardcoded_utc` — Patch `datetime` in the service to return a fixed `datetime` whose `astimezone()` yields an EST/EDT-like tzinfo (or use `datetime.now().astimezone()` and just assert the `UTC` literal does not appear in the new subheading when system tz is non-UTC; otherwise allow `UTC`). Concretely: assert the new sub-heading does **not** end with `' UTC'` UNLESS the test's local `datetime.now().astimezone().tzname() == 'UTC'`. A simpler version: monkey-patch `static_page_service.datetime` so `datetime.now().astimezone()` returns a known timestamp with `tzname() == 'EDT'`, then assert `'2026-05-11 14:32 EDT'` (or similar) appears in the HTML.
-    3. `test_open_records_listed_for_non_green_equipment` — Create equipment with one `make_repair_record(status='In Progress', severity='Down', description='Belt slipping', eta=date(2026, 6, 1))`. Assert HTML contains `'In Progress'`, `'Belt slipping'`, `'[Down]'`, and `'ETA: ' + date(2026, 6, 1).strftime('%b %d, %Y')` AND contains a `class="open-record open-record-red"` substring.
-    4. `test_open_records_omitted_for_green_equipment` — Create equipment with no repair records. Assert HTML does NOT contain `class="open-records-list"`.
-    5. `test_open_records_uses_yellow_class_for_degraded_and_not_sure` — Create two equipment items, one with severity `'Degraded'` and one with `'Not Sure'`. Assert both render `class="open-record open-record-yellow"`.
-    6. `test_open_records_uses_gray_class_for_no_severity` — Create a repair record with `severity=None` (raw). Assert `class="open-record open-record-gray"` appears AND the equipment's color falls back per `_derive_status_from_records` (yellow Degraded). Severity badge `[…]` must NOT appear since severity is `None`.
-    7. `test_open_records_omits_eta_when_unset` — Repair record with `eta=None`. Assert `record-eta` class does not appear in the rendered `<li class="open-record …">` block.
-    8. `test_open_records_ordered_by_created_at_asc` — Create two records on the same equipment, the second with an earlier `created_at`. Assert the earlier record appears first in the HTML (substring index check).
-    9. `test_site_footer_replaces_old_generated_line` — Assert HTML contains `'Jason Antman'`, `'github.com/jantman/equipment-status-board'`, and `'MIT licensed'`, AND does NOT contain `'<div class="footer">'` (the old class name).
-    10. `test_footer_renders_current_year` — Patch `datetime.now()` in `inject_current_year` (or just assert the rendered current year matches `datetime.now(timezone.utc).year`).
-    11. **Update existing `test_includes_generated_timestamp`** — it currently asserts `'UTC' in html`. Replace that assertion with `'Generated:' in html` only (timezone now depends on host); or keep `'UTC'` only if the host TZ is UTC. Safest: change to assert `'Generated:' in html`.
-  - Notes: The fixtures `make_area`, `make_equipment`, `make_repair_record` accept `area`, `name`, `status`, `severity`, `description`, `eta`, etc. as kwargs (per existing tests in this same file).
+  - Add the following tests (inside `class TestGenerate` unless noted):
 
-- [ ] **Task 5: Run lint and full test suite.**
+    1. `test_generated_at_subheading_renders_above_areas` — Given an area with one equipment item, when `generate()` runs, then the HTML contains `<div class="generated-at">` and that string's `find()` index is less than the index of the first `<div class="area">` AND greater than the index of `</h1>`.
+
+    2. `test_generated_at_uses_local_timezone_helper` (covers AC 7) — Monkey-patch `esb.services.static_page_service._compute_generated_at` to return `('2026-05-11 14:32:15 EDT', 2026)`. Call `generate()`. Assert HTML contains `Generated: 2026-05-11 14:32:15 EDT`. This bypasses the host TZ entirely and verifies the wiring between the helper and the template.
+
+    3. `test_compute_generated_at_uses_tzname_when_present` (covers AC 7, helper-level) — Use `unittest.mock.patch` on `esb.services.static_page_service.datetime` to make `datetime.now().astimezone()` return a real `datetime` with `tzinfo=ZoneInfo('America/New_York')` set to a specific UTC instant (e.g., `2026-07-15 14:32:15` US Eastern). Call `_compute_generated_at()` directly. Assert returned timestamp ends with ` EDT` and year is `2026`.
+
+    4. `test_compute_generated_at_falls_back_to_offset_when_tzname_empty` (covers AC 8) — Patch `datetime.now().astimezone()` to return a `datetime` whose `tzinfo` is a `timezone(timedelta(hours=-4))` (anonymous offset; `tzname()` returns `'UTC-04:00'` by default in newer Python, but `timezone(timedelta(hours=-4), name=None)` then `tzname()` returns the offset string — verify behavior; if needed, build a custom `tzinfo` subclass whose `tzname()` returns `None`). Assert the returned timestamp ends with `-0400` (i.e., `%z` format), not an empty trailing space.
+
+    5. `test_open_records_listed_for_non_green_equipment` (covers AC 1) — Create equipment with one record `make_repair_record(equipment=eq, status='In Progress', severity='Down', description='Belt slipping', eta=date(2026, 6, 1))`. Call `generate()`. Assert HTML contains `'In Progress'`, `'[Down]'`, `'Belt slipping'`, and `'ETA: ' + date(2026, 6, 1).strftime('%b %d, %Y')`, AND contains the substring `class="open-record open-record-red"`.
+
+    6. `test_open_records_omitted_for_green_equipment` (covers AC 2) — Create equipment with no repair records. Assert HTML does NOT contain `'open-records-list'`.
+
+    7. `test_open_records_uses_yellow_class_for_degraded_and_not_sure` (covers AC 4) — Create two equipment items in the same area, one with `severity='Degraded'`, one with `severity='Not Sure'`. Assert HTML contains at least two occurrences of `'open-record-yellow'`.
+
+    8. `test_open_records_uses_gray_class_for_no_severity` (covers AC 4 None branch) — Create a repair record passing `severity=None` (note: this requires inserting via the fixture; the model column is nullable). Assert HTML contains `'open-record-gray'` AND does NOT contain `'<span class="record-severity">'` for that record.
+
+    9. `test_open_records_omits_eta_when_unset` (covers AC 5) — Create a repair record with `eta=None`. Within its `<li class="open-record …">` block, the rendered HTML must not contain `'record-eta'`. Use a sliced substring (e.g., split on `open-record open-record-`) to isolate the relevant `<li>` for the assertion.
+
+    10. `test_open_records_sorted_by_severity_priority_then_created_at` (covers AC 3) — Create one equipment with three records: `(severity='Down', created_at=datetime(2026, 5, 1, tzinfo=UTC), description='down-newer')`, `(severity='Not Sure', created_at=datetime(2026, 4, 1, tzinfo=UTC), description='notsure-older')`, `(severity='Degraded', created_at=datetime(2026, 4, 15, tzinfo=UTC), description='degraded-mid')`. Insert in mixed insertion order. Call `generate()`. Assert the HTML substring index of `'down-newer'` < `'degraded-mid'` < `'notsure-older'` (severity priority order: Down(0) < Degraded(1) < Not Sure(2)).
+
+    11. `test_site_footer_replaces_old_generated_line` (covers AC 9) — Call `generate()`. Assert HTML contains `'Jason Antman'`, `'github.com/jantman/equipment-status-board'`, and `'MIT licensed'`, AND contains `'<footer class="site-footer"'`, AND does NOT contain `'<div class="footer">'` (the old class).
+
+    12. `test_footer_renders_local_tz_year` (covers AC 10) — Monkey-patch `_compute_generated_at` to return `(..., 2027)`. Assert HTML footer contains `'&copy; 2027 Jason Antman'` (or `'© 2027 Jason Antman'` after Jinja unescaping — use the literal-byte form Jinja emits; in practice `&copy;` is emitted verbatim because the template uses the entity).
+
+    13. `test_footer_pins_to_live_footer_text` (covers F9 drift mitigation) — Read `esb/templates/components/_footer.html` from disk. Extract the three load-bearing substrings: `'Jason Antman'`, the GitHub URL `https://github.com/jantman/equipment-status-board`, and the MIT URL `https://opensource.org/license/mit`. Assert each appears in the rendered static page HTML. If the live footer ever changes its owner name or link targets, this test fails and forces the static page to be updated in lockstep.
+
+    14. `test_description_is_html_escaped` (covers F11 XSS defense) — Create a repair record with `description='<script>alert(1)</script><img src=x onerror=y>'`. Call `generate()`. Assert HTML contains `'&lt;script&gt;'` (escaped) AND does NOT contain the literal `'<script>alert(1)</script>'`.
+
+    15. `test_csp_meta_tag_directive_unchanged` (covers AC 11; strengthen existing test) — Update existing `test_includes_csp_meta_tag` (or add a sibling) to assert the verbatim substring `"default-src 'none'; style-src 'unsafe-inline'"` appears in the HTML, not just `'Content-Security-Policy'`.
+
+    16. `test_equipment_row_keeps_dot_name_label_on_one_line` (covers AC re. F8 layout) — Assert HTML contains `<div class="equipment-row">` and within that wrapper, the order of substrings is `status-dot`, `equipment-name`, `status-label` (i.e., the existing single-line composition is preserved structurally).
+
+    17. **Update existing `test_includes_generated_timestamp`** (covers AC 12) — Replace `assert 'UTC' in html` with `assert 'Generated:' in html`. The timezone token now depends on host TZ / patched helper; pinning to `UTC` is no longer correct.
+
+  - Notes:
+    - Use `from datetime import UTC, datetime` (Python 3.11+) for the `created_at` kwarg values.
+    - The fixture `make_repair_record(equipment, status='New', description='X', **kwargs)` — pass `created_at`, `severity`, `eta` via kwargs.
+    - For `test_compute_generated_at_falls_back_to_offset_when_tzname_empty`, the cleanest approach is a tiny custom `tzinfo` subclass: `class _NamelessTZ(tzinfo): utcoffset = lambda self, dt: timedelta(hours=-4); tzname = lambda self, dt: None; dst = lambda self, dt: timedelta(0)`. Then patch `datetime.now().astimezone()` to return a datetime with that `tzinfo`.
+
+- [ ] **Task 5: Add a regression test for the new `open_records` key in `tests/test_services/test_status_service.py`.**
+  - File: `tests/test_services/test_status_service.py`
+  - Add (in an existing `TestGetAreaStatusDashboard` class, or create one if missing):
+
+    1. `test_includes_open_records_list_per_equipment` — Create one area with one equipment item and two non-closed repair records and one closed record (`status='Resolved'`). Call `get_area_status_dashboard()`. Assert `result[0]['equipment'][0]` has key `'open_records'` whose value is a `list` of length 2 (the two non-closed). Assert the closed record is excluded. Assert each entry is a `RepairRecord` instance.
+
+    2. `test_open_records_sorted_by_severity_then_created_at` — Create one equipment with `Down/2026-05-01`, `Not Sure/2026-04-01`, `Degraded/2026-04-15`, `None/2026-03-01`. Call the dashboard. Assert the `open_records` list order is: `Down`, `Degraded`, `Not Sure`, `None`-severity (severity-priority sort, ties broken by `created_at`).
+
+    3. `test_empty_open_records_list_for_green_equipment` — Create equipment with zero non-closed records. Assert `equipment[0]['open_records'] == []`.
+
+  - Notes: Verify existing tests in the file still pass — the new key is additive but make sure no existing assertion uses `set(equipment[0].keys())` style equality.
+
+- [ ] **Task 6: Configure default TZ in `docker-compose.yml` worker service.**
+  - File: `docker-compose.yml`
+  - Action: In the `worker:` service's `environment:` block (lines 53-60), add a new line: `      - TZ=${TZ:-America/New_York}`. Place it adjacent to the existing `PYTHONUNBUFFERED=1` and `WORKER_HEARTBEAT_PATH=…` entries.
+  - Notes: The `${TZ:-America/New_York}` syntax means "use the `TZ` env var if set in `.env` or shell, otherwise default to `America/New_York`." This matches the makerspace location (Decatur Makers) while letting other deployments override. The `app` service does **not** need TZ — only the worker calls `generate()`.
+
+- [ ] **Task 7: Document the `TZ` environment variable in `docs/administrators.md`.**
+  - File: `docs/administrators.md`
+  - Action: In the Environment Variable Reference table (line 72 onward), add a new row:
+    ```markdown
+    | `TZ` | IANA timezone name for the worker container. Controls the timezone displayed in the static status page's generation timestamp (sub-heading near top of page and the copyright year in the footer). Set this to your local timezone for accurate display. The `app` service does not use this variable. | No | `America/New_York` | `America/Chicago` |
+    ```
+  - Notes: Place the row alphabetically or near other deployment-configuration variables. The default reflects what's in `docker-compose.yml`. Also add a short paragraph in the "Static Status Page Setup" section (line 245+) noting that the static page's generation timestamp reflects the `worker` container's `TZ`, and that operators should set `TZ` in `.env` to match their local timezone.
+
+- [ ] **Task 8: Run lint and full test suite.**
   - Commands: `make lint` then `make test`.
-  - Expected: All green. Existing test `test_includes_generated_timestamp` was updated in Task 4.11; `test_produces_self_contained_html` continues to pass (no new `<link>` or `<script src=>`).
+  - Expected: All green. Existing test `test_includes_generated_timestamp` was updated in Task 4 case 17; `test_produces_self_contained_html` continues to pass (no new `<link>` or `<script src=>`); existing `test_includes_csp_meta_tag` may need rename/strengthen per Task 4 case 15. The full suite covers Slack formatter tests (`tests/test_slack/`) which exercise consumers of `get_area_status_dashboard()` — confirms no regression.
 
 ### Acceptance Criteria
 
-- [ ] **AC 1 (happy path — repair list rendered):** Given a non-archived area with one equipment item whose only open repair record has `status='In Progress'`, `severity='Down'`, `description='Belt slipping'`, `eta=2026-06-01`, when `static_page_service.generate()` is called, then the returned HTML contains a `<ul class="open-records-list">` nested under that equipment's `<li class="equipment-item">` whose single `<li>` includes the substrings `In Progress`, `[Down]`, `Belt slipping`, and `ETA: Jun 01, 2026`, and has CSS class `open-record-red`.
+- [ ] **AC 1 (happy path — repair list rendered):** Given a non-archived area with one equipment item whose only open repair record has `status='In Progress'`, `severity='Down'`, `description='Belt slipping'`, `eta=date(2026, 6, 1)`, when `static_page_service.generate()` is called, then the returned HTML contains a `<ul class="open-records-list">` nested under that equipment's `<li class="equipment-item">` whose single `<li>` includes the substrings `In Progress`, `[Down]`, `Belt slipping`, and `ETA: Jun 01, 2026`, and has the CSS class substring `open-record-red`.
 
 - [ ] **AC 2 (green equipment — no list):** Given a non-archived equipment item with zero open repair records, when `generate()` is called, then the HTML for that equipment contains no `open-records-list` element.
 
-- [ ] **AC 3 (multiple records — ordering):** Given one equipment item with two open repair records (record A `created_at = 2026-04-01`, record B `created_at = 2026-05-01`), when `generate()` is called, then the substring for record A appears before the substring for record B in the HTML (oldest first).
+- [ ] **AC 3 (severity-priority sort):** Given one equipment item with three open repair records (`severity='Down', created_at=2026-05-01`; `severity='Not Sure', created_at=2026-04-01`; `severity='Degraded', created_at=2026-04-15`), when `generate()` is called, then in the HTML the `Down` record appears before the `Degraded` record, which appears before the `Not Sure` record (severity-priority ascending; ties broken by older `created_at` first).
 
-- [ ] **AC 4 (severity color mapping):** Given open repair records with severities `'Down'`, `'Degraded'`, `'Not Sure'`, and `None`, when `generate()` is called, then their `<li class="open-record …">` elements receive classes `open-record-red`, `open-record-yellow`, `open-record-yellow`, and `open-record-gray` respectively, and the `None`-severity record does **not** render a `[…]` severity badge.
+- [ ] **AC 4 (severity color mapping):** Given open repair records with severities `'Down'`, `'Degraded'`, `'Not Sure'`, and `None`, when `generate()` is called, then their `<li class="open-record …">` elements receive classes `open-record-red`, `open-record-yellow`, `open-record-yellow`, and `open-record-gray` respectively, and the `None`-severity record does **not** render a `<span class="record-severity">[…]</span>` badge.
 
-- [ ] **AC 5 (ETA optional):** Given an open repair record with `eta=None`, when `generate()` is called, then its rendered `<li class="open-record …">` does not include a `record-eta` span and contains no `ETA:` substring.
+- [ ] **AC 5 (ETA optional):** Given an open repair record with `eta=None`, when `generate()` is called, then its rendered `<li class="open-record …">` does not include a `record-eta` span and contains no `ETA:` substring within that record's `<li>`.
 
-- [ ] **AC 6 (top sub-heading present and positioned):** Given any non-empty status dashboard, when `generate()` is called, then the HTML contains exactly one element matching `<div class="generated-at">` whose position in the document is after the closing tag of `<h1>Equipment Status</h1>` and before the first `<div class="area">`. Its inner text starts with `Generated: ` followed by a `YYYY-MM-DD HH:MM ` and a non-empty timezone token.
+- [ ] **AC 6 (top sub-heading present and positioned):** Given any non-empty status dashboard, when `generate()` is called, then the HTML contains exactly one element matching `<div class="generated-at">` whose `find()` position in the document is greater than the position of `</h1>` and less than the position of the first `<div class="area">`. Its inner text starts with `Generated: ` followed by a `YYYY-MM-DD HH:MM:SS ` (including seconds) and a non-empty timezone token.
 
-- [ ] **AC 7 (local timezone, not UTC by default):** Given the host system's local timezone is set to `America/New_York` (`TZ=America/New_York`), when `generate()` is called, then the `<div class="generated-at">` content ends with either `EST` or `EDT` (depending on date), and does NOT contain the literal string `UTC` in the sub-heading. (Acceptance under containerized prod requires `TZ` to be set in `docker-compose.yml` / deployment — see Notes.)
+- [ ] **AC 7 (local-timezone helper, monkey-patchable):** Given the helper `_compute_generated_at()` is patched to return `('2026-05-11 14:32:15 EDT', 2026)`, when `generate()` is called, then the HTML contains the exact substring `Generated: 2026-05-11 14:32:15 EDT` in the `<div class="generated-at">`. The helper's source uses `datetime.now().astimezone()` with no explicit `UTC` argument, and detects the no-tzname case via `dt.tzname()` (not via string inspection of the formatted output).
 
-- [ ] **AC 8 (timezone fallback for unnamed offsets):** Given a `datetime.astimezone()` result whose `tzname()` returns `None` or empty string (e.g., a fixed-offset zone), when `generate()` is called, then the sub-heading contains an ISO offset like `+0000` or `-0400` instead of an empty trailing space.
+- [ ] **AC 8 (timezone fallback for unnamed offsets):** Given a `datetime` whose `tzinfo.tzname(dt)` returns `None` or `''`, when `_compute_generated_at()` is called, then the returned timestamp string contains an ISO offset like `+0000` or `-0400` (no empty trailing space, no `None` token).
 
 - [ ] **AC 9 (site footer replaces "Generated:" line):** Given any rendering, when `generate()` is called, then the HTML contains a `<footer class="site-footer">` element whose text includes `© <YEAR> Jason Antman`, an anchor to `https://github.com/jantman/equipment-status-board`, and an anchor to `https://opensource.org/license/mit` (text `MIT licensed`), AND the HTML does NOT contain the old `<div class="footer">` element.
 
-- [ ] **AC 10 (year derives from `current_year` context):** Given the current year is 2026, when `generate()` is called, then the rendered footer contains `© 2026 Jason Antman`.
+- [ ] **AC 10 (footer year matches generation timestamp year):** Given the helper `_compute_generated_at()` is patched to return year `2027`, when `generate()` is called, then the rendered footer contains `© 2027 Jason Antman` (the local-tz year, not `current_year` UTC).
 
-- [ ] **AC 11 (still self-contained):** When `generate()` is called, then the HTML contains no `<link …>` and no `<script src="…">`, and the meta CSP tag `default-src 'none'; style-src 'unsafe-inline'` is unchanged.
+- [ ] **AC 11 (still self-contained — no external sub-resources):** When `generate()` is called, then the HTML contains no `<link …>`, no `<script src="…">`, and no `<img src="http…">` or other external sub-resource references. Anchor (`<a href="…">`) links to external sites are permitted. The meta CSP tag's full directive `default-src 'none'; style-src 'unsafe-inline'` is unchanged.
 
-- [ ] **AC 12 (existing assertions preserved):** Existing tests in `tests/test_services/test_static_page_service.py` continue to pass after Task 4.11's adjustment of `test_includes_generated_timestamp` (assert only `'Generated:' in html`, drop the `'UTC' in html` assertion).
+- [ ] **AC 12 (existing tests preserved):** Existing tests in `tests/test_services/test_static_page_service.py` continue to pass after Task 4 case 17's adjustment (drop the `'UTC' in html` assertion in `test_includes_generated_timestamp`; replace with `'Generated:' in html`).
+
+- [ ] **AC 13 (XSS defense — description is HTML-escaped):** Given a repair record with `description='<script>alert(1)</script><img src=x onerror=y>'`, when `generate()` is called, then the HTML contains `&lt;script&gt;` (escaped) and does NOT contain the literal `<script>alert(1)</script>` as a tag.
+
+- [ ] **AC 14 (description preserves newlines and wraps long text):** Given a repair record with a multi-line `description` containing `\n`, when `generate()` is called, then the rendered `.record-description` span carries inline CSS `white-space: pre-wrap; overflow-wrap: anywhere;` (verified by asserting the rule appears in the page's `<style>` block — no DOM rendering check required).
+
+- [ ] **AC 15 (footer-text drift detector):** Given the source file `esb/templates/components/_footer.html`, when `generate()` is called, then the three load-bearing substrings from `_footer.html` (`Jason Antman`, `https://github.com/jantman/equipment-status-board`, `https://opensource.org/license/mit`) all appear in the rendered static page HTML. If the live footer changes any of these, this AC fails and the static page must be updated.
+
+- [ ] **AC 16 (single-line equipment row preserved):** When `generate()` is called for an area with at least one equipment item, then the HTML contains a `<div class="equipment-row">` wrapper, and within that wrapper the substrings `status-dot`, `equipment-name`, and `status-label` appear in that order. The new `<ul class="open-records-list">` (when rendered) is outside this wrapper but inside the parent `<li class="equipment-item">`.
+
+- [ ] **AC 17 (`get_area_status_dashboard()` returns `open_records`):** Given an equipment item with two non-closed repair records and one record with `status='Resolved'`, when `get_area_status_dashboard()` is called, then `result[0]['equipment'][0]['open_records']` is a `list` of exactly 2 `RepairRecord` instances (the non-closed ones), in `(severity priority ASC, created_at ASC, id ASC)` order.
+
+- [ ] **AC 18 (deployment-default TZ wired):** Given `docker-compose.yml` defines the `worker` service, when the file is read, then its `environment:` block includes a `TZ=${TZ:-America/New_York}` entry. (Verified by reading the YAML in a test or by visual inspection during code review; not a Python unit test.)
+
+- [ ] **AC 19 (admin docs include TZ row):** Given `docs/administrators.md`, when grepped for `| \`TZ\` |`, then a row exists in the Environment Variable Reference table documenting the variable, its default, and an example value.
 
 ## Additional Context
 
 ### Dependencies
 
-None new — uses existing `datetime`, Flask, Jinja2. No DB migration. No new packages.
+None new — uses existing `datetime`, `zoneinfo` (stdlib), Flask, Jinja2. No DB migration. No new Python packages.
 
 ### Testing Strategy
 
 **Unit tests (pytest, SQLite in-memory per `TestingConfig`):**
 
-All new tests live in `tests/test_services/test_static_page_service.py` inside `class TestGenerate`. Use the existing fixtures: `app`, `make_area`, `make_equipment`, `make_repair_record`. Assertions are substring / index-position checks against the rendered HTML string returned by `static_page_service.generate()`.
+All new tests live in `tests/test_services/test_static_page_service.py` (HTML-level) and `tests/test_services/test_status_service.py` (service-level). Use the existing fixtures: `app`, `make_area`, `make_equipment`, `make_repair_record`. The `make_repair_record(equipment, status='New', description='X', **kwargs)` signature accepts `RepairRecord` column kwargs (`severity`, `eta`, `created_at`, etc.); it does NOT accept `area` or `name`.
 
-New test cases (one per AC group):
+Strategy for tz-sensitive tests: **never** assert on the unpatched host clock. Either patch `_compute_generated_at()` to return a known string, or patch `datetime.now().astimezone()` to return a fixed `datetime` with a known `tzinfo`. This keeps tests deterministic on UTC CI runners.
 
 | Test | Covers AC |
 | ---- | --------- |
 | `test_open_records_listed_for_non_green_equipment` | AC 1 |
 | `test_open_records_omitted_for_green_equipment` | AC 2 |
-| `test_open_records_ordered_by_created_at_asc` | AC 3 |
+| `test_open_records_sorted_by_severity_priority_then_created_at` | AC 3 |
 | `test_open_records_uses_yellow_class_for_degraded_and_not_sure` | AC 4 |
-| `test_open_records_uses_gray_class_for_no_severity` | AC 4 (None severity branch) |
+| `test_open_records_uses_gray_class_for_no_severity` | AC 4 (None branch) |
 | `test_open_records_omits_eta_when_unset` | AC 5 |
 | `test_generated_at_subheading_renders_above_areas` | AC 6 |
-| `test_generated_at_uses_local_timezone_not_hardcoded_utc` | AC 7 (monkey-patch system tz via `datetime` patch or `os.environ['TZ']` + `time.tzset()`) |
-| `test_generated_at_falls_back_to_iso_offset_when_tzname_empty` | AC 8 |
+| `test_generated_at_uses_local_timezone_helper` | AC 7 |
+| `test_compute_generated_at_uses_tzname_when_present` | AC 7 (helper) |
+| `test_compute_generated_at_falls_back_to_offset_when_tzname_empty` | AC 8 |
 | `test_site_footer_replaces_old_generated_line` | AC 9 |
-| `test_footer_renders_current_year` | AC 10 |
-| (existing) `test_produces_self_contained_html` | AC 11 (no change required; should still pass) |
-| (existing, modified) `test_includes_generated_timestamp` | AC 12 (drop `'UTC' in html` assertion; keep `'Generated:' in html`) |
+| `test_footer_renders_local_tz_year` | AC 10 |
+| (modified) `test_produces_self_contained_html` and `test_csp_meta_tag_directive_unchanged` | AC 11 |
+| (modified) `test_includes_generated_timestamp` | AC 12 |
+| `test_description_is_html_escaped` | AC 13 |
+| (assert CSS rule in `<style>`) `test_description_has_prewrap_styles` | AC 14 |
+| `test_footer_pins_to_live_footer_text` | AC 15 |
+| `test_equipment_row_keeps_dot_name_label_on_one_line` | AC 16 |
+| `test_status_service.test_includes_open_records_list_per_equipment` | AC 17 |
+| `test_status_service.test_open_records_sorted_by_severity_then_created_at` | AC 17 (sort) |
+
+AC 18 and AC 19 are configuration/documentation criteria verified by code review (or trivially by `grep` in a CI step).
 
 **Manual / smoke testing:**
 
 1. Apply the changes locally.
-2. Start the dev server (`make db-up && make migrate && make run`).
-3. Create at least one Area, two Equipment items, and one open `RepairRecord` per equipment (one `Down`, one `Degraded`) via the staff UI.
-4. Run `flask shell` and call `from esb.services import static_page_service; print(static_page_service.generate())` (or hit the static export path on disk via `STATIC_PAGE_PUSH_METHOD=local`).
-5. Open the resulting `index.html` in a browser. Verify:
-   - Top right under the title: `Generated: 2026-05-11 14:32 EDT` (or local zone).
-   - Under each non-green equipment item: a bullet-less list with one row per open record, colored by severity, showing status + description + ETA.
-   - Bottom: centered copyright footer with the GitHub and MIT license links.
-   - View source: no `<link>`, no `<script src=...>`, CSP meta tag unchanged.
+2. `make db-up && make migrate && make run` and create at least one Area, two Equipment items, and one open `RepairRecord` per equipment (one `Down`, one `Degraded`, one `Not Sure` or `None`) via the staff UI. Include one long-text description and one multi-line description to verify wrap behavior.
+3. Set `TZ=America/New_York` in shell before running `flask shell`, then `from esb.services import static_page_service; print(static_page_service.generate())` (or hit the export path on disk via `STATIC_PAGE_PUSH_METHOD=local`).
+4. Open the resulting `index.html` in a browser. Verify:
+   - Top right under the title: `Generated: 2026-05-11 14:32:15 EDT` (or local zone).
+   - Equipment header (dot + name + label + ETA) on a single line under each area.
+   - Under each non-green equipment item: a list with one row per open record, colored by severity, showing status + `[severity]` badge + description (multi-line / long text wrapping correctly) + ETA (when set). Records sorted with `Down` records on top.
+   - Bottom: centered copyright footer with the GitHub and MIT license links; year matches the generation sub-heading year.
+   - View source: no `<link>`, no `<script src=...>`, no external `<img>`; CSP meta tag value is `default-src 'none'; style-src 'unsafe-inline'` verbatim.
+5. Repeat with `TZ=UTC` to verify the UTC fallback rendering matches expectations.
 
 ### Notes
 
-**Production timezone configuration.** The local-timezone behavior depends on the container's `TZ` env var. The current `docker-compose.yml` does not set `TZ` on the `app` or `worker` services, so a default deployment will render `UTC`. To get a true local time, the operator must set `TZ` in the `worker` service environment (it's the `worker` that calls `generate_and_push()` via the notification handler — `app` itself doesn't invoke `generate()` on a request path). This is a deployment-config concern; document it in a follow-up but do NOT modify `docker-compose.yml` as part of this spec.
+**Production timezone configuration.** The default `docker-compose.yml` now sets `TZ=America/New_York` on the `worker` service to match the makerspace's location. Operators in other zones override via the `TZ` env var in `.env` (e.g., `TZ=America/Chicago`). Documented in `docs/administrators.md` Environment Variable Reference. `app` service does not need TZ (does not render the static page).
 
-**Risk: timezone test flakiness.** Tests that assert the timezone abbreviation depend on the runner's `TZ`. The strategy in Task 4 is to monkey-patch the `datetime` object returned in the service (so test outcome is independent of the host TZ). Avoid asserting raw `EDT`/`EST` against the unpatched system clock — CI is typically UTC.
+**Risk: timezone test flakiness.** Mitigated. All tz-sensitive tests patch either `_compute_generated_at()` or `datetime.now().astimezone()`. No test depends on the runner's `TZ` env var. Avoid asserting raw `EDT`/`EST` against an unpatched clock.
 
-**Risk: live dashboard regression.** Task 1 adds an `open_records` key to the dict returned by `get_area_status_dashboard()`. Existing live templates (`status_dashboard.html`, `kiosk.html`, `kiosk_area.html`) iterate the dict's `equipment` list but reference only `item.equipment` and `item.status`. Verified manually during Step 2; no template change needed for the live site. Run the full test suite (`make test`) after Task 1 to confirm no regressions.
+**Risk: live dashboard / Slack regression.** Task 1 adds an `open_records` key to the dict returned by `get_area_status_dashboard()`. Audited consumers: `public/status_dashboard.html`, `public/kiosk.html`, `public/equipment_page.html` (different route, not affected), `esb/slack/forms.py::format_status_summary`, `esb/slack/forms.py::format_area_status_detail`, `esb/slack/handlers.py:288`. None iterate or reference `open_records`. Task 8 runs the full suite — including `tests/test_slack/` — to confirm.
 
-**Risk: `_derive_status_from_records` "Not Sure" mapping.** A repair record with `severity='Not Sure'` produces `color='yellow'` at the equipment level (per `_SEVERITY_STATUS`). The per-record visual treatment in the new repair list also uses yellow for `Not Sure` (Task 3.2 mapping), so the equipment dot and the record's left-border match. A record with `severity=None` is unusual (severity is nullable but the create paths set it); guard with the `gray` fallback so we never crash on a missing key.
+**Risk: severity-priority sort change.** Spec changes the sort from "created_at ASC oldest-first" to "severity priority then created_at ASC." This is the right call for the static fallback view but is a visible behavior change vs. the previously-shipped behavior of the highest-severity-only display. The change affects only the static page's repair list (a new feature), not the equipment-level status dot which was already severity-derived. No callers depend on the old "created_at order" because the `open_records` list itself is new.
+
+**Risk: footer drift detector test could become flaky.** AC 15 / Task 4 case 13 reads `_footer.html` from disk and asserts substrings. If someone edits `_footer.html` to change the owner name, the test fails. That is **intentional** — the failure prompts the implementer to also update the static-page footer. Not a flake; it's a coupling alarm.
+
+**Risk: `severity=None` repair records.** Repair creation paths set severity by default, but the column is nullable. Spec handles `None` explicitly in (a) sort key (priority `999` → sorted last), (b) template class mapping (`open-record-gray`), (c) severity-badge rendering (`{% if rec.severity %}…{% endif %}` guards the `[…]` text). Tests cover this branch.
+
+**Explicit non-decisions:**
+- **No cap on records displayed per equipment.** Static page is the fallback view; full information takes priority over visual tidiness in the rare worst case. (F20 decision.)
+- **Severity text badge `[Down]` retained** as accessibility/redundancy for color-coding. (F19 decision.)
 
 **Future / out of scope (do not implement now):**
 - Per-area kiosk static export (would require extending `get_single_area_status_dashboard()` similarly).
-- Sorting open records by severity instead of `created_at` ASC.
 - Showing `specialist_description` or `assignee` on the static page (privacy / clutter concerns).
-- Localizing the timestamp into a non-system timezone via a config var.
+- Localizing the timestamp into a non-system timezone via an app-level config var (currently driven by OS `TZ`).
 
 GitHub issue #44 text:
 > 1. The static status page currently just shows a list of equipment by area and operational/degraded/down state. For degraded or down equipment this should also include a list of the open repair records, their status, ETA if set, and description.
 > 2. There is currently a small unobtrusive "Generated:" line at the bottom of the static page. Let's replace that with the copyright footer used on the live site, and add a sub-heading near the top right under "Equipment Status" that gives the generated date and time in the local/system timezone.
+
+### Adversarial Review Resolution
+
+Findings F1–F20 from the 2026-05-11 adversarial review applied:
+
+| ID | Resolution |
+| --- | --- |
+| F1 (AC 7 unenforceable) | Rewrote AC 7 to assert via monkey-patched `_compute_generated_at()`, not host env. |
+| F2 (function-scoped `datetime` defeats patch) | Hoisted import to module top; added `_compute_generated_at()` helper at module scope (Task 2). |
+| F3 (worker TZ broken by default) | Added `TZ=${TZ:-America/New_York}` to `docker-compose.yml` worker (Task 6); documented in `docs/administrators.md` (Task 7). |
+| F4 (hallucinated `kiosk_area.html`) | Removed; corrected consumer list to actual files audited. |
+| F5 (Slack consumers missed) | Audited and listed: `esb/slack/forms.py`, `esb/slack/handlers.py`. None affected by additive key. |
+| F6 (trailing-space fallback brittle) | Detect fallback via `dt.tzname()` directly; build timestamp by concatenation, not `%Z` format. |
+| F7 (description wrap policy) | Decision: CSS `white-space: pre-wrap; overflow-wrap: anywhere;` on `.record-description`. AC 14 added. |
+| F8 (CSS layout non-atomic) | Spec now contains the full template diff in Task 3. AC 16 added. |
+| F9 (footer drift) | Added test that pins static-page footer to `_footer.html` substrings (Task 4 case 13, AC 15). |
+| F10 (no service-level test) | Added `tests/test_services/test_status_service.py` cases (Task 5, AC 17). |
+| F11 (XSS escape not asserted) | Added `test_description_is_html_escaped` (Task 4 case 14, AC 13). |
+| F12 (fixture kwargs doc) | Corrected: `make_repair_record(equipment, status, description, **kwargs)`; `area`/`name` not accepted. |
+| F13 (sort policy) | Decision: severity priority then `created_at` ASC. (Task 1, AC 3.) |
+| F14 (ordering test fragile) | Task 4 case 10 specifies explicit `datetime(…, tzinfo=UTC)` values. |
+| F15 (CSP test weak) | Strengthened to assert verbatim directive contents (Task 4 case 15). |
+| F16 (no seconds) | Decision: include seconds → `%Y-%m-%d %H:%M:%S`. |
+| F17 ("self-contained" wording) | Clarified: "no external sub-resources" vs. anchor links to external sites permitted (AC 11). |
+| F18 (year mismatch) | Decision: pass local-tz `generated_year` to template; footer uses it (Task 2/3, AC 10). |
+| F19 (severity badge beyond ask) | Decision: keep badge for accessibility; called out as enhancement in Overview. |
+| F20 (record cap) | Decision: no cap; documented in Notes/Explicit non-decisions. |

--- a/_bmad-output/implementation-artifacts/tech-spec-static-status-page-export-improvements.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-static-status-page-export-improvements.md
@@ -4,7 +4,7 @@ slug: 'static-status-page-export-improvements'
 created: '2026-05-11'
 status: 'ready-for-dev'
 stepsCompleted: [1, 2, 3, 4]
-tech_stack: ['Python 3.14', 'Flask', 'Jinja2', 'pytest', 'Docker (python:3.14-slim)']
+tech_stack: ['Python 3.14', 'Flask', 'Jinja2', 'pytest', 'Docker (python:3.14-slim, Debian 13 trixie)']
 files_to_modify:
   - 'esb/services/static_page_service.py'
   - 'esb/services/status_service.py'
@@ -25,13 +25,14 @@ test_patterns:
 revision_history:
   - '2026-05-11 — initial spec'
   - '2026-05-11 — applied 20 adversarial-review findings (R1F1–R1F20)'
-  - '2026-05-11 — applied real findings from round-2 adversarial review (R2F1–R2F19)'
+  - '2026-05-11 — applied real findings from round-2 adversarial review (R2F1–R2F21: 16 applied, 5 deferred as noise)'
+  - '2026-05-11 — applied real findings from round-3 adversarial review (R3F1–R3F17: all 17 applied; R3F1 invalidated the R2F1 "load-bearing tzdata" framing, recharacterized as defensive pin)'
 ---
 
 # Tech-Spec: Static status page export improvements
 
 **Created:** 2026-05-11
-**Revised:** 2026-05-11 (post-R1 adversarial review, post-R2 adversarial review)
+**Revised:** 2026-05-11 (post-R1 adversarial review, post-R2 adversarial review, post-R3 adversarial review)
 
 GitHub Issue: [#44](https://github.com/jantman/equipment-status-board/issues/44)
 
@@ -46,7 +47,7 @@ The static status page (`esb/services/static_page_service.py` → `esb/templates
 
 ### Solution
 
-Update `static_page_service.generate()` to pass through (a) the open repair records per non-green equipment item (sorted by severity priority, then `created_at` ASC) and (b) a generation timestamp in the system's local timezone (with seconds). Update `esb/templates/public/static_page.html` to (i) render a list of open repair records — with each record's status, severity, ETA, and description — nested under each non-green equipment item; (ii) add a generation-time sub-heading immediately under the `<h1>Equipment Status</h1>` title, right-aligned, in local timezone; (iii) replace the bottom "Generated:" line with the site's copyright/license footer text (inlined verbatim including the `aria-label` attributes and `<small>` wrapper — the static page must remain CSP-locked and have no external **sub-resources**, though anchor links to external sites are permitted). Configure the `worker` container's `TZ` env via `docker-compose.yml` AND install the `tzdata` package in the `Dockerfile` so the configured zone actually resolves; document the env var in `docs/administrators.md`.
+Update `static_page_service.generate()` to pass through (a) the open repair records per non-green equipment item (sorted by severity priority, then `created_at` ASC) and (b) a generation timestamp in the system's local timezone (with seconds). Update `esb/templates/public/static_page.html` to (i) render a list of open repair records — with each record's status, severity, ETA, and description — nested under each non-green equipment item; (ii) add a generation-time sub-heading immediately under the `<h1>Equipment Status</h1>` title, right-aligned, in local timezone; (iii) replace the bottom "Generated:" line with the site's copyright/license footer text (inlined verbatim including the `aria-label` attributes and `<small>` wrapper — the static page must remain CSP-locked and have no external **sub-resources**, though anchor links to external sites are permitted). Configure the `worker` container's `TZ` env via `docker-compose.yml` and explicitly pin `tzdata` as a defensive dependency in the `Dockerfile`; document the env var in `docs/administrators.md`.
 
 **Note on scope additions beyond issue #44's literal text:** The issue lists status, ETA, and description as required per-record fields. This spec additionally includes (a) a textual severity badge `[Down]` / `[Degraded]` / `[Not Sure]` per record — for accessibility, since color alone (the left-border indicator) is a WCAG concern; (b) sort-by-severity-priority — so the most urgent records bubble to the top at a glance, since this is the fallback view when the live site is down. These are explicitly called out as enhancements.
 
@@ -54,13 +55,13 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 
 **In Scope:**
 - `esb/services/status_service.py` — extend `get_area_status_dashboard()` to include per-equipment `open_records` list, sorted by severity priority then `created_at` ASC. Unknown severities (and `None`) sort at "Not Sure" priority, matching the equipment-level fallback behavior.
-- `esb/services/static_page_service.py` — compute local-tz generation timestamp (with seconds), pass local-tz year to the template.
-- `esb/templates/public/static_page.html` — repair-record list under non-green items, top sub-heading with generated time, replace bottom footer with inlined copyright text + a11y attributes.
+- `esb/services/static_page_service.py` — compute local-tz generation timestamp (with seconds, with explicit tzname validation), pass local-tz year to the template.
+- `esb/templates/public/static_page.html` — repair-record list under non-green items, top sub-heading with generated time, replace bottom footer with inlined copyright text + a11y attributes. Severity badge displayed only for canonical severities (Down / Degraded / Not Sure).
 - Inline the copyright footer markup/text into the static template, including the live footer's `aria-label` attributes and `<small>` wrapper (the static page must have no external sub-resources — same self-contained / `default-src 'none'` CSP rule).
 - `docker-compose.yml` — set `TZ=${TZ:-America/New_York}` as the default `worker`-service environment variable.
-- `Dockerfile` — add `tzdata` to the `apt-get install` line so the configured `TZ` env var actually resolves against `/usr/share/zoneinfo/`.
+- `Dockerfile` — add `tzdata` to the `apt-get install` line as a **defensive dependency pin**. The current `python:3.14-slim` base image (Debian 13 trixie) already ships `tzdata` by default — verified via `docker run --rm python:3.14-slim dpkg -l tzdata`. The explicit install protects against a future minimal-image variant that might drop the package; it does NOT fix a current failure mode.
 - `docs/administrators.md` — document the `TZ` environment variable in the Environment Variable Reference table.
-- `tests/test_services/test_static_page_service.py` — cover the new repair list, footer, generation-time placement, XSS escape, CSP directive integrity, pre-wrap CSS, footer a11y attributes.
+- `tests/test_services/test_static_page_service.py` — cover the new repair list, footer, generation-time placement, XSS escape, CSP directive integrity, pre-wrap CSS, footer a11y attributes, entity-content escaping, archived-area exclusion, empty-dashboard rendering, cross-area name collision.
 - `tests/test_services/test_status_service.py` — regression test for the new `open_records` key in `get_area_status_dashboard()`.
 
 **Out of Scope:**
@@ -71,7 +72,6 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 - Reuse of `_footer.html` via `{% include %}` — static export must remain self-contained.
 - Pagination / cap on the number of open records displayed per equipment (explicit decision — see Notes).
 - `get_single_area_status_dashboard()` extension (per-area kiosk static export).
-- Empty-`tzname()` fallback in `_compute_generated_at()` — CPython 3.11+ always emits a non-empty tzname; the fallback branch added in v2 was unreachable in production and is dropped (see Decision #3).
 
 ## Context for Development
 
@@ -94,9 +94,10 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
   - `description: str` (Text, non-null). Can be multi-line and effectively unbounded.
   - `eta: date | None`.
   - `created_at: datetime` (UTC).
-- **Severity → color map** (`status_service._SEVERITY_STATUS`): `Down`→red (priority 0), `Degraded`→yellow (priority 1), `Not Sure`→yellow (priority 2). For records whose severity is `None` or any *unknown* string, both the equipment-level status derivation (`status_service.py` `_derive_status_from_records`, "fall through to yellow/Degraded" branch) and the new sort key fall back to the **`Not Sure` priority (2)**. This keeps equipment-level rendering and record-list ordering consistent — a yellow-coded equipment cannot contain a record that sorts beneath a Not-Sure record (Round-2 finding R2F8). Per-record visual styling (`open-record-gray` left border) is independent of the sort priority.
-- **Local-timezone formatting.** No existing helper. Place the implementation in a module-level helper `_compute_generated_at()` in `static_page_service.py` (NOT inline in `generate()`) so tests can monkey-patch it directly. Format: `'%Y-%m-%d %H:%M:%S %Z'` → `2026-05-11 14:32:15 EDT`. Build the string by concatenation of `dt.strftime('%Y-%m-%d %H:%M:%S ')` and `dt.tzname()` (rather than using `%Z`) so the trailing token is explicit and never an empty trailing space. No fallback branch — under CPython 3.11+ with `tzdata` available in the runtime, `datetime.now().astimezone()` always returns a `datetime` whose `tzinfo` produces a non-empty `tzname()`. The Dockerfile change (Task 8) ensures `tzdata` is present.
+- **Severity → color map** (`status_service._SEVERITY_STATUS`): `Down`→red (priority 0), `Degraded`→yellow (priority 1), `Not Sure`→yellow (priority 2). For records whose severity is `None` or any *unknown* string, both the equipment-level status derivation (`status_service.py` `_derive_status_from_records`, "fall through to yellow/Degraded" branch) and the new sort key fall back to the **`Not Sure` priority (2)**. This keeps equipment-level rendering and record-list ordering consistent (Round-2 finding R2F8). **For the per-record visual:** the left border maps `Down`→red, `Degraded`/`Not Sure`→yellow, everything else (`None` and unknown strings) → gray; the severity text badge `[…]` displays **only for canonical severities** (`Down`/`Degraded`/`Not Sure`) — for unknown strings the badge is suppressed entirely (Round-3 finding R3F3), so the data-quality signal is "gray border, no badge" rather than the previous tri-state of yellow-priority + gray-border + raw-text-badge.
+- **Local-timezone formatting.** No existing helper. Place the implementation in a module-level helper `_compute_generated_at()` in `static_page_service.py` (NOT inline in `generate()`) so tests can monkey-patch it directly. Format: `'%Y-%m-%d %H:%M:%S '` + `dt.tzname()` → `2026-05-11 14:32:15 EDT`. The helper **explicitly validates** that `dt.tzname()` returns a truthy non-empty string and raises `RuntimeError` otherwise — preserves a real loud-failure guarantee, vs. the silent-trailing-space degradation that a bare concatenation would allow (Round-3 finding R3F5). Under CPython 3.11+ with the system's `tzdata` package available, `datetime.now().astimezone()` reliably yields a non-empty tzname; the validation is defense in depth.
 - **Reference data shape only** (not visual precedent): `esb/templates/public/equipment_page.html`'s `open_repairs` list shows the conceptual shape (one row per open record, severity-styled, description visible, ETA when set). The actual styling cannot be copied — `equipment_page.html` uses Bootstrap classes (`card`, `card-body`, `mb-2`, etc.) which are unavailable in the static export. The static page reimplements the layout in inline CSS.
+- **Base image timezone behavior** (verified 2026-05-11 via `docker run --rm python:3.14-slim`): `python:3.14-slim` ships on Debian 13 trixie and pre-installs `tzdata` (`tzdata 2026a-0+deb13u1`). `/usr/share/zoneinfo/America/New_York` exists by default, and `TZ=America/New_York python -c '…tzname()'` correctly emits `EDT` out of the box. The Dockerfile change in Task 8 is a **defensive dependency pin** — making `tzdata` explicit in the install list so a future swap to a hypothetical thinner base image (or a Debian package retraction) cannot silently regress the feature. It is **not** fixing a current bug.
 - **Test fixtures** (`tests/conftest.py`):
   - `make_area(name='Test Area', slack_channel='#test-area')` → `Area`.
   - `make_equipment(name='Test Equipment', manufacturer='TestCo', model='Model X', area=None, **kwargs)` → `Equipment` (extra kwargs forwarded to model constructor). If `area=None`, the fixture auto-creates a fresh area.
@@ -114,9 +115,9 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 | `esb/utils/filters.py` | `format_date` Jinja filter. |
 | `esb/slack/forms.py`, `esb/slack/handlers.py` | Existing consumers of `get_area_status_dashboard()`; verified not affected by the additive `open_records` key. |
 | `docker-compose.yml` | Add `TZ=${TZ:-America/New_York}` to the `worker` service. |
-| `Dockerfile` | Add `tzdata` to the `apt-get install` line so the configured `TZ` resolves against `/usr/share/zoneinfo/`. **Without `tzdata`, `python:3.14-slim` falls back to UTC silently regardless of the `TZ` env var.** |
+| `Dockerfile` | Add `tzdata` to the `apt-get install` line as a **defensive dependency pin**. The current base image already includes it; the explicit install protects against future image-content drift. |
 | `docs/administrators.md` | Document the `TZ` env var in the Environment Variable Reference section. |
-| `tests/test_services/test_static_page_service.py` | Existing test class `TestGenerate`; add cases for repair list, top-right timestamp, inline footer, footer-text pin, XSS escape, CSP directive integrity, pre-wrap CSS, footer a11y attributes. |
+| `tests/test_services/test_static_page_service.py` | Existing test class `TestGenerate`; add cases for repair list, top-right timestamp, inline footer, footer-text pin, XSS escape, CSP directive integrity, pre-wrap CSS, footer a11y attributes, entity-content escape, archived exclusion, empty-dashboard, cross-area name collision, regex format check. |
 | `tests/test_services/test_status_service.py` | Add regression test for `open_records` key. |
 | `tests/conftest.py` | Fixture definitions (`make_area`, `make_equipment`, `make_repair_record`). |
 
@@ -124,15 +125,15 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 
 1. **Extend `get_area_status_dashboard()` to include an `open_records` list per equipment.** Records are already prefetched and grouped in `records_by_equipment`; threading the list through is a one-line change. Rejected the "new helper" option to avoid duplicating ~40 lines of prefetch code. Existing callers (live dashboard, kiosk, Slack formatters) ignore the new key.
 2. **Sort open records by `(severity priority, created_at)` ASC.** Rationale: the static page is the fallback at-a-glance view. Sorting by severity ensures `Down` records bubble above `Degraded`/`Not Sure`/unknown within each equipment's record list. Sort key: `(priority, rec.created_at)` where `priority = _SEVERITY_STATUS.get(rec.severity, (..., ..., _SEVERITY_STATUS['Not Sure'][2]))[2]`. **No `id` in the sort key** — Python's `list.sort()` is stable and the prefetch query order (`created_at ASC, id ASC`) is preserved on ties. **Unknown severity strings and `None` both fall back to the `Not Sure` priority (2)** — same as the equipment-level status derivation — to avoid an inversion where the equipment dot says yellow but the unknown-severity record sorts beneath Not-Sure records (R2F8).
-3. **Local-timezone generation timestamp.** Implemented in module-level helper `_compute_generated_at()` in `static_page_service.py` (so tests can patch it). Uses `datetime.now().astimezone()` (no `tzinfo` argument) — Python picks up the host system's TZ from `TZ` env / `/etc/localtime`. Format: `'%Y-%m-%d %H:%M:%S '` + `dt.tzname()` → `2026-05-11 14:32:15 EDT`. Seconds are included for debugging value when multiple pushes happen within a minute. **No empty-tzname fallback branch** — under CPython 3.11+ with `tzdata` present (Dockerfile Task 8), `astimezone()` always returns a tzinfo whose `tzname()` is non-empty. If a future runtime change ever produces `None`/empty, the code will fail loudly with a `TypeError` on string concatenation — which is the correct loud-failure mode for an invariant violation, vs. a silent fallback that masks a deployment problem.
-4. **Footer text is inlined verbatim** from `_footer.html` (copyright line + GitHub link + MIT license link, INCLUDING `<small>` wrapper and all `aria-label` attributes) into `static_page.html`, NOT included via `{% include %}`. Reasons: (a) the static page must remain self-contained (no external sub-resources); (b) an include couples the export to a fragment used by the live site, which is brittle if that fragment later pulls in Bootstrap classes; (c) copyright text is short and stable. **Drift mitigation:** Task 4 case 13 adds a unit test that loads `_footer.html` through Flask's Jinja loader and asserts its **three load-bearing substrings** (`Jason Antman`, the GitHub URL, the MIT URL) appear in the rendered static page. The test is explicitly named `test_footer_text_pin` (not "drift detector") — it pins owner + URLs only, NOT year-token markup or `<small>`/aria attribute wrapping. Those are covered by their own ACs (AC 9 / AC 9a).
-5. **Per-record styling**. Repair-record `<li>` items use a small inline left-border indicator color-coded by severity using the same mapping as the equipment-level dot (`Down`→red, `Degraded`/`Not Sure`→yellow, no severity → gray). Display order within the record: `[status badge] [severity badge if set] description …ETA: …`. Severity text badge is **retained** (e.g., `[Down]`) as an accessibility/redundancy feature — color alone is a WCAG concern, and the text badge gives the same information non-visually. This is called out as a spec-added enhancement beyond issue #44's literal ask.
+3. **Local-timezone generation timestamp.** Implemented in module-level helper `_compute_generated_at()` in `static_page_service.py` (so tests can patch it). Uses `datetime.now().astimezone()` (no `tzinfo` argument) — Python picks up the host system's TZ from `TZ` env / `/etc/localtime`. Format: `'%Y-%m-%d %H:%M:%S '` + `dt.tzname()` → `2026-05-11 14:32:15 EDT`. Seconds are included for debugging value when multiple pushes happen within a minute. **Explicit tzname validation** (R3F5): the helper checks `tzname = dt.tzname(); if not tzname: raise RuntimeError(...)` — this is a real loud-failure guarantee that catches both `None` (TypeError on concatenation) AND empty-string (silent trailing space) cases. Build the string by concatenation (not `%Z`) so the trailing token is explicit.
+4. **Footer text is inlined verbatim** from `_footer.html` (copyright line + GitHub link + MIT license link, INCLUDING `<small>` wrapper and all `aria-label` attributes) into `static_page.html`, NOT included via `{% include %}`. Reasons: (a) the static page must remain self-contained (no external sub-resources); (b) an include couples the export to a fragment used by the live site, which is brittle if that fragment later pulls in Bootstrap classes; (c) copyright text is short and stable. **Drift mitigation:** Task 4 case 12 adds a unit test that loads `_footer.html` through Flask's Jinja loader and asserts its **three load-bearing substrings** (`Jason Antman`, the GitHub URL, the MIT URL) appear in the rendered static page. The test is explicitly named `test_footer_text_pin` — it pins owner + URLs only, NOT year-token markup or `<small>`/aria attribute wrapping. Those are covered by their own ACs (AC 8 / AC 9).
+5. **Per-record styling**. Repair-record `<li>` items use a small inline left-border indicator color-coded by severity using the same mapping as the equipment-level dot (`Down`→red, `Degraded`/`Not Sure`→yellow, everything else including `None` and unknown strings → gray). Display order within the record: `[status badge] [severity badge if canonical severity] description …ETA: …`. Severity text badge is **retained for canonical severities** (`Down`/`Degraded`/`Not Sure`) as an accessibility/redundancy feature — color alone is a WCAG concern, and the text badge gives the same information non-visually. **For non-canonical severities (R3F3)** — unknown strings AND `None` — the badge is suppressed entirely; the gray border serves as the "unrecognized data" signal. This resolves the prior tri-state inconsistency where an unknown severity produced yellow-priority sort + gray border + raw-text badge.
 6. **Description wrap, not truncate.** `RepairRecord.description` is unbounded Text. Apply inline CSS `white-space: pre-wrap; overflow-wrap: anywhere;` to `.record-description` so multi-line descriptions render correctly and long un-broken strings (URLs, etc.) wrap rather than overflow the page. **No truncation** — the static page is a fallback view and full text is more useful than an ellipsis.
 7. **Local-tz year for the footer.** Compute the footer year from the same `datetime` used by `_compute_generated_at()` (Python's `datetime.astimezone()` returns a `datetime` whose `.year` is the converted local-tz year, not the source UTC year — verified empirically). Pass it to the template as a separate kwarg `generated_year`. The footer renders `&copy; {{ generated_year }} Jason Antman`. The `current_year` context processor (UTC) is left alone so the live site is unaffected. This avoids the ~5-hour disagreement window around midnight Dec 31.
 8. **Generation sub-heading placement.** Below the `<h1>Equipment Status</h1>` block, right-aligned via `text-align: right` on a `.generated-at` div (new CSS rule).
 9. **Equipment-row layout wrapper.** Existing `.equipment-item` uses `display: flex` to lay out dot/name/label/eta on one line. Adding a nested `<ul>` for open records inside the same `<li>` would make the `<ul>` a flex sibling. Spec wraps the existing four spans into a new `<div class="equipment-row">` (with `display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem;`) and changes `.equipment-item` to `display: block`. The new `<ul class="open-records-list">` lays out beneath the row with `margin-top: 0.4rem` for visual separation. The full template diff is spelled out in Task 3.
-10. **TZ default in `docker-compose.yml` AND `tzdata` in Dockerfile.** Set `TZ=${TZ:-America/New_York}` in the `worker` service `environment:` block. Add `tzdata` to the `apt-get install` line in `Dockerfile` — this is the **load-bearing change** for the local-tz feature to work at all in production. Without `tzdata`, the `python:3.14-slim` base image has no `/usr/share/zoneinfo/America/New_York`, so glibc's `tzset()` falls back to UTC and the env var is effectively ignored. The `app` service does not need either change because it does not render the static page; the worker is the sole producer via `generate_and_push()`.
-11. **Module-level datetime import in `static_page_service.py`.** Hoist `from datetime import datetime` to module top (it is currently function-scoped). This is required for the `_compute_generated_at()` helper to exist at module scope, and it lets tests patch `static_page_service._compute_generated_at` directly.
+10. **TZ default in `docker-compose.yml`** and **defensive `tzdata` pin in `Dockerfile`.** Set `TZ=${TZ:-America/New_York}` in the `worker` service `environment:` block — load-bearing change that actually controls the timestamp's timezone. Add `tzdata` to the `apt-get install` line in `Dockerfile` as a **defensive dependency pin** — the current `python:3.14-slim` base image already includes `tzdata`, so the install is currently redundant; making it explicit protects against a future minimal-image variant that might drop the package. The `app` service does not need `TZ` because it does not render the static page; the worker is the sole producer via `generate_and_push()`.
+11. **Module-level datetime import in `static_page_service.py`.** Hoist `from datetime import datetime` to module top (it is currently function-scoped). This is required for the `_compute_generated_at()` helper to exist at module scope, and it lets tests patch `static_page_service.datetime` (or `_compute_generated_at` itself) directly.
 
 ## Implementation Plan
 
@@ -153,7 +154,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
        for records in records_by_equipment.values():
            records.sort(key=_open_records_sort_key)
        ```
-       Define `_NOT_SURE_PRIORITY` and `_open_records_sort_key` at module level (right after the `_SEVERITY_STATUS` dict definition near line 17-21). Do **not** introduce a separate `999` sentinel — unknown severities and `None` both map to `Not Sure` priority for sort purposes, matching the equipment-level fallback (R2F7, R2F8).
+       Define `_NOT_SURE_PRIORITY` and `_open_records_sort_key` at module level (right after the `_SEVERITY_STATUS` dict definition). Do **not** introduce a separate `999` sentinel — unknown severities and `None` both map to `Not Sure` priority for sort purposes, matching the equipment-level fallback (R2F7, R2F8).
     2. In the loop that builds `equip_statuses`, add `'open_records': equip_records` to the dict appended for each equipment.
     3. Update the function's docstring to document the new `open_records` key — list of `RepairRecord` instances, sorted by `(severity priority, created_at)` with unknown severities folded to `Not Sure` priority; ties on those fields preserve the prefetch query's `(created_at, id)` ASC order (stable sort).
   - Notes: Existing live-page templates (`public/status_dashboard.html`, `public/kiosk.html`) and Slack formatters (`esb/slack/forms.py`) iterate `area_data.equipment` but reference only `item.equipment` and `item.status`. The additive key is safe. `get_single_area_status_dashboard()` is **not** changed.
@@ -173,14 +174,21 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
                same instant (datetime.astimezone() returns a datetime whose
                .year reflects the converted zone, not the source UTC year).
 
-           Requires the runtime to have a non-empty tzname for the local
-           zone — production deployments must include the tzdata package
-           in the base image (see Dockerfile).
+           Raises:
+               RuntimeError: if the local timezone has no resolvable tzname
+                   (indicates the runtime is missing tzdata, e.g. a stripped
+                   Docker image). The Dockerfile pins tzdata; this guard is
+                   defense-in-depth against future image-content drift.
            """
            dt = datetime.now().astimezone()
-           return (dt.strftime('%Y-%m-%d %H:%M:%S ') + dt.tzname(), dt.year)
+           tzname = dt.tzname()
+           if not tzname:
+               raise RuntimeError(
+                   "Local timezone has no resolvable tzname; tzdata may be missing."
+               )
+           return (dt.strftime('%Y-%m-%d %H:%M:%S ') + tzname, dt.year)
        ```
-       Build the string by concatenation (not `%Z`) so the trailing token is explicit. **No fallback branch** — if `dt.tzname()` is `None`, this fails loudly with a `TypeError`, which is the correct response to a deployment that violates the tzdata invariant.
+       Explicit `if not tzname:` check covers both `None` and empty-string cases (R3F5). Build the string by concatenation (not `%Z`) so the trailing token is explicit.
     3. Update `generate()`:
        ```python
        def generate() -> str:
@@ -259,7 +267,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
                     <ul class="open-records-list">
                         {% for rec in item.open_records %}
                         <li class="open-record open-record-{{ 'red' if rec.severity == 'Down' else 'yellow' if rec.severity in ('Degraded', 'Not Sure') else 'gray' }}">
-                            <span class="record-status">{{ rec.status }}</span>{% if rec.severity %} <span class="record-severity">[{{ rec.severity }}]</span>{% endif %} <span class="record-description">{{ rec.description }}</span>{% if rec.eta %} <span class="record-eta">ETA: {{ rec.eta|format_date }}</span>{% endif %}
+                            <span class="record-status">{{ rec.status }}</span>{% if rec.severity in ('Down', 'Degraded', 'Not Sure') %} <span class="record-severity">[{{ rec.severity }}]</span>{% endif %} <span class="record-description">{{ rec.description }}</span>{% if rec.eta %} <span class="record-eta">ETA: {{ rec.eta|format_date }}</span>{% endif %}
                         </li>
                         {% endfor %}
                     </ul>
@@ -279,7 +287,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
     </html>
     ```
 
-  - Key changes vs. previous template: `.equipment-item` becomes `display: block`; the existing dot/name/label/eta row is wrapped in `<div class="equipment-row">`; new `<ul class="open-records-list">` rendered only when equipment is non-green AND has open records; old `<div class="footer">Generated: …</div>` replaced by `<footer class="site-footer" role="contentinfo" aria-label="Site copyright and license">` with a `<small>` wrapper and `aria-label` on the GitHub and MIT anchors (mirrors `_footer.html`); new `.generated-at` sub-heading directly under the `<h1>`. The footer uses `generated_year` (local-tz, from `_compute_generated_at()`), NOT `current_year`. The CSP directive is unchanged.
+  - Key changes vs. previous template: `.equipment-item` becomes `display: block`; the existing dot/name/label/eta row is wrapped in `<div class="equipment-row">`; new `<ul class="open-records-list">` rendered only when equipment is non-green AND has open records; **severity badge guard changed from `{% if rec.severity %}` to `{% if rec.severity in ('Down', 'Degraded', 'Not Sure') %}`** so unknown/None severities suppress the badge entirely (R3F3); old `<div class="footer">Generated: …</div>` replaced by `<footer class="site-footer" role="contentinfo" aria-label="Site copyright and license">` with a `<small>` wrapper and `aria-label` on the GitHub and MIT anchors (mirrors `_footer.html`); new `.generated-at` sub-heading directly under the `<h1>`. The footer uses `generated_year` (local-tz, from `_compute_generated_at()`), NOT `current_year`. The CSP directive is unchanged.
 
 - [ ] **Task 4: Add tests in `tests/test_services/test_static_page_service.py`.**
   - File: `tests/test_services/test_static_page_service.py`
@@ -289,38 +297,71 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 
     2. `test_generated_at_uses_local_timezone_helper` (covers AC 7a) — Monkey-patch `esb.services.static_page_service._compute_generated_at` to return `('2026-05-11 14:32:15 EDT', 2026)`. Call `generate()`. Assert HTML contains `Generated: 2026-05-11 14:32:15 EDT` and footer contains `2026`.
 
-    3. `test_compute_generated_at_formats_tzname` (covers AC 7b, helper-level) — Use `unittest.mock.patch.object(static_page_service, 'datetime')` to make `datetime.now().astimezone()` return a real `datetime` with `tzinfo=ZoneInfo('America/New_York')` set to `2026-07-15 14:32:15` US Eastern. Call `_compute_generated_at()` directly. Assert returned tuple is `('2026-07-15 14:32:15 EDT', 2026)`.
+    3. `test_compute_generated_at_formats_tzname` (covers AC 7b, helper-level) — Use the following exact mock setup to avoid the chained-Mock ambiguity flagged in R3F4:
+       ```python
+       fixed_dt = datetime(2026, 7, 15, 14, 32, 15, tzinfo=ZoneInfo('America/New_York'))
+       with patch.object(static_page_service, 'datetime') as mock_datetime:
+           mock_datetime.now.return_value.astimezone.return_value = fixed_dt
+           result = static_page_service._compute_generated_at()
+       assert result == ('2026-07-15 14:32:15 EDT', 2026)
+       ```
+       Note: this creates a `ZoneInfo('America/New_York')` instance, which depends on tzdata being available either via the OS or the PyPI `tzdata` package. The Docker base image provides it; local pytest runs do too on standard Linux/macOS dev machines. If CI ever runs on a stripped image without tzdata, add the PyPI `tzdata` package to test/dev requirements (R3F6).
 
-    4. `test_open_records_listed_for_non_green_equipment` (covers AC 1) — Create equipment with one record `make_repair_record(equipment=eq, status='In Progress', severity='Down', description='Belt slipping', eta=date(2026, 6, 1))`. Call `generate()`. Assert HTML contains `'In Progress'`, `'[Down]'`, `'Belt slipping'`, and `'ETA: ' + date(2026, 6, 1).strftime('%b %d, %Y')`, AND contains the substring `class="open-record open-record-red"`.
+    4. `test_compute_generated_at_raises_on_empty_tzname` (covers AC 7c, R3F5 explicit-validation) — Build a minimal custom `tzinfo` subclass whose `tzname(dt)` returns `''` (empty). Patch `datetime` to make `datetime.now().astimezone()` return a `datetime` with that tzinfo. Assert `_compute_generated_at()` raises `RuntimeError` matching `"tzname"`.
 
-    5. `test_open_records_omitted_for_green_equipment` (covers AC 2) — Create equipment with no repair records. Assert HTML does NOT contain `'open-records-list'`.
+    5. `test_compute_generated_at_format_matches_regex` (covers AC 6, R3F17 end-to-end regex) — Call the **unpatched** helper (no mocks). Assert the returned timestamp string matches `re.fullmatch(r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \S+', result[0])` — verifies the format end-to-end against the real codepath, including a non-empty timezone token, on the real host clock.
 
-    6. `test_open_records_uses_yellow_class_for_degraded_and_not_sure` (covers AC 4) — Create two equipment items in the same area, one with `severity='Degraded'`, one with `severity='Not Sure'`. Assert HTML contains at least two occurrences of `'open-record-yellow'`.
+    6. `test_open_records_listed_for_non_green_equipment` (covers AC 1) — Create equipment with one record `make_repair_record(equipment=eq, status='In Progress', severity='Down', description='Belt slipping', eta=date(2026, 6, 1))`. Call `generate()`. Assert HTML contains `'In Progress'`, `'[Down]'`, `'Belt slipping'`, and `'ETA: ' + date(2026, 6, 1).strftime('%b %d, %Y')`, AND contains the substring `class="open-record open-record-red"`.
 
-    7. `test_open_records_uses_gray_class_for_no_severity` (covers AC 4 None branch) — Create a repair record passing `severity=None`. Assert HTML contains `'open-record-gray'` AND does NOT contain `'<span class="record-severity">'` for that record.
+    7. `test_open_records_omitted_for_green_equipment` (covers AC 2) — Create equipment with no repair records. Assert HTML does NOT contain `'open-records-list'`.
 
-    8. `test_open_records_omits_eta_when_unset` (covers AC 5) — In a fresh test fixture, create exactly one equipment with one record `make_repair_record(equipment=eq, severity='Down', eta=None)`. Assert HTML does NOT contain `'record-eta'`. (Scoped to a single equipment so the global assertion is safe — no substring splitting required.)
+    8. `test_open_records_uses_yellow_class_for_degraded_and_not_sure` (covers AC 4) — Create two equipment items in the same area, one with `severity='Degraded'`, one with `severity='Not Sure'`. Assert HTML contains at least two occurrences of `'open-record-yellow'` AND contains both `'[Degraded]'` and `'[Not Sure]'` text badges.
 
-    9. `test_open_records_sorted_by_severity_priority_then_created_at` (covers AC 3) — Create one equipment with three records: `(severity='Down', created_at=datetime(2026, 5, 1, tzinfo=UTC), description='down-newer')`, `(severity='Not Sure', created_at=datetime(2026, 4, 1, tzinfo=UTC), description='notsure-older')`, `(severity='Degraded', created_at=datetime(2026, 4, 15, tzinfo=UTC), description='degraded-mid')`. Insert in mixed order. Call `generate()`. Assert `html.find('down-newer') < html.find('degraded-mid') < html.find('notsure-older')`.
+    9. `test_open_records_uses_gray_class_for_no_severity` (covers AC 4 None branch) — Create one equipment with one record passing `severity=None`. Assert HTML contains `'open-record-gray'` AND does NOT contain `'<span class="record-severity">'` (badge suppressed per R3F3).
 
-    10. `test_site_footer_replaces_old_generated_line` (covers AC 9) — Call `generate()`. Assert HTML contains `'<footer class="site-footer"'`, `'role="contentinfo"'`, `'aria-label="Site copyright and license"'`, `'<small>'`, `'Jason Antman'`, `'aria-label="Source code on GitHub"'`, `'aria-label="MIT License (opensource.org)"'`, `'github.com/jantman/equipment-status-board'`, `'MIT licensed'`, AND does NOT contain `'<div class="footer">'` (the old class).
+    10. `test_open_records_uses_gray_class_and_suppresses_badge_for_unknown_severity` (covers AC 4 unknown branch, R3F3) — Create one equipment with one record passing `severity='Critical'` (or any unknown string). Assert HTML contains `'open-record-gray'` AND does NOT contain `'<span class="record-severity">'` AND does NOT contain `'[Critical]'`. The unknown severity sorts at Not-Sure priority (covered by Task 5) but renders with the gray-no-badge "unrecognized data" treatment.
 
-    11. `test_footer_renders_local_tz_year_as_entity` (covers AC 10) — Monkey-patch `_compute_generated_at` to return `(..., 2027)`. Assert HTML footer contains the literal substring `&copy; 2027 Jason Antman` (HTML-entity form — Jinja does NOT decode `&copy;`).
+    11. `test_open_records_omits_eta_when_unset` (covers AC 5) — In a fresh test fixture, create exactly one equipment with one record `make_repair_record(equipment=eq, severity='Down', eta=None)`. Assert HTML does NOT contain `'record-eta'`. (Scoped to a single equipment so the global assertion is safe — no substring splitting required.)
 
-    12. `test_footer_text_pin` (covers AC 12 — footer-text pin against `_footer.html`) — Load `_footer.html` source via Flask's Jinja loader: `source = app.jinja_env.loader.get_source(app.jinja_env, 'components/_footer.html')[0]`. From that source, extract three load-bearing substrings: `'Jason Antman'`, `'https://github.com/jantman/equipment-status-board'`, and `'https://opensource.org/license/mit'`. Assert each appears in the rendered static page HTML. Scope: this test ONLY pins owner + URLs — it does NOT detect changes to year-token markup, `<small>` wrapping, or aria-label text (those have dedicated assertions in case 10). If a future edit to `_footer.html` changes the owner name or a link URL, this test fails loudly and the static page must be updated in lockstep.
+    12. `test_open_records_sorted_by_severity_priority_then_created_at` (covers AC 3) — Create one equipment with three records: `(severity='Down', created_at=datetime(2026, 5, 1, tzinfo=UTC), description='down-newer')`, `(severity='Not Sure', created_at=datetime(2026, 4, 1, tzinfo=UTC), description='notsure-older')`, `(severity='Degraded', created_at=datetime(2026, 4, 15, tzinfo=UTC), description='degraded-mid')`. Insert in mixed order. Call `generate()`. Assert `html.find('down-newer') < html.find('degraded-mid') < html.find('notsure-older')`.
 
-    13. `test_description_is_html_escaped` (covers AC 11 / XSS defense) — Create a repair record with `description='<script>alert(1)</script><img src=x onerror=y>'`. Call `generate()`. Assert HTML contains `'&lt;script&gt;'` (escaped) AND does NOT contain the literal `'<script>alert(1)</script>'`.
+    13. `test_site_footer_replaces_old_generated_line` (covers AC 8) — Call `generate()`. Assert HTML contains `'<footer class="site-footer"'`, `'role="contentinfo"'`, `'aria-label="Site copyright and license"'`, `'<small>'`, `'Jason Antman'`, `'aria-label="Source code on GitHub"'`, `'aria-label="MIT License (opensource.org)"'`, `'github.com/jantman/equipment-status-board'`, `'MIT licensed'`, AND does NOT contain `'<div class="footer">'` (the old class).
 
-    14. `test_csp_meta_tag_directive_unchanged` (strengthens existing `test_includes_csp_meta_tag`) — Replace the existing test (or add a sibling) that asserts only `'Content-Security-Policy' in html` with: `assert "default-src 'none'; style-src 'unsafe-inline'" in html` (verbatim directive contents).
+    14. `test_footer_renders_local_tz_year_as_entity` (covers AC 9) — Monkey-patch `_compute_generated_at` to return `(..., 2027)`. Assert HTML footer contains the literal substring `&copy; 2027 Jason Antman` (HTML-entity form — Jinja does NOT decode `&copy;`).
 
-    15. `test_equipment_row_keeps_dot_name_label_on_one_line` (covers AC 14 layout) — Assert HTML contains `<div class="equipment-row">` and within that wrapper (slice to its closing tag), the order of substrings is `status-dot`, `equipment-name`, `status-label`.
+    15. `test_footer_text_pin` (covers AC 12 — footer-text pin against `_footer.html`) — Load `_footer.html` source via Flask's Jinja loader:
+        ```python
+        try:
+            source = app.jinja_env.loader.get_source(app.jinja_env, 'components/_footer.html')[0]
+        except TemplateNotFound as e:
+            raise AssertionError(
+                "_footer.html not found — has it been moved or renamed? "
+                "Update this pin test's path."
+            ) from e
+        ```
+        From that source, extract three load-bearing substrings: `'Jason Antman'`, `'https://github.com/jantman/equipment-status-board'`, and `'https://opensource.org/license/mit'`. Assert each appears in the rendered static page HTML. Scope: this test pins owner + URLs only (R3F13 wrapper added for clearer error message).
 
-    16. `test_description_uses_prewrap_styles` (covers AC 13 wrap CSS) — Assert HTML contains the substring `.record-description { white-space: pre-wrap; overflow-wrap: anywhere; }` inside the `<style>` block.
+    16. `test_description_is_html_escaped` (covers AC 11 / XSS defense) — Create a repair record with `description='<script>alert(1)</script><img src=x onerror=y>'`. Call `generate()`. Assert HTML contains `'&lt;script&gt;'` (escaped) AND does NOT contain the literal `'<script>alert(1)</script>'`.
 
-    17. **Update existing `test_includes_generated_timestamp`** — Replace `assert 'UTC' in html` with `assert 'Generated:' in html`. The timezone token now depends on host TZ / patched helper.
+    17. `test_description_escapes_entity_content` (covers AC 11b, R3F11) — Create a repair record with `description='Bob & Alice broke it; price was 50%<'`. Assert HTML contains the substrings `'Bob &amp; Alice broke it'` and `'50%&lt;'` (autoescaped), AND does NOT contain a bare `'Bob & Alice'` substring (which would indicate autoescape failure).
+
+    18. `test_csp_meta_tag_directive_unchanged` (strengthens existing `test_includes_csp_meta_tag`) — Replace the existing test (or add a sibling) that asserts only `'Content-Security-Policy' in html` with: `assert "default-src 'none'; style-src 'unsafe-inline'" in html` (verbatim directive contents).
+
+    19. `test_equipment_row_keeps_dot_name_label_on_one_line` (covers AC 14 layout) — Assert HTML contains `<div class="equipment-row">` and within that wrapper (slice to its closing tag), the order of substrings is `status-dot`, `equipment-name`, `status-label`.
+
+    20. `test_description_uses_prewrap_styles` (covers AC 13 wrap CSS) — Assert HTML contains the substring `.record-description { white-space: pre-wrap; overflow-wrap: anywhere; }` inside the `<style>` block.
+
+    21. `test_archived_areas_and_equipment_are_excluded` (covers AC 17, R3F9) — Create one archived area (`is_archived=True`) named `'Archived Area'` with one piece of equipment, AND one active area named `'Active Area'` with one piece of equipment. Call `generate()`. Assert HTML contains `'Active Area'` and does NOT contain `'Archived Area'`. Then create one active area containing one active equipment named `'Visible Tool'` and one archived equipment (`is_archived=True`) named `'Retired Tool'`. Call `generate()`. Assert HTML contains `'Visible Tool'` and does NOT contain `'Retired Tool'`.
+
+    22. `test_empty_dashboard_renders_skeleton` (covers AC 18, R3F10) — With zero non-archived areas in the DB, call `generate()`. Assert HTML contains `<h1>Equipment Status</h1>`, `<div class="generated-at">`, and `<footer class="site-footer"`, but does NOT contain `<div class="area">`.
+
+    23. `test_two_equipment_with_same_name_in_different_areas` (covers AC 19, R3F12) — Create two areas (`'Area A'`, `'Area B'`) each with an equipment item named `'Drill Press'`, each with one `Down` open record (descriptions `'a-issue'` and `'b-issue'` respectively). Call `generate()`. Assert HTML contains both `'Area A'` and `'Area B'` AND that `html.find('Area A') < html.find('a-issue') < html.find('Area B') < html.find('b-issue')` (records appear under their correct area in document order).
+
+    24. **Update existing `test_includes_generated_timestamp`** — Replace `assert 'UTC' in html` with `assert 'Generated:' in html`. The timezone token now depends on host TZ / patched helper.
 
   - Notes:
     - Use `from datetime import UTC, datetime` (Python 3.11+) for `created_at` kwarg values.
+    - Use `from zoneinfo import ZoneInfo` for the tzname-formats test.
     - The fixture `make_repair_record(equipment=None, status='New', description='Test issue', **kwargs)` — pass `equipment=…` explicitly to avoid auto-create side effects; pass `severity`, `eta`, `created_at` via kwargs.
 
 - [ ] **Task 5: Add a regression test for the new `open_records` key in `tests/test_services/test_status_service.py`.**
@@ -329,7 +370,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 
     1. `test_includes_open_records_list_per_equipment` — Create one area with one equipment item and two non-closed repair records and one closed record (`status='Resolved'`). Call `get_area_status_dashboard()`. Assert `result[0]['equipment'][0]['open_records']` is a `list` of length 2; the closed record is excluded; each entry is a `RepairRecord` instance.
 
-    2. `test_open_records_sorted_by_severity_then_created_at` — Create one equipment with `Down/2026-05-01`, `Not Sure/2026-04-01`, `Degraded/2026-04-15`, `None/2026-03-01`, `'Critical'` (unknown severity) `/2026-02-01`. Call the dashboard. Assert the `open_records` list order is: `Down`, `Degraded`, then within priority-2 (`Not Sure`/`None`/`'Critical'`) sorted by `created_at` ASC — so `'Critical'` (oldest), then `None`, then `Not Sure`.
+    2. `test_open_records_sorted_by_severity_then_created_at` — Create one equipment with five records: `(Down, 2026-05-01)`, `(Not Sure, 2026-04-01)`, `(Degraded, 2026-04-15)`, `(None, 2026-03-01)`, `('Critical', 2026-02-01)` (unknown severity, oldest). Call the dashboard. Assert the `open_records` list order is: `Down`, `Degraded`, then within priority-2 sorted by `created_at` ASC — `'Critical'` (oldest), then `None`, then `Not Sure`.
 
     3. `test_empty_open_records_list_for_green_equipment` — Create equipment with zero non-closed records. Assert `equipment[0]['open_records'] == []`.
 
@@ -338,17 +379,17 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 - [ ] **Task 6: Configure default TZ in `docker-compose.yml` worker service.**
   - File: `docker-compose.yml`
   - Action: In the `worker:` service's `environment:` block, add a new line: `      - TZ=${TZ:-America/New_York}`. Place it adjacent to the existing `PYTHONUNBUFFERED=1` and `WORKER_HEARTBEAT_PATH=…` entries.
-  - Notes: The `${TZ:-America/New_York}` syntax means "use the `TZ` env var if set in `.env` or shell, otherwise default to `America/New_York`." This matches the makerspace location (Decatur Makers) while letting other deployments override. The `app` service does **not** need TZ — only the worker calls `generate()`.
+  - Notes: The `${TZ:-America/New_York}` syntax means "use the `TZ` env var if set in `.env` or shell, otherwise default to `America/New_York`." This matches the makerspace location (Decatur Makers) while letting other deployments override. The `app` service does **not** need TZ — only the worker calls `generate()`. This is the load-bearing change for the local-tz feature.
 
 - [ ] **Task 7: Document the `TZ` environment variable in `docs/administrators.md`.**
   - File: `docs/administrators.md`
   - Action: In the Environment Variable Reference table, add a new row:
     ```markdown
-    | `TZ` | IANA timezone name for the worker container. Controls the timezone displayed in the static status page's generation timestamp (sub-heading near top of page) and the year used in the footer. Set this to your local timezone for accurate display. The `app` service does not use this variable. Requires the `tzdata` package in the Docker image (included by default — see Dockerfile). | No | `America/New_York` | `America/Chicago` |
+    | `TZ` | IANA timezone name for the worker container. Controls the timezone displayed in the static status page's generation timestamp (sub-heading near top of page) and the year used in the footer. Set this to your local timezone for accurate display. The `app` service does not use this variable. | No | `America/New_York` | `America/Chicago` |
     ```
-  - Also add a short paragraph in the "Static Status Page Setup" section noting that the static page's generation timestamp reflects the `worker` container's `TZ` and that operators should set `TZ` in `.env` to match their local timezone. Add a sentence: "Note: the Docker image installs the `tzdata` package; without it, the `TZ` env var has no effect and timestamps render in UTC."
+  - Also add a short paragraph in the "Static Status Page Setup" section: "The static page's generation timestamp reflects the `worker` container's `TZ` environment variable. The variable resolves against the OS tzdata database (`/usr/share/zoneinfo`), which is provided by the `tzdata` system package. Both the `python:3.14-slim` base image and this image's Dockerfile install list include `tzdata`; do not remove it. To use a non-default zone, set `TZ` in `.env` before running `docker compose up`."
 
-- [ ] **Task 8: Add `tzdata` to the Dockerfile so `TZ` actually resolves.**
+- [ ] **Task 8: Add `tzdata` to the Dockerfile as a defensive dependency pin.**
   - File: `Dockerfile`
   - Action: In the existing `apt-get install` line, add `tzdata` alongside `gcc` and `libzbar0`:
     ```dockerfile
@@ -358,11 +399,11 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
         tzdata \
         && rm -rf /var/lib/apt/lists/*
     ```
-  - Notes: Without `tzdata`, the `python:3.14-slim` base image has no `/usr/share/zoneinfo/` database, so glibc's `tzset()` cannot resolve `TZ=America/New_York` and falls back to UTC. This task is the load-bearing change for the whole local-tz feature; setting the env var in compose without this Dockerfile change is a no-op (Round-2 finding R2F1). `apt-get` non-interactive install of `tzdata` does not require additional `DEBIAN_FRONTEND=noninteractive` because Debian's bookworm-based slim images configure non-interactive apt by default in `Dockerfile` contexts; if the build prompts for tz selection, prepend `ENV DEBIAN_FRONTEND=noninteractive` before the `RUN` line.
+  - Notes: **This is a defensive dependency pin, NOT a fix for a current bug.** The `python:3.14-slim` base image (Debian 13 trixie) already ships `tzdata` by default — verified via `docker run --rm python:3.14-slim dpkg -l tzdata` showing `tzdata 2026a-0+deb13u1`. With the base image as-is, `TZ=America/New_York` already resolves correctly. The explicit install guarantees `tzdata` remains in the image if a future base-image variant ever drops the package (or if a Debian repository retraction makes it disappear). `apt-get install -y --no-install-recommends` is fully non-interactive on Debian trixie without needing `DEBIAN_FRONTEND=noninteractive`.
 
 - [ ] **Task 9: Run lint and full test suite.**
   - Commands: `make lint` then `make test`.
-  - Expected: All green. Existing test `test_includes_generated_timestamp` was updated in Task 4 case 17; `test_produces_self_contained_html` continues to pass; existing `test_includes_csp_meta_tag` is replaced/strengthened per Task 4 case 14. The full suite covers Slack formatter tests (`tests/test_slack/`) which exercise consumers of `get_area_status_dashboard()` — confirms no regression.
+  - Expected: All green. Existing test `test_includes_generated_timestamp` was updated in Task 4 case 24; `test_produces_self_contained_html` continues to pass; existing `test_includes_csp_meta_tag` is replaced/strengthened per Task 4 case 18. The full suite covers Slack formatter tests (`tests/test_slack/`) which exercise consumers of `get_area_status_dashboard()` — confirms no regression.
 
 ### Acceptance Criteria
 
@@ -372,15 +413,17 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 
 - [ ] **AC 3 (severity-priority sort, unknown folds to Not Sure):** Given one equipment item with five open repair records — `(severity='Down', created_at=2026-05-01)`, `(severity='Degraded', created_at=2026-04-15)`, `(severity='Not Sure', created_at=2026-04-01)`, `(severity=None, created_at=2026-03-01)`, `(severity='Critical', created_at=2026-02-01)` — when `generate()` is called, then in the HTML the records appear in the order: Down, Degraded, `'Critical'` (priority-2 tie, oldest `created_at`), None (priority-2 tie), Not Sure (priority-2 tie). Unknown severities and `None` both sort at the `Not Sure` priority; ties are broken by `created_at` ASC.
 
-- [ ] **AC 4 (severity color mapping):** Given open repair records with severities `'Down'`, `'Degraded'`, `'Not Sure'`, and `None`, when `generate()` is called, then their `<li class="open-record …">` elements receive classes `open-record-red`, `open-record-yellow`, `open-record-yellow`, and `open-record-gray` respectively, and the `None`-severity record does **not** render a `<span class="record-severity">[…]</span>` badge.
+- [ ] **AC 4 (severity color mapping and badge visibility):** Given open repair records with severities `'Down'`, `'Degraded'`, `'Not Sure'`, `None`, and `'Critical'` (an unknown string), when `generate()` is called, then their `<li class="open-record …">` elements receive classes `open-record-red`, `open-record-yellow`, `open-record-yellow`, `open-record-gray`, and `open-record-gray` respectively. **Severity text badges (`<span class="record-severity">[…]</span>`) appear only for canonical severities** (`Down`, `Degraded`, `Not Sure`); the `None` and `'Critical'` records render WITHOUT a badge — gray border alone signals "unrecognized data."
 
 - [ ] **AC 5 (ETA optional):** Given an open repair record with `eta=None`, when `generate()` is called for an area containing only that record's equipment, then the rendered HTML contains no `record-eta` substring.
 
-- [ ] **AC 6 (top sub-heading present and positioned):** Given any non-empty status dashboard, when `generate()` is called, then the HTML contains exactly one element matching `<div class="generated-at">` whose `find()` position is greater than the position of `</h1>` and less than the position of the first `<div class="area">`. Its inner text starts with `Generated: ` followed by a `YYYY-MM-DD HH:MM:SS ` (including seconds) and a non-empty timezone token.
+- [ ] **AC 6 (top sub-heading format, verified end-to-end):** Given any non-empty status dashboard, when `generate()` is called using the **unpatched** `_compute_generated_at()` helper, then the HTML contains exactly one `<div class="generated-at">` whose `find()` position is greater than the position of `</h1>` and less than the position of the first `<div class="area">`. Its inner text matches the regex `Generated: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \S+` (including seconds and a non-empty timezone token).
 
 - [ ] **AC 7a (helper-wiring):** Given `_compute_generated_at()` is patched to return `('2026-05-11 14:32:15 EDT', 2026)`, when `generate()` is called, then the rendered HTML contains the exact substring `Generated: 2026-05-11 14:32:15 EDT` inside the `<div class="generated-at">`, and the footer year is `2026`.
 
-- [ ] **AC 7b (helper formats tzname correctly):** Given a `datetime` whose `tzinfo` is `ZoneInfo('America/New_York')` set to `2026-07-15 14:32:15` local time, when `_compute_generated_at()` is called (with `datetime.now().astimezone()` patched to return that instance), then the helper returns exactly `('2026-07-15 14:32:15 EDT', 2026)`.
+- [ ] **AC 7b (helper formats tzname correctly):** Given `datetime.now().astimezone()` is mocked (via the exact `mock_datetime.now.return_value.astimezone.return_value = fixed_dt` chain) to return a `datetime` with `tzinfo=ZoneInfo('America/New_York')` set to `2026-07-15 14:32:15` local time, when `_compute_generated_at()` is called, then the helper returns exactly `('2026-07-15 14:32:15 EDT', 2026)`.
+
+- [ ] **AC 7c (helper fails loud on missing tzname):** Given `datetime.now().astimezone()` returns a `datetime` whose `tzinfo.tzname(dt)` returns `None` OR `''` (empty string), when `_compute_generated_at()` is called, then it raises `RuntimeError` with a message mentioning `tzname` or `tzdata`.
 
 - [ ] **AC 8 (site footer with a11y attributes):** Given any rendering, when `generate()` is called, then the HTML contains a `<footer class="site-footer" role="contentinfo" aria-label="Site copyright and license">` element wrapping a `<small>` that contains: the entity sequence `&copy; <YEAR> Jason Antman`, an anchor `<a href="https://github.com/jantman/equipment-status-board" …>` with `aria-label="Source code on GitHub"`, and an anchor `<a href="https://opensource.org/license/mit" …>` with `aria-label="MIT License (opensource.org)"` and link text `MIT licensed`. The HTML does NOT contain `<div class="footer">` (the old element).
 
@@ -390,6 +433,8 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 
 - [ ] **AC 11 (XSS defense — description is HTML-escaped):** Given a repair record with `description='<script>alert(1)</script><img src=x onerror=y>'`, when `generate()` is called, then the HTML contains `&lt;script&gt;` (escaped) and does NOT contain the literal `<script>alert(1)</script>` as a tag.
 
+- [ ] **AC 11b (entity-content in descriptions is HTML-escaped):** Given a repair record with `description='Bob & Alice broke it; price was 50%<'`, when `generate()` is called, then the rendered HTML contains the substrings `Bob &amp; Alice broke it` and `50%&lt;` (autoescaped), and does NOT contain a bare `Bob & Alice` substring.
+
 - [ ] **AC 12 (footer-text pin against `_footer.html`):** Given the source of `esb/templates/components/_footer.html` loaded via Flask's Jinja loader (`app.jinja_env.loader.get_source(app.jinja_env, 'components/_footer.html')[0]`), when `generate()` is called, then the three load-bearing substrings from `_footer.html` (`Jason Antman`, `https://github.com/jantman/equipment-status-board`, `https://opensource.org/license/mit`) all appear in the rendered static page HTML. Scope clarification: this AC pins owner + URLs only. Year-token markup, `<small>` wrapping, and aria-label texts are covered by AC 8 / AC 9 — not by this AC.
 
 - [ ] **AC 13 (description preserves newlines and wraps long text):** Given any rendering, when `generate()` is called, then the rendered HTML's `<style>` block contains the verbatim substring `.record-description { white-space: pre-wrap; overflow-wrap: anywhere; }`.
@@ -398,21 +443,29 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 
 - [ ] **AC 15 (`get_area_status_dashboard()` returns `open_records`):** Given an equipment item with two non-closed repair records and one record with `status='Resolved'`, when `get_area_status_dashboard()` is called, then `result[0]['equipment'][0]['open_records']` is a `list` of exactly 2 `RepairRecord` instances (the non-closed ones), in `(severity priority ASC, created_at ASC)` order, with unknown severities folded to the `Not Sure` priority.
 
-- [ ] **AC 16 (existing tests preserved):** Existing tests in `tests/test_services/test_static_page_service.py` continue to pass after Task 4 case 17's adjustment (drop the `'UTC' in html` assertion in `test_includes_generated_timestamp`; replace with `'Generated:' in html`).
+- [ ] **AC 16 (existing tests preserved):** Existing tests in `tests/test_services/test_static_page_service.py` continue to pass after Task 4 case 24's adjustment (drop the `'UTC' in html` assertion in `test_includes_generated_timestamp`; replace with `'Generated:' in html`).
+
+- [ ] **AC 17 (archived areas and equipment excluded):** Given one archived area named `Archived Area` and one active area named `Active Area`, when `generate()` is called, then the HTML contains `Active Area` and does NOT contain `Archived Area`. Likewise, given an active area containing one active equipment `Visible Tool` and one archived equipment `Retired Tool`, the HTML contains `Visible Tool` and does NOT contain `Retired Tool`.
+
+- [ ] **AC 18 (empty-dashboard renders skeleton):** Given no non-archived areas exist, when `generate()` is called, then the HTML contains `<h1>Equipment Status</h1>`, `<div class="generated-at">`, and `<footer class="site-footer"`, but contains no `<div class="area">` element.
+
+- [ ] **AC 19 (same equipment name in different areas):** Given two areas (`Area A`, `Area B`) each containing one equipment item named `Drill Press` with one `Down` open record (descriptions `'a-issue'` and `'b-issue'` respectively), when `generate()` is called, then the HTML contains both `Area A` and `Area B`, and in document order `Area A` appears before `a-issue` which appears before `Area B` which appears before `b-issue`.
 
 ### Documentation Checklist
 
 These items are verified by code review at PR time, not by automated tests:
 
-- [ ] **DC 1 (`docker-compose.yml` worker has TZ default):** The `worker` service's `environment:` block contains a `TZ=${TZ:-America/New_York}` entry.
-- [ ] **DC 2 (`Dockerfile` installs `tzdata`):** The `apt-get install` line includes `tzdata`.
-- [ ] **DC 3 (admin docs document `TZ`):** `docs/administrators.md` Environment Variable Reference table contains a row for `TZ` with description, default, and example. The Static Status Page Setup section mentions that the `worker` container's `TZ` controls the generation-timestamp display and that the Dockerfile installs `tzdata` to make the env var effective.
+- [ ] **DC 1 (`docker-compose.yml` worker has TZ default):** The `worker` service's `environment:` block contains a `TZ=${TZ:-America/New_York}` entry. **This is the load-bearing change** for the local-tz feature.
+- [ ] **DC 2 (`Dockerfile` defensively pins `tzdata`):** The `apt-get install` line includes `tzdata`. Note: this is a **defensive dependency pin**, not a fix for a current bug — the `python:3.14-slim` base image already ships `tzdata`. The explicit install protects against future image-content drift. Do not remove this line as a "size optimization."
+- [ ] **DC 3 (admin docs document `TZ`):** `docs/administrators.md` Environment Variable Reference table contains a row for `TZ` with description, default, and example. The Static Status Page Setup section explains the env var's effect, references the `tzdata` dependency, and warns against removing it.
 
 ## Additional Context
 
 ### Dependencies
 
-No new Python packages. Adds the OS-level `tzdata` package to the Docker image. No DB migration.
+No new Python packages. The `tzdata` system package is already provided by the `python:3.14-slim` base image; the Dockerfile change makes its presence explicit as a defensive pin. No DB migration.
+
+**Test-time tzdata note (R3F6):** Tests that instantiate `ZoneInfo('America/New_York')` (case 3 in Task 4) require tzdata to be available at runtime — provided by the OS on Linux/macOS dev machines and the Docker test image. If CI is ever moved to a stripped image without tzdata, add the PyPI `tzdata` package to `requirements-dev.txt`.
 
 ### Testing Strategy
 
@@ -420,29 +473,36 @@ No new Python packages. Adds the OS-level `tzdata` package to the Docker image. 
 
 All new tests live in `tests/test_services/test_static_page_service.py` (HTML-level) and `tests/test_services/test_status_service.py` (service-level). Use the existing fixtures: `app`, `make_area`, `make_equipment`, `make_repair_record`. The `make_repair_record(equipment=None, status='New', description='Test issue', **kwargs)` signature accepts `RepairRecord` column kwargs (`severity`, `eta`, `created_at`, etc.); it does NOT accept `area` or `name`. **Always pass `equipment=…` explicitly** to avoid the fixture's auto-create-area+equipment side effect.
 
-Strategy for tz-sensitive tests: **never** assert on the unpatched host clock. Either patch `_compute_generated_at()` to return a known string, or patch `datetime` inside `static_page_service` so `datetime.now().astimezone()` returns a fixed `datetime` with a known `tzinfo` (`ZoneInfo('America/New_York')` for the helper-level test). This keeps tests deterministic on UTC CI runners.
+Strategy for tz-sensitive tests: **never** assert on the unpatched host clock except where explicitly intended (AC 6 / case 5 is the end-to-end regex check against real output). Patching: `_compute_generated_at()` directly for `generate()`-level tests; for the helper-level format test (case 3), use the exact chained-Mock setup `mock_datetime.now.return_value.astimezone.return_value = fixed_dt` to avoid the chain-ambiguity flagged in R3F4.
 
 | Test | Covers AC |
 | ---- | --------- |
 | `test_open_records_listed_for_non_green_equipment` | AC 1 |
 | `test_open_records_omitted_for_green_equipment` | AC 2 |
 | `test_open_records_sorted_by_severity_priority_then_created_at` | AC 3 |
-| `test_open_records_uses_yellow_class_for_degraded_and_not_sure` | AC 4 |
+| `test_open_records_uses_yellow_class_for_degraded_and_not_sure` | AC 4 (canonical branches) |
 | `test_open_records_uses_gray_class_for_no_severity` | AC 4 (None branch) |
+| `test_open_records_uses_gray_class_and_suppresses_badge_for_unknown_severity` | AC 4 (unknown branch) |
 | `test_open_records_omits_eta_when_unset` | AC 5 |
-| `test_generated_at_subheading_renders_above_areas` | AC 6 |
+| `test_generated_at_subheading_renders_above_areas` | AC 6 (position) |
+| `test_compute_generated_at_format_matches_regex` | AC 6 (format) |
 | `test_generated_at_uses_local_timezone_helper` | AC 7a |
 | `test_compute_generated_at_formats_tzname` | AC 7b |
+| `test_compute_generated_at_raises_on_empty_tzname` | AC 7c |
 | `test_site_footer_replaces_old_generated_line` | AC 8 |
 | `test_footer_renders_local_tz_year_as_entity` | AC 9 |
 | (existing, modified) `test_produces_self_contained_html` + `test_csp_meta_tag_directive_unchanged` | AC 10 |
 | `test_description_is_html_escaped` | AC 11 |
+| `test_description_escapes_entity_content` | AC 11b |
 | `test_footer_text_pin` | AC 12 |
 | `test_description_uses_prewrap_styles` | AC 13 |
 | `test_equipment_row_keeps_dot_name_label_on_one_line` | AC 14 |
 | `test_status_service.test_includes_open_records_list_per_equipment` | AC 15 |
 | `test_status_service.test_open_records_sorted_by_severity_then_created_at` | AC 15 (sort) |
 | (existing, modified) `test_includes_generated_timestamp` | AC 16 |
+| `test_archived_areas_and_equipment_are_excluded` | AC 17 |
+| `test_empty_dashboard_renders_skeleton` | AC 18 |
+| `test_two_equipment_with_same_name_in_different_areas` | AC 19 |
 
 DC 1, DC 2, DC 3 are verified by code review at PR time.
 
@@ -450,33 +510,37 @@ DC 1, DC 2, DC 3 are verified by code review at PR time.
 
 1. Apply the changes locally.
 2. `make db-up && make migrate && make run` and create at least one Area, two Equipment items, and one open `RepairRecord` per equipment (one `Down`, one `Degraded`, one `Not Sure` or `None`) via the staff UI. Include one long-text description (200+ chars) and one multi-line description (with embedded newlines) to verify wrap behavior. Add a fourth equipment with 5+ open records on a long-named equipment to verify visual spacing under the equipment row.
-3. Set `TZ=America/New_York` in shell before running `flask shell`, then `from esb.services import static_page_service; print(static_page_service.generate())` (or hit the export path on disk via `STATIC_PAGE_PUSH_METHOD=local`).
+3. **Local dev TZ display check (limited scope — verifies dev env only, NOT production):** Set `TZ=America/New_York` in shell before running `flask shell`, then `from esb.services import static_page_service; print(static_page_service.generate())`. Confirm the output contains a non-UTC tzname like `EDT`/`EST`. **This step verifies the dev's local Python venv resolves `TZ` correctly — it does NOT verify the worker container's behavior.** Production behavior is verified by step 5 (R3F14).
 4. Open the resulting `index.html` in a browser. Verify:
    - Top right under the title: `Generated: 2026-05-11 14:32:15 EDT` (or local zone).
    - Equipment header (dot + name + label + ETA) on a single line under each area.
-   - Under each non-green equipment item: a list with one row per open record, colored by severity, showing status + `[severity]` badge + description (multi-line / long text wrapping correctly) + ETA (when set). Records sorted with `Down` records on top.
+   - Under each non-green equipment item: a list with one row per open record, colored by severity, showing status + `[severity]` badge (only for canonical severities) + description (multi-line / long text wrapping correctly) + ETA (when set). Records sorted with `Down` records on top.
    - Bottom: centered copyright footer with `<small>` wrapper, GitHub and MIT license anchors, aria-labels present (verifiable in DevTools); year matches the generation sub-heading year.
    - View source: no `<link>`, no `<script src=...>`, no external `<img>`; CSP meta tag value is `default-src 'none'; style-src 'unsafe-inline'` verbatim; `<footer>` has `role="contentinfo"` and `aria-label="Site copyright and license"`.
-5. **End-to-end Docker smoke (verifies R2F1 Dockerfile change):** Build the image with the Dockerfile change applied. Run `docker compose run --rm worker python -c "from datetime import datetime; print(datetime.now().astimezone().tzname())"`. Confirm output is `EDT`/`EST` (not `UTC`) when `TZ=America/New_York` is in `.env`. This catches the silent UTC fallback that occurs if `tzdata` is missing from the image.
+5. **End-to-end Docker production smoke check:** Build the image with the Dockerfile change applied. Run:
+   ```bash
+   TZ=America/New_York docker compose run --rm worker python -c "from datetime import datetime; print(datetime.now().astimezone().tzname())"
+   ```
+   Confirm output is `EDT`/`EST` (not `UTC`). This is the authoritative production verification — step 3 only covers the dev's local environment.
 
 ### Notes
 
-**Production timezone configuration.** The default `docker-compose.yml` sets `TZ=America/New_York` on the `worker` service AND the `Dockerfile` installs `tzdata`. Both changes are required — `TZ` without `tzdata` is a silent no-op. Operators in other zones override via the `TZ` env var in `.env`. Documented in `docs/administrators.md`. The `app` service does not need TZ.
+**Production timezone configuration.** The `docker-compose.yml` `worker` service has `TZ=${TZ:-America/New_York}` set as the default; the `Dockerfile` defensively pins `tzdata` in the apt install line (the current `python:3.14-slim` base image already includes it — verified). Operators in other zones override via the `TZ` env var in `.env`. Documented in `docs/administrators.md`. The `app` service does not need TZ. **The load-bearing change is the `TZ` env var in compose — the `tzdata` pin is defense in depth, not a current-bug fix (R3F1, R3F15, R3F16).**
 
-**Risk: timezone test flakiness.** Mitigated. All tz-sensitive tests patch either `_compute_generated_at()` or `datetime.now().astimezone()`. No test depends on the runner's `TZ` env var.
+**Risk: timezone test flakiness.** Mitigated. Most tz-sensitive tests patch either `_compute_generated_at()` or the `datetime` import in `static_page_service`. The end-to-end format-regex test (case 5) deliberately runs against unpatched code on the host's real clock — it verifies the format shape, not a specific zone, so it's CI-portable.
 
 **Risk: live dashboard / Slack regression.** Task 1 adds an `open_records` key to the dict returned by `get_area_status_dashboard()`. Audited consumers: `public/status_dashboard.html`, `public/kiosk.html`, `esb/slack/forms.py::format_status_summary`, `esb/slack/forms.py::format_area_status_detail`, `esb/slack/handlers.py` `/esb-status` path. None iterate or reference `open_records`. Task 9 runs the full suite to confirm.
 
-**Risk: severity-priority sort change.** Spec changes the sort from "created_at ASC oldest-first" (round-1 default) to "severity priority then `created_at` ASC" with unknown severities folded to `Not Sure` priority. This is the right call for the static fallback view AND it matches the equipment-level status-fallback behavior, eliminating the inversion bug where a yellow-coded equipment could contain a record sorting below Not Sure (R2F8).
+**Risk: severity-priority sort change.** Spec changes the sort from "created_at ASC oldest-first" (round-1 default) to "severity priority then `created_at` ASC" with unknown severities folded to `Not Sure` priority. This matches the equipment-level status-fallback behavior, eliminating the inversion bug where a yellow-coded equipment could contain a record sorting below Not Sure (R2F8).
 
-**Risk: footer-text pin is narrowly scoped.** AC 12 / Task 4 case 12 pins owner + URLs only — not year-token markup, `<small>`, or aria-labels. Those are covered by AC 8/9. If a future edit to `_footer.html` swaps `<small>` for `<span>`, AC 12 will NOT fire; the static page will visually diverge silently. Acceptable trade-off: the alternative (full markup pin) would require rendering `_footer.html` through Jinja with mocked context, which complicates the test and over-couples the static page to the live one. The aria-label / `<small>` invariants are pinned directly against the static page in AC 8 instead.
+**Risk: footer-text pin is narrowly scoped.** AC 12 / Task 4 case 15 pins owner + URLs only — not year-token markup, `<small>`, or aria-labels. Those are covered by AC 8/9. If a future edit to `_footer.html` swaps `<small>` for `<span>`, AC 12 will NOT fire; the static page will visually diverge silently. Acceptable trade-off: the alternative (full markup pin) would require rendering `_footer.html` through Jinja with mocked context, complicating the test and over-coupling the static page to the live one. The aria-label / `<small>` invariants are pinned directly against the static page in AC 8 instead.
 
-**Risk: `severity=None` and unknown severity strings.** Repair creation paths set severity by default, but the column is nullable AND unconstrained. Spec handles both cases identically in the sort (priority 2 = Not Sure), in the template class mapping (`open-record-gray` for None, would also be `gray` for any unknown string — see template `{% if rec.severity == 'Down' %}…{% elif rec.severity in ('Degraded', 'Not Sure') %}…{% else %}gray{% endif %}`), and in severity-badge rendering (the `{% if rec.severity %}` guard hides the `[…]` text for None but shows it for unknown strings). Tests cover the None branch in case 7 and the sort behavior in case 9 / Task 5 case 2.
+**Risk: `severity=None` and unknown severity strings.** Repair creation paths set severity by default, but the column is nullable AND unconstrained. Spec handles both cases consistently: (a) **sort**: both fold to `Not Sure` priority (2); (b) **template class**: both map to `open-record-gray` (the `else` branch); (c) **template badge**: both suppress the badge via `{% if rec.severity in ('Down', 'Degraded', 'Not Sure') %}`. The combined effect is "gray border, no badge" for any non-canonical severity — a clear data-quality signal. Tests cover all three branches: canonical (case 8), None (case 9), unknown string (case 10).
 
 **Explicit non-decisions:**
 - **No cap on records displayed per equipment.** Static page is the fallback view; full information takes priority over visual tidiness in the rare worst case.
-- **Severity text badge `[Down]` retained** as accessibility/redundancy for color-coding.
-- **No empty-tzname fallback in `_compute_generated_at`.** CPython 3.11+ with `tzdata` installed always yields non-empty `tzname()`. If a future deployment violates that invariant, the helper fails loudly with `TypeError` (concatenating `str` and `None`) — preferable to a silent UTC-offset fallback that masks a Dockerfile regression.
+- **Severity text badge retained ONLY for canonical severities.** Non-canonical (`None`, unknown strings) renders without badge — gray border alone serves as the "unrecognized data" signal.
+- **No empty-tzname silent fallback in `_compute_generated_at`.** Explicit `RuntimeError` on `None`-OR-empty tzname is preferred over a silent UTC-offset fallback (which would mask a deployment regression).
 
 **Future / out of scope (do not implement now):**
 - Per-area kiosk static export (would require extending `get_single_area_status_dashboard()` similarly).
@@ -489,25 +553,30 @@ GitHub issue #44 text:
 
 ### Adversarial Review Resolution
 
-**Round 1 (2026-05-11):** 20 findings (R1F1–R1F20), all addressed in the second revision. Resolution table previously included; see commit history for full audit trail.
+**Round 1 (2026-05-11):** 20 findings (R1F1–R1F20), all addressed.
 
-**Round 2 (2026-05-11):** 21 findings (R2F1–R2F21); fixed all real findings (15 of 21). The 6 "Noise" findings (R2F9 / test scoping nit, R2F16 / general line-number audit reminder, R2F18 / dt.year comment, R2F20 / broader XSS, R2F21 / fixture auto-create) deferred or rolled into adjacent fixes.
+**Round 2 (2026-05-11):** 21 findings (R2F1–R2F21); 16 applied, 5 deferred as noise (R2F9, R2F16, R2F18, R2F20, R2F21).
+
+**Round 3 (2026-05-11):** 17 findings (R3F1–R3F17); all 17 applied. The most significant outcome: **R3F1 invalidated the R2F1 "load-bearing tzdata fix" framing** — direct verification (`docker run --rm python:3.14-slim`) showed the base image already includes `tzdata`. The Dockerfile change is retained as a defensive dependency pin, not as a fix for a current bug; all related framing in Decision #10, Task 8, the admin docs (Task 7), and DC 2 was rewritten accordingly.
 
 | ID | Severity | Resolution |
 | --- | --- | --- |
-| R2F1 | Critical | Added Task 8 (Dockerfile `tzdata`). Without this, the whole local-tz feature is a silent no-op. Added end-to-end Docker smoke step in manual testing. |
-| R2F2 | High | Renamed Task 4 case 12 from "drift detector" to `test_footer_text_pin`. AC 12 explicitly scopes coverage to owner + URLs and documents what it does NOT detect; year/markup/aria covered by AC 8/9. |
-| R2F3 | Med | Added `margin-top` ≥ 0.4rem on `.open-records-list` (already in spec — explicitly called out in Decision #9). Added long-name / many-records manual smoke step. |
-| R2F4 | Med | Dropped the empty-tzname fallback entirely; helper now fails loudly via `TypeError` on `None`-tzname. Decision #3 and Task 2 updated. AC 8 fallback case removed. |
-| R2F5 | Med | Split AC 7 into AC 7a (helper wiring via patched return) and AC 7b (helper formats tzname-present case via patched `datetime`). Dropped "via dt.tzname() not string inspection" — not externally testable. |
-| R2F6 | Low | Dropped `id` from the sort key in Task 1; documented that Python's stable sort + prefetch `(created_at, id)` order provides the tiebreak. |
-| R2F7 | Low | Eliminated the `_NO_SEVERITY_SORT_PRIORITY = 999` constant entirely. Unknown / None severities fold to `_NOT_SURE_PRIORITY` (= `_SEVERITY_STATUS['Not Sure'][2]`), avoiding both magic-number duplication AND the equipment-level inversion (R2F8). |
-| R2F8 | Med | Unknown severities and `None` both sort at `Not Sure` priority (2), matching the equipment-level Degraded fallback. AC 3 expanded to cover the unknown-severity case explicitly. |
-| R2F10 | Med | AC 9 (now AC 9) asserts `&copy; <YEAR> Jason Antman` literal entity. Test case renamed `test_footer_renders_local_tz_year_as_entity`. |
-| R2F11 | Med | Inlined footer now includes `aria-label="Site copyright and license"` on `<footer>`, `<small>` wrapper, and `aria-label` on both anchors — mirrors `_footer.html`. AC 8 pins these. |
-| R2F12 | Low | Task 4 case 12 specifies `app.jinja_env.loader.get_source(app.jinja_env, 'components/_footer.html')[0]` for path resolution. |
-| R2F13 | Low | Moved AC 18/19 to a new **Documentation Checklist** section (DC 1, DC 2, DC 3). Hedge "in a test or" dropped. Explicit owner: PR reviewer. |
-| R2F14 | Low | Corrected `description='X'` → `description='Test issue'` in code patterns, fixture description, and the test_patterns frontmatter. |
-| R2F15 | Low | Removed inaccurate `tests/conftest.py:118-160` line range; cite by file + named fixture instead. Other line-number cites checked. |
-| R2F17 | Med | Added Task 4 case 16 (`test_description_uses_prewrap_styles`) covering AC 13 (pre-wrap CSS). |
-| R2F19 | Low | Tightened `equipment_page.html` precedent note: "shows conceptual data shape only; static page reimplements layout in inline CSS without Bootstrap." |
+| R3F1 | Critical | Recharacterized Task 8 as defensive pin (not "load-bearing fix"). Updated Decision #10, Task 8 notes, Notes section, admin docs (Task 7), DC 2 to remove the false "silent UTC fallback" framing. Verified base image already includes `tzdata`. |
+| R3F2 | Med | Replaced "Debian bookworm-based" with explicit "Debian trixie-based (Debian 13)" in Task 8 notes; `--no-install-recommends` plus `-y` is fully non-interactive on trixie. |
+| R3F3 | Med | Template severity-badge guard changed from `{% if rec.severity %}` to `{% if rec.severity in ('Down', 'Degraded', 'Not Sure') %}`. Decision #5 / Risk section now documents the consistent "gray border + no badge for non-canonical severity" rule. AC 4 expanded to assert badge suppression for both `None` and unknown strings; new test case 10. |
+| R3F4 | Med | Task 4 case 3 now spells out the exact Mock chain: `mock_datetime.now.return_value.astimezone.return_value = fixed_dt`. Removes the ambiguity that could let a wrong-semantics test pass. |
+| R3F5 | Med | `_compute_generated_at` now performs explicit `if not tzname: raise RuntimeError(...)` validation (catches both `None` and empty string). New AC 7c + new test case 4 pin this behavior. Decision #3 and Notes updated. |
+| R3F6 | Med | Documented test-time tzdata expectation: provided by OS on dev machines / Docker image; if CI ever moves to a stripped image, add PyPI `tzdata` to dev requirements. Added a Dependencies section note. |
+| R3F7 | Low | Revision history line updated to `R2F1–R2F21 (16 applied, 5 deferred as noise)` — accurate range and counts. |
+| R3F8 | Low | Round-2 narrative arithmetic corrected: "fixed 16 real findings; 5 deferred as noise" (was "15 of 21"). |
+| R3F9 | Low | New AC 17 + new test case 21 covering archived-area / archived-equipment exclusion. |
+| R3F10 | Low | New AC 18 + new test case 22 covering empty-dashboard (`areas == []`) skeleton rendering. |
+| R3F11 | Low | New AC 11b + new test case 17 covering autoescape of entity-content descriptions (`Bob & Alice`, `50%<`). |
+| R3F12 | Low | New AC 19 + new test case 23 covering two equipment with the same name in different areas. |
+| R3F13 | Low | Task 4 case 15 wraps `get_source()` call in try/except with a clear error message ("update this pin test's path"). |
+| R3F14 | Low | Smoke step 3 (local dev) and step 5 (Docker production) clearly distinguished: step 3 explicitly notes "this step does NOT verify the worker container's behavior — see step 5." |
+| R3F15 | Low | Admin docs prose rewritten: "TZ resolves against /usr/share/zoneinfo, provided by the tzdata system package. Both python:3.14-slim's defaults and this image's Dockerfile install include tzdata; do not remove it." Replaces the misleading "without tzdata it falls back to UTC" framing. |
+| R3F16 | Low | DC 2 rewritten as "defensive dependency pin (not a current-bug fix)" with explicit warning against size-optimization removal. |
+| R3F17 | Low | New AC 6 regex assertion + new test case 5 (`test_compute_generated_at_format_matches_regex`) runs the **unpatched** helper and asserts the format end-to-end. |
+
+**Round 1 and Round 2 resolutions remain authoritative** — see commit history (`b95... ` and `2862a82`/`c88d833`) for full audit trails of those rounds' fixes.

--- a/_bmad-output/implementation-artifacts/tech-spec-static-status-page-export-improvements.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-static-status-page-export-improvements.md
@@ -27,6 +27,7 @@ revision_history:
   - '2026-05-11 — applied 20 adversarial-review findings (R1F1–R1F20)'
   - '2026-05-11 — applied real findings from round-2 adversarial review (R2F1–R2F21: 16 applied, 5 deferred as noise)'
   - '2026-05-11 — applied real findings from round-3 adversarial review (R3F1–R3F17: all 17 applied; R3F1 invalidated the R2F1 "load-bearing tzdata" framing, recharacterized as defensive pin)'
+  - '2026-05-12 — applied selected round-4 adversarial-review findings (R4F1, R4F2, R4F4, R4F10 applied; R4F3/R4F5/R4F6/R4F7 deferred as low-value polish; R4F8/R4F9 noise). Round-4 reviewer verdict: "spec is mature, ready for fresh dev agent."'
 ---
 
 # Tech-Spec: Static status page export improvements
@@ -124,7 +125,14 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 ### Technical Decisions
 
 1. **Extend `get_area_status_dashboard()` to include an `open_records` list per equipment.** Records are already prefetched and grouped in `records_by_equipment`; threading the list through is a one-line change. Rejected the "new helper" option to avoid duplicating ~40 lines of prefetch code. Existing callers (live dashboard, kiosk, Slack formatters) ignore the new key.
-2. **Sort open records by `(severity priority, created_at)` ASC.** Rationale: the static page is the fallback at-a-glance view. Sorting by severity ensures `Down` records bubble above `Degraded`/`Not Sure`/unknown within each equipment's record list. Sort key: `(priority, rec.created_at)` where `priority = _SEVERITY_STATUS.get(rec.severity, (..., ..., _SEVERITY_STATUS['Not Sure'][2]))[2]`. **No `id` in the sort key** — Python's `list.sort()` is stable and the prefetch query order (`created_at ASC, id ASC`) is preserved on ties. **Unknown severity strings and `None` both fall back to the `Not Sure` priority (2)** — same as the equipment-level status derivation — to avoid an inversion where the equipment dot says yellow but the unknown-severity record sorts beneath Not-Sure records (R2F8).
+2. **Sort open records by `(severity priority, created_at)` ASC.** Rationale: the static page is the fallback at-a-glance view. Sorting by severity ensures `Down` records bubble above `Degraded`/`Not Sure`/unknown within each equipment's record list. Sort-key implementation (canonical — see Task 1 for the same snippet):
+   ```python
+   def _open_records_sort_key(rec):
+       sev_entry = _SEVERITY_STATUS.get(rec.severity)
+       priority = sev_entry[2] if sev_entry else _NOT_SURE_PRIORITY
+       return (priority, rec.created_at)
+   ```
+   **No `id` in the sort key** — Python's `list.sort()` is stable and the prefetch query order (`created_at ASC, id ASC`) is preserved on ties. **Unknown severity strings and `None` both fall back to the `Not Sure` priority (2)** — same as the equipment-level status derivation — to avoid an inversion where the equipment dot says yellow but the unknown-severity record sorts beneath Not-Sure records (R2F8). (R4F2: Decision #2 and Task 1 now share the same two-line snippet.)
 3. **Local-timezone generation timestamp.** Implemented in module-level helper `_compute_generated_at()` in `static_page_service.py` (so tests can patch it). Uses `datetime.now().astimezone()` (no `tzinfo` argument) — Python picks up the host system's TZ from `TZ` env / `/etc/localtime`. Format: `'%Y-%m-%d %H:%M:%S '` + `dt.tzname()` → `2026-05-11 14:32:15 EDT`. Seconds are included for debugging value when multiple pushes happen within a minute. **Explicit tzname validation** (R3F5): the helper checks `tzname = dt.tzname(); if not tzname: raise RuntimeError(...)` — this is a real loud-failure guarantee that catches both `None` (TypeError on concatenation) AND empty-string (silent trailing space) cases. Build the string by concatenation (not `%Z`) so the trailing token is explicit.
 4. **Footer text is inlined verbatim** from `_footer.html` (copyright line + GitHub link + MIT license link, INCLUDING `<small>` wrapper and all `aria-label` attributes) into `static_page.html`, NOT included via `{% include %}`. Reasons: (a) the static page must remain self-contained (no external sub-resources); (b) an include couples the export to a fragment used by the live site, which is brittle if that fragment later pulls in Bootstrap classes; (c) copyright text is short and stable. **Drift mitigation:** Task 4 case 12 adds a unit test that loads `_footer.html` through Flask's Jinja loader and asserts its **three load-bearing substrings** (`Jason Antman`, the GitHub URL, the MIT URL) appear in the rendered static page. The test is explicitly named `test_footer_text_pin` — it pins owner + URLs only, NOT year-token markup or `<small>`/aria attribute wrapping. Those are covered by their own ACs (AC 8 / AC 9).
 5. **Per-record styling**. Repair-record `<li>` items use a small inline left-border indicator color-coded by severity using the same mapping as the equipment-level dot (`Down`→red, `Degraded`/`Not Sure`→yellow, everything else including `None` and unknown strings → gray). Display order within the record: `[status badge] [severity badge if canonical severity] description …ETA: …`. Severity text badge is **retained for canonical severities** (`Down`/`Degraded`/`Not Sure`) as an accessibility/redundancy feature — color alone is a WCAG concern, and the text badge gives the same information non-visually. **For non-canonical severities (R3F3)** — unknown strings AND `None` — the badge is suppressed entirely; the gray border serves as the "unrecognized data" signal. This resolves the prior tri-state inconsistency where an unknown severity produced yellow-priority sort + gray border + raw-text badge.
@@ -189,9 +197,10 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
            return (dt.strftime('%Y-%m-%d %H:%M:%S ') + tzname, dt.year)
        ```
        Explicit `if not tzname:` check covers both `None` and empty-string cases (R3F5). Build the string by concatenation (not `%Z`) so the trailing token is explicit.
-    3. Update `generate()`:
+    3. Update `generate()` — import `REPAIR_SEVERITIES` from the model and pass it as a template context kwarg so the template's badge guard isn't a hardcoded copy of the canonical list (R4F1):
        ```python
        def generate() -> str:
+           from esb.models.repair_record import REPAIR_SEVERITIES
            from esb.services import status_service
            areas = status_service.get_area_status_dashboard()
            generated_at, generated_year = _compute_generated_at()
@@ -200,6 +209,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
                areas=areas,
                generated_at=generated_at,
                generated_year=generated_year,
+               repair_severities=REPAIR_SEVERITIES,
            )
        ```
   - Notes: No new external deps. Tests patch `esb.services.static_page_service._compute_generated_at` to inject deterministic timestamps regardless of host TZ.
@@ -267,7 +277,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
                     <ul class="open-records-list">
                         {% for rec in item.open_records %}
                         <li class="open-record open-record-{{ 'red' if rec.severity == 'Down' else 'yellow' if rec.severity in ('Degraded', 'Not Sure') else 'gray' }}">
-                            <span class="record-status">{{ rec.status }}</span>{% if rec.severity in ('Down', 'Degraded', 'Not Sure') %} <span class="record-severity">[{{ rec.severity }}]</span>{% endif %} <span class="record-description">{{ rec.description }}</span>{% if rec.eta %} <span class="record-eta">ETA: {{ rec.eta|format_date }}</span>{% endif %}
+                            <span class="record-status">{{ rec.status }}</span>{% if rec.severity in repair_severities %} <span class="record-severity">[{{ rec.severity }}]</span>{% endif %} <span class="record-description">{{ rec.description }}</span>{% if rec.eta %} <span class="record-eta">ETA: {{ rec.eta|format_date }}</span>{% endif %}
                         </li>
                         {% endfor %}
                     </ul>
@@ -287,7 +297,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
     </html>
     ```
 
-  - Key changes vs. previous template: `.equipment-item` becomes `display: block`; the existing dot/name/label/eta row is wrapped in `<div class="equipment-row">`; new `<ul class="open-records-list">` rendered only when equipment is non-green AND has open records; **severity badge guard changed from `{% if rec.severity %}` to `{% if rec.severity in ('Down', 'Degraded', 'Not Sure') %}`** so unknown/None severities suppress the badge entirely (R3F3); old `<div class="footer">Generated: …</div>` replaced by `<footer class="site-footer" role="contentinfo" aria-label="Site copyright and license">` with a `<small>` wrapper and `aria-label` on the GitHub and MIT anchors (mirrors `_footer.html`); new `.generated-at` sub-heading directly under the `<h1>`. The footer uses `generated_year` (local-tz, from `_compute_generated_at()`), NOT `current_year`. The CSP directive is unchanged.
+  - Key changes vs. previous template: `.equipment-item` becomes `display: block`; the existing dot/name/label/eta row is wrapped in `<div class="equipment-row">`; new `<ul class="open-records-list">` rendered only when equipment is non-green AND has open records; **severity badge guard is `{% if rec.severity in repair_severities %}`** (where `repair_severities = REPAIR_SEVERITIES` from `esb.models.repair_record`, passed via `generate()` context) so unknown/None severities suppress the badge entirely (R3F3) AND a future addition to `REPAIR_SEVERITIES` automatically picks up badge rendering without a template edit (R4F1); old `<div class="footer">Generated: …</div>` replaced by `<footer class="site-footer" role="contentinfo" aria-label="Site copyright and license">` with a `<small>` wrapper and `aria-label` on the GitHub and MIT anchors (mirrors `_footer.html`); new `.generated-at` sub-heading directly under the `<h1>`. The footer uses `generated_year` (local-tz, from `_compute_generated_at()`), NOT `current_year`. The CSP directive is unchanged. Note: the color-class chain `{{ 'red' if rec.severity == 'Down' else 'yellow' if rec.severity in ('Degraded', 'Not Sure') else 'gray' }}` intentionally keeps hardcoded membership — color is a semantic mapping per severity (not derivable from the list alone), so adding a new canonical severity also requires a deliberate color decision in this template.
 
 - [ ] **Task 4: Add tests in `tests/test_services/test_static_page_service.py`.**
   - File: `tests/test_services/test_static_page_service.py`
@@ -360,9 +370,14 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
     24. **Update existing `test_includes_generated_timestamp`** — Replace `assert 'UTC' in html` with `assert 'Generated:' in html`. The timezone token now depends on host TZ / patched helper.
 
   - Notes:
-    - Use `from datetime import UTC, datetime` (Python 3.11+) for `created_at` kwarg values.
-    - Use `from zoneinfo import ZoneInfo` for the tzname-formats test.
     - The fixture `make_repair_record(equipment=None, status='New', description='Test issue', **kwargs)` — pass `equipment=…` explicitly to avoid auto-create side effects; pass `severity`, `eta`, `created_at` via kwargs.
+    - **Explicit imports required by the new test cases** (R4F4 — make these unambiguous for a fresh dev):
+      - `from datetime import UTC, datetime` (Python 3.11+) — cases 12, 21, 22, 23 for `created_at` kwarg values.
+      - `from zoneinfo import ZoneInfo` — case 3 for `ZoneInfo('America/New_York')`.
+      - `from unittest.mock import patch` — cases 2, 3, 4, 14.
+      - `from jinja2.exceptions import TemplateNotFound` — case 15.
+      - `import re` — case 5.
+      - `from esb.services import static_page_service` — cases 2, 3, 4, 5 (the cases that patch helper internals or call them directly; the broader test module already imports it).
 
 - [ ] **Task 5: Add a regression test for the new `open_records` key in `tests/test_services/test_status_service.py`.**
   - File: `tests/test_services/test_status_service.py`
@@ -517,11 +532,11 @@ DC 1, DC 2, DC 3 are verified by code review at PR time.
    - Under each non-green equipment item: a list with one row per open record, colored by severity, showing status + `[severity]` badge (only for canonical severities) + description (multi-line / long text wrapping correctly) + ETA (when set). Records sorted with `Down` records on top.
    - Bottom: centered copyright footer with `<small>` wrapper, GitHub and MIT license anchors, aria-labels present (verifiable in DevTools); year matches the generation sub-heading year.
    - View source: no `<link>`, no `<script src=...>`, no external `<img>`; CSP meta tag value is `default-src 'none'; style-src 'unsafe-inline'` verbatim; `<footer>` has `role="contentinfo"` and `aria-label="Site copyright and license"`.
-5. **End-to-end Docker production smoke check:** Build the image with the Dockerfile change applied. Run:
+5. **End-to-end Docker production smoke check:** Build the image with the Dockerfile change applied. Run the actual helper inside the worker container (R4F10 — calls the real codepath, not just `datetime.now().astimezone().tzname()`):
    ```bash
-   TZ=America/New_York docker compose run --rm worker python -c "from datetime import datetime; print(datetime.now().astimezone().tzname())"
+   TZ=America/New_York docker compose run --rm worker python -c "from esb.services.static_page_service import _compute_generated_at; print(_compute_generated_at())"
    ```
-   Confirm output is `EDT`/`EST` (not `UTC`). This is the authoritative production verification — step 3 only covers the dev's local environment.
+   Confirm output looks like `('2026-05-12 14:32:15 EDT', 2026)` — non-UTC tzname, current local-tz year. This is the authoritative production verification: it exercises `_compute_generated_at()` directly, so a future regression that breaks the helper (wrong return shape, missing `.astimezone()`, etc.) will surface here. Step 3 only covers the dev's local environment.
 
 ### Notes
 
@@ -579,4 +594,19 @@ GitHub issue #44 text:
 | R3F16 | Low | DC 2 rewritten as "defensive dependency pin (not a current-bug fix)" with explicit warning against size-optimization removal. |
 | R3F17 | Low | New AC 6 regex assertion + new test case 5 (`test_compute_generated_at_format_matches_regex`) runs the **unpatched** helper and asserts the format end-to-end. |
 
-**Round 1 and Round 2 resolutions remain authoritative** — see commit history (`b95... ` and `2862a82`/`c88d833`) for full audit trails of those rounds' fixes.
+**Round 4 (2026-05-12):** 10 findings (R4F1–R4F10); 4 applied, 4 deferred as low-value polish, 2 noise. **Reviewer's explicit verdict: "spec is mature, ready for fresh dev agent; I would ship this with fix #1 applied."**
+
+| ID | Severity | Resolution |
+| --- | --- | --- |
+| R4F1 | Med | Applied. `generate()` now imports `REPAIR_SEVERITIES` from `esb.models.repair_record` and passes it as `repair_severities=` template context. Template badge guard rewritten to `{% if rec.severity in repair_severities %}`. A future addition to `REPAIR_SEVERITIES` automatically picks up badge rendering without a template edit. The color-class chain in the template intentionally retains its hardcoded membership — color is a per-severity semantic decision, not derivable from list membership alone. |
+| R4F2 | Low | Applied. Decision #2 now shows the same two-line `_open_records_sort_key` snippet as Task 1, removing the prior `.get()`-with-tuple-default variant. |
+| R4F4 | Low | Applied. Task 4 Notes now lists explicit imports per test case: `from datetime import UTC, datetime`, `from zoneinfo import ZoneInfo`, `from unittest.mock import patch`, `from jinja2.exceptions import TemplateNotFound`, `import re`, with case-number annotations. |
+| R4F10 | Low | Applied. Smoke step 5 now calls `_compute_generated_at()` directly instead of inline `datetime.now().astimezone().tzname()` — exercises the real helper codepath. |
+| R4F3 | Low | Deferred. Risk that case 5's `RuntimeError` from a tzdata-missing CI masks the test's stated intent is real but rare; failure is still red. Notes section discusses the failure mode under R3F6. |
+| R4F5 | Low | Deferred. `_compute_generated_at()` returns a positional 2-tuple. Tests pin the shape; a NamedTuple is cosmetic. |
+| R4F6 | Low | Deferred. Decision #11 wording is fine; both patching paths are valid, and the tests demonstrate which is canonical for each use. |
+| R4F7 | Low | Deferred. AC 18's "no `<div class=\"area\">`" is brittle only to a future empty-state UI; that's a separate spec when it happens. |
+| R4F8 | Noise | Not applied. Regex `\S+` is fine for all IANA TZ names on Debian trixie. |
+| R4F9 | Noise | Not applied. Dockerfile layer cache + ~3MB tzdata is negligible. |
+
+**Round 1, Round 2, Round 3 resolutions remain authoritative** — see commit history for full audit trails of those rounds' fixes.

--- a/_bmad-output/implementation-artifacts/tech-spec-static-status-page-export-improvements.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-static-status-page-export-improvements.md
@@ -2,8 +2,8 @@
 title: 'Static status page export improvements'
 slug: 'static-status-page-export-improvements'
 created: '2026-05-11'
-status: 'ready-for-dev'
-stepsCompleted: [1, 2, 3, 4]
+status: 'Completed'
+stepsCompleted: [1, 2, 3, 4, 5, 6]
 tech_stack: ['Python 3.14', 'Flask', 'Jinja2', 'pytest', 'Docker (python:3.14-slim, Debian 13 trixie)']
 files_to_modify:
   - 'esb/services/static_page_service.py'
@@ -28,7 +28,22 @@ revision_history:
   - '2026-05-11 — applied real findings from round-2 adversarial review (R2F1–R2F21: 16 applied, 5 deferred as noise)'
   - '2026-05-11 — applied real findings from round-3 adversarial review (R3F1–R3F17: all 17 applied; R3F1 invalidated the R2F1 "load-bearing tzdata" framing, recharacterized as defensive pin)'
   - '2026-05-12 — applied selected round-4 adversarial-review findings (R4F1, R4F2, R4F4, R4F10 applied; R4F3/R4F5/R4F6/R4F7 deferred as low-value polish; R4F8/R4F9 noise). Round-4 reviewer verdict: "spec is mature, ready for fresh dev agent."'
+  - '2026-05-12 — implementation complete. Post-impl adversarial review returned 16 findings; 9 applied (F1, F2, F3, F4, F5, F6, F9, F11, F12), 7 skipped (F7 cosmetic test-name, F8 feature-creep, F10/F16 undecided, F13 audit-only, F14 noise, F15 spec-mandated combined-test). All 1422 tests passing; lint clean.'
 ---
+
+## Review Notes
+
+- Adversarial review completed.
+- Findings: 16 total, 9 fixed, 7 skipped.
+- Resolution approach: auto-fix all "real" findings; skip noise/undecided/feature-creep.
+- Skipped, with rationale:
+  - **F7** — Test name "archived areas and equipment" accurately reflects its two-part body; rename would not add coverage.
+  - **F8** — Startup tzname log line is a feature addition, not a defect fix.
+  - **F10** — Concatenation placement is exactly what the spec mandates; refactor undecided.
+  - **F13** — Audit pass over substring-vs-element assertions already completed; the two real collisions (cases 7, 11) were caught at first test run.
+  - **F14** — Module-level `tzinfo` import is cosmetic.
+  - **F15** — Spec explicitly combined the two archived-exclusion scenarios into one test (Task 4 case 21).
+  - **F16** — Live-vs-static year inconsistency note in admin docs is undecided polish.
 
 # Tech-Spec: Static status page export improvements
 
@@ -147,7 +162,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 
 ### Tasks
 
-- [ ] **Task 1: Extend `get_area_status_dashboard()` to include sorted per-equipment open repair records.**
+- [x] **Task 1: Extend `get_area_status_dashboard()` to include sorted per-equipment open repair records.**
   - File: `esb/services/status_service.py`
   - Action:
     1. Inside `get_area_status_dashboard()`, after the `records_by_equipment` grouping, add a sort: for each list in `records_by_equipment.values()`, sort in place by `(priority, created_at)`. Helper:
@@ -167,7 +182,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
     3. Update the function's docstring to document the new `open_records` key — list of `RepairRecord` instances, sorted by `(severity priority, created_at)` with unknown severities folded to `Not Sure` priority; ties on those fields preserve the prefetch query's `(created_at, id)` ASC order (stable sort).
   - Notes: Existing live-page templates (`public/status_dashboard.html`, `public/kiosk.html`) and Slack formatters (`esb/slack/forms.py`) iterate `area_data.equipment` but reference only `item.equipment` and `item.status`. The additive key is safe. `get_single_area_status_dashboard()` is **not** changed.
 
-- [ ] **Task 2: Add `_compute_generated_at()` helper and hoist `datetime` import in `static_page_service.py`.**
+- [x] **Task 2: Add `_compute_generated_at()` helper and hoist `datetime` import in `static_page_service.py`.**
   - File: `esb/services/static_page_service.py`
   - Action:
     1. Move `from datetime import UTC, datetime` from inside `generate()` to the module-level imports. Remove the unused `UTC` if not referenced elsewhere.
@@ -214,7 +229,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
        ```
   - Notes: No new external deps. Tests patch `esb.services.static_page_service._compute_generated_at` to inject deterministic timestamps regardless of host TZ.
 
-- [ ] **Task 3: Update `static_page.html` template structure.**
+- [x] **Task 3: Update `static_page.html` template structure.**
   - File: `esb/templates/public/static_page.html`
   - Below is the full intended template (replace the file's contents). Read the existing file first to confirm no other recent edits.
 
@@ -299,7 +314,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 
   - Key changes vs. previous template: `.equipment-item` becomes `display: block`; the existing dot/name/label/eta row is wrapped in `<div class="equipment-row">`; new `<ul class="open-records-list">` rendered only when equipment is non-green AND has open records; **severity badge guard is `{% if rec.severity in repair_severities %}`** (where `repair_severities = REPAIR_SEVERITIES` from `esb.models.repair_record`, passed via `generate()` context) so unknown/None severities suppress the badge entirely (R3F3) AND a future addition to `REPAIR_SEVERITIES` automatically picks up badge rendering without a template edit (R4F1); old `<div class="footer">Generated: …</div>` replaced by `<footer class="site-footer" role="contentinfo" aria-label="Site copyright and license">` with a `<small>` wrapper and `aria-label` on the GitHub and MIT anchors (mirrors `_footer.html`); new `.generated-at` sub-heading directly under the `<h1>`. The footer uses `generated_year` (local-tz, from `_compute_generated_at()`), NOT `current_year`. The CSP directive is unchanged. Note: the color-class chain `{{ 'red' if rec.severity == 'Down' else 'yellow' if rec.severity in ('Degraded', 'Not Sure') else 'gray' }}` intentionally keeps hardcoded membership — color is a semantic mapping per severity (not derivable from the list alone), so adding a new canonical severity also requires a deliberate color decision in this template.
 
-- [ ] **Task 4: Add tests in `tests/test_services/test_static_page_service.py`.**
+- [x] **Task 4: Add tests in `tests/test_services/test_static_page_service.py`.**
   - File: `tests/test_services/test_static_page_service.py`
   - Add the following tests (inside `class TestGenerate` unless noted). Always pass `equipment=…` explicitly to `make_repair_record` to avoid the fixture auto-creating its own area/equipment.
 
@@ -379,7 +394,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
       - `import re` — case 5.
       - `from esb.services import static_page_service` — cases 2, 3, 4, 5 (the cases that patch helper internals or call them directly; the broader test module already imports it).
 
-- [ ] **Task 5: Add a regression test for the new `open_records` key in `tests/test_services/test_status_service.py`.**
+- [x] **Task 5: Add a regression test for the new `open_records` key in `tests/test_services/test_status_service.py`.**
   - File: `tests/test_services/test_status_service.py`
   - Add (in an existing `TestGetAreaStatusDashboard` class, or create one):
 
@@ -391,12 +406,12 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
 
   - Notes: Verify existing tests still pass — the new key is additive.
 
-- [ ] **Task 6: Configure default TZ in `docker-compose.yml` worker service.**
+- [x] **Task 6: Configure default TZ in `docker-compose.yml` worker service.**
   - File: `docker-compose.yml`
   - Action: In the `worker:` service's `environment:` block, add a new line: `      - TZ=${TZ:-America/New_York}`. Place it adjacent to the existing `PYTHONUNBUFFERED=1` and `WORKER_HEARTBEAT_PATH=…` entries.
   - Notes: The `${TZ:-America/New_York}` syntax means "use the `TZ` env var if set in `.env` or shell, otherwise default to `America/New_York`." This matches the makerspace location (Decatur Makers) while letting other deployments override. The `app` service does **not** need TZ — only the worker calls `generate()`. This is the load-bearing change for the local-tz feature.
 
-- [ ] **Task 7: Document the `TZ` environment variable in `docs/administrators.md`.**
+- [x] **Task 7: Document the `TZ` environment variable in `docs/administrators.md`.**
   - File: `docs/administrators.md`
   - Action: In the Environment Variable Reference table, add a new row:
     ```markdown
@@ -404,7 +419,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
     ```
   - Also add a short paragraph in the "Static Status Page Setup" section: "The static page's generation timestamp reflects the `worker` container's `TZ` environment variable. The variable resolves against the OS tzdata database (`/usr/share/zoneinfo`), which is provided by the `tzdata` system package. Both the `python:3.14-slim` base image and this image's Dockerfile install list include `tzdata`; do not remove it. To use a non-default zone, set `TZ` in `.env` before running `docker compose up`."
 
-- [ ] **Task 8: Add `tzdata` to the Dockerfile as a defensive dependency pin.**
+- [x] **Task 8: Add `tzdata` to the Dockerfile as a defensive dependency pin.**
   - File: `Dockerfile`
   - Action: In the existing `apt-get install` line, add `tzdata` alongside `gcc` and `libzbar0`:
     ```dockerfile
@@ -416,7 +431,7 @@ Update `static_page_service.generate()` to pass through (a) the open repair reco
     ```
   - Notes: **This is a defensive dependency pin, NOT a fix for a current bug.** The `python:3.14-slim` base image (Debian 13 trixie) already ships `tzdata` by default — verified via `docker run --rm python:3.14-slim dpkg -l tzdata` showing `tzdata 2026a-0+deb13u1`. With the base image as-is, `TZ=America/New_York` already resolves correctly. The explicit install guarantees `tzdata` remains in the image if a future base-image variant ever drops the package (or if a Debian repository retraction makes it disappear). `apt-get install -y --no-install-recommends` is fully non-interactive on Debian trixie without needing `DEBIAN_FRONTEND=noninteractive`.
 
-- [ ] **Task 9: Run lint and full test suite.**
+- [x] **Task 9: Run lint and full test suite.**
   - Commands: `make lint` then `make test`.
   - Expected: All green. Existing test `test_includes_generated_timestamp` was updated in Task 4 case 24; `test_produces_self_contained_html` continues to pass; existing `test_includes_csp_meta_tag` is replaced/strengthened per Task 4 case 18. The full suite covers Slack formatter tests (`tests/test_slack/`) which exercise consumers of `get_area_status_dashboard()` — confirms no regression.
 

--- a/_bmad-output/implementation-artifacts/tech-spec-static-status-page-export-improvements.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-static-status-page-export-improvements.md
@@ -1,0 +1,234 @@
+---
+title: 'Static status page export improvements'
+slug: 'static-status-page-export-improvements'
+created: '2026-05-11'
+status: 'ready-for-dev'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack: ['Python 3.14', 'Flask', 'Jinja2', 'pytest']
+files_to_modify:
+  - 'esb/services/static_page_service.py'
+  - 'esb/templates/public/static_page.html'
+  - 'tests/test_services/test_static_page_service.py'
+code_patterns:
+  - 'esb.services.status_service.get_area_status_dashboard() returns areas with computed status only — needs extension or supplementary query to expose ALL open repair records per equipment'
+  - 'esb.templates.components._footer.html is the site copyright footer used on live pages; references current_year context var (injected in esb/__init__.py)'
+  - 'esb.utils.filters.format_date and format_datetime are registered Jinja filters'
+test_patterns:
+  - 'tests/test_services/test_static_page_service.py uses make_area, make_equipment, make_repair_record fixtures; asserts on substrings in generated HTML'
+---
+
+# Tech-Spec: Static status page export improvements
+
+**Created:** 2026-05-11
+
+GitHub Issue: [#44](https://github.com/jantman/equipment-status-board/issues/44)
+
+## Overview
+
+### Problem Statement
+
+The static status page (`esb/services/static_page_service.py` → `esb/templates/public/static_page.html`) — exported to local disk / S3 / GCS for public-facing display when the live Flask site is unavailable — has two presentation gaps:
+
+1. **No repair detail for non-green equipment.** It lists each equipment item by area with a status dot (green/yellow/red), a label, and (for the highest-severity record only) an ETA. When equipment is Degraded or Down, the page does not enumerate the **open repair records** with their per-record status, ETA, and description, so a reader cannot see *why* equipment is impaired or *what is being done about it*.
+2. **Generation metadata is inconsistent and visually weak.** A small "Generated: YYYY-MM-DD HH:MM UTC" line at the very bottom is the only branding/footer content. The live site uses a richer copyright/license footer (`esb/templates/components/_footer.html`). The static export should match the live look-and-feel, and the generation timestamp should be more prominent and in local/system timezone (not UTC).
+
+### Solution
+
+Update `static_page_service.generate()` to pass through (a) the open repair records per non-green equipment item and (b) a generation timestamp in the system's local timezone. Update `esb/templates/public/static_page.html` to (i) render a list of open repair records — with each record's status, ETA, and description — nested under each non-green equipment item; (ii) add a generation-time sub-heading immediately under the `<h1>Equipment Status</h1>` title, right-aligned, in local timezone; (iii) replace the bottom "Generated:" line with the site's copyright/license footer text (inlined — the static page must remain CSP-locked and have no external assets).
+
+### Scope
+
+**In Scope:**
+- `esb/services/static_page_service.py` `generate()` — pass open repair records per equipment + local-timezone timestamp.
+- `esb/templates/public/static_page.html` — repair-record list under non-green items, top sub-heading with generated time, replace bottom footer with inlined copyright text.
+- Inline the copyright footer markup/text into the static template (the static page may not depend on `_footer.html` or external CSS — same self-contained / `default-src 'none'` CSP rule).
+- Update `tests/test_services/test_static_page_service.py` to cover the new repair list and footer / generation-time placement.
+
+**Out of Scope:**
+- Live `public/status_dashboard.html`, kiosk views, or equipment-info pages.
+- Database schema changes.
+- Push delivery backends (`_push_local`, `_push_s3`, `_push_gcs`) — unchanged.
+- Changes to `status_service` status derivation (color/label/severity logic stays as-is).
+- Reuse of `_footer.html` via `{% include %}` — static export must remain self-contained.
+
+## Context for Development
+
+### Codebase Patterns
+
+- **Self-contained static page.** `static_page.html` declares `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'` and uses only inline `<style>`. The page must continue to render with no external `<link>` or `<script src=>` (existing test `test_produces_self_contained_html` enforces this).
+- **Status derivation lives in `esb/services/status_service.py`.** `get_area_status_dashboard()` currently emits one `status` dict per equipment (computed from the highest-severity open record). The new requirement needs **all open repair records** per non-green equipment. Approach: extend `get_area_status_dashboard()` to additionally include the per-equipment list of `RepairRecord` instances in each entry (e.g., `open_records: list[RepairRecord]`). The records are already prefetched and grouped by `equipment_id` in the existing implementation (`records_by_equipment` dict), so threading the list through to the result dict is a non-disruptive add — existing callers ignoring the new key continue to work, and we avoid a near-duplicate helper. **However**, since the live dashboard uses the same call but should not show the per-record list, the template change is gated on this being the *static page* template — the live `status_dashboard.html` does not iterate `open_records`. Verify no live-page templates accidentally start rendering the new key (none do today).
+- **`current_year` is injected via `app.context_processor` in `esb/__init__.py`** (`esb/__init__.py:75-76`); that processor works for `render_template()` calls so it is available to the static template without explicit kwargs.
+- **Jinja filters `format_date` and `format_datetime`** (in `esb/utils/filters.py:13-32`) are registered on the app's Jinja env and usable from any template, including the static one.
+- **`RepairRecord` model fields** (confirmed in `esb/models/repair_record.py`):
+  - `status: str` from `REPAIR_STATUSES = ['New', 'Assigned', 'In Progress', 'Parts Needed', 'Parts Ordered', 'Parts Received', 'Needs Specialist', 'Resolved', 'Closed - No Issue Found', 'Closed - Duplicate']`. Non-closed = anything not in `CLOSED_STATUSES = ('Resolved', 'Closed - No Issue Found', 'Closed - Duplicate')`.
+  - `severity: str | None` from `REPAIR_SEVERITIES = ['Down', 'Degraded', 'Not Sure']`.
+  - `description: str` (Text, non-null).
+  - `eta: date | None`.
+  - `created_at: datetime` (UTC).
+- **Severity → color map** (`status_service._SEVERITY_STATUS`): `Down`→red, `Degraded`→yellow, `Not Sure`→yellow. Use this same mapping for per-record styling in the new repair list to stay consistent.
+- **Local-timezone formatting.** No existing helper. Use `datetime.now().astimezone()` (passing no `tzinfo`) — Python derives the system tz from `TZ` env / `/etc/localtime`. Format with `strftime('%Y-%m-%d %H:%M %Z')` (e.g., `2026-05-11 14:32 EDT`). If `%Z` is empty (rare; happens when `tzinfo` is a fixed offset without a name), fall back to ISO offset `%z`. Compute in the service (not Jinja) so all tz logic stays out of the template.
+- **Reference precedent.** `esb/templates/public/equipment_page.html:29-46` already renders an `open_repairs` list with severity-derived `status-card-*` styling — same data shape, similar visual treatment. The static page repair list should follow the same conceptual layout (record per `<li>`, severity styling, description visible, ETA shown when set) but using *inline* CSS classes already defined in `static_page.html` (Bootstrap is unavailable in the export).
+
+### Files to Reference
+
+| File | Purpose |
+| ---- | ------- |
+| `esb/services/static_page_service.py` | Modify `generate()` to fetch repair records + local-tz timestamp. |
+| `esb/services/status_service.py` | Add (or extend) a helper that returns areas with each equipment's full open-record list. |
+| `esb/templates/public/static_page.html` | Render repair list, top-right generation timestamp, inline copyright footer. |
+| `esb/templates/components/_footer.html` | Source of truth for the copyright/license text and link targets (used as reference; not included). |
+| `esb/__init__.py` | `inject_current_year` context processor (already wired). |
+| `esb/utils/filters.py` | `format_date`, `format_datetime` Jinja filters. |
+| `tests/test_services/test_static_page_service.py` | Existing test class `TestGenerate`; add cases for repair list, top-right timestamp, and inline footer. |
+
+### Technical Decisions
+
+1. **Extend `get_area_status_dashboard()` to include an `open_records` list per equipment.** Records are already prefetched and grouped in `records_by_equipment`; threading the list through is a one-line change. Rejected the "new helper" option to avoid duplicating ~40 lines of prefetch code. Existing callers (live dashboard, kiosk) ignore the new key.
+2. **Render repair records sorted by `created_at` ASC** (matches the prefetch order already used by `status_service` — `.order_by(RepairRecord.created_at, RepairRecord.id)`).
+3. **Local timezone for the generation timestamp.** Use `datetime.now().astimezone()` (no `tzinfo` argument) — Python picks up the host system's TZ from `TZ` / `/etc/localtime`. The container `docker-compose.yml` / production deployment is responsible for setting `TZ`; in absence of `TZ` the default is UTC, which is acceptable. Format string: `'%Y-%m-%d %H:%M %Z'` → `2026-05-11 14:32 EDT`. If `%Z` produces an empty string (fixed-offset zones without names), fall back to `'%Y-%m-%d %H:%M %z'` → `2026-05-11 14:32 -0400`.
+4. **Footer text is inlined verbatim** from `_footer.html` (copyright line + GitHub link + MIT license link) into `static_page.html`, NOT included via `{% include %}`. Reasons: (a) the static page must remain self-contained / asset-free; (b) an include couples the export to a fragment used by the live site, which is brittle if that fragment later pulls in Bootstrap classes or external icons; (c) copyright text is short and stable. Footer markup uses inline styles defined in `static_page.html` (no Bootstrap class dependency).
+5. **Per-record styling**. Repair-record `<li>` items use a small inline left-border indicator color-coded by severity using the same mapping as the equipment-level dot (`Down`→red, `Degraded`/`Not Sure`→yellow, no severity → neutral gray). Display order within the record: `[status badge] [severity badge if set] description …ETA: …`.
+6. **Generation sub-heading placement.** Below the `<h1>Equipment Status</h1>` block, right-aligned via `text-align: right` on a `.generated-at` div (new CSS rule). On narrow screens it remains right-aligned (CSS `text-align: right` is fine in single-column flow at any width).
+
+## Implementation Plan
+
+### Tasks
+
+- [ ] **Task 1: Extend `get_area_status_dashboard()` to include per-equipment open repair records.**
+  - File: `esb/services/status_service.py`
+  - Action: In the loop that builds `equip_statuses` (currently lines 238-246), add `'open_records': equip_records` to the dict appended for each equipment. The list is already on hand as `records_by_equipment.get(equip.id, [])` and is ordered by `(created_at ASC, id ASC)` from the prefetch query.
+  - Update the function's docstring (lines 170-186) to document the new `open_records` key — list of `RepairRecord` instances, ordered oldest-first.
+  - Notes: Existing callers (live `public/status_dashboard.html`, `public/kiosk.html`, `public/kiosk_area.html`) do not iterate `open_records`, so this is additive. Do **not** change `get_single_area_status_dashboard()` for now — it is used by the per-area kiosk view; out of scope.
+
+- [ ] **Task 2: Compute a local-timezone generation timestamp in `generate()`.**
+  - File: `esb/services/static_page_service.py`
+  - Action: Replace lines 22-28 (`generated_at` computation and `render_template` call) with logic that builds the timestamp using `datetime.now().astimezone()`. Try `strftime('%Y-%m-%d %H:%M %Z')`; if the resulting `%Z` portion is empty (i.e., string ends with a trailing space), fall back to `strftime('%Y-%m-%d %H:%M %z')`. Pass the string as `generated_at` to `render_template('public/static_page.html', areas=areas, generated_at=generated_at)` (template var name unchanged).
+  - Notes: Keep the import inside the function (existing pattern). No new external deps.
+
+- [ ] **Task 3: Update `static_page.html` template structure.**
+  - File: `esb/templates/public/static_page.html`
+  - Sub-actions:
+    1. **Add top-right generation sub-heading.** Immediately after `<h1>Equipment Status</h1>` (line 28), insert `<div class="generated-at">Generated: {{ generated_at }}</div>`. Add CSS rule `.generated-at { text-align: right; font-size: 0.85rem; color: #6c757d; margin-bottom: 1rem; }` in the inline `<style>` block.
+    2. **Render open-records list under non-green equipment.** Inside the `<li class="equipment-item">` loop (lines 35-40), after the existing inline status row, add a conditional block: `{% if item.status.color != 'green' and item.open_records %}<ul class="open-records-list">{% for rec in item.open_records %}<li class="open-record open-record-{{ 'red' if rec.severity == 'Down' else 'yellow' if rec.severity in ('Degraded', 'Not Sure') else 'gray' }}"><span class="record-status">{{ rec.status }}</span>{% if rec.severity %} <span class="record-severity">[{{ rec.severity }}]</span>{% endif %} <span class="record-description">{{ rec.description }}</span>{% if rec.eta %} <span class="record-eta">ETA: {{ rec.eta|format_date }}</span>{% endif %}</li>{% endfor %}</ul>{% endif %}`. Wrap the existing inline-item content in a span if needed to keep the dot/name/label on one line and push the `<ul>` to a new line — easiest: change `.equipment-item` from `flex` to `block`, wrap the dot+name+label+eta into a header `<div class="equipment-row">` with `display: flex` so the new `<ul>` lays out beneath it naturally.
+    3. **Add inline CSS for the records list.**
+       ```css
+       .open-records-list { list-style: none; margin: 0.4rem 0 0.6rem 1.5rem; }
+       .open-record { font-size: 0.85rem; padding: 0.25rem 0.4rem; margin-bottom: 0.2rem; border-left: 3px solid #6c757d; background: #fff; }
+       .open-record-red { border-left-color: #dc3545; }
+       .open-record-yellow { border-left-color: #ffc107; }
+       .open-record-gray { border-left-color: #6c757d; }
+       .record-status { font-weight: 600; }
+       .record-severity { color: #6c757d; }
+       .record-description { }
+       .record-eta { color: #6c757d; margin-left: 0.25rem; }
+       ```
+    4. **Replace bottom footer.** Delete the existing `<div class="footer">Generated: {{ generated_at }}</div>` block (lines 48-50) and the corresponding `.footer` CSS rule (line 24). Insert in its place: `<footer class="site-footer" role="contentinfo">&copy; {{ current_year }} Jason Antman. <a href="https://github.com/jantman/equipment-status-board" rel="noopener noreferrer">github.com/jantman/equipment-status-board</a> <a href="https://opensource.org/license/mit" rel="noopener noreferrer">MIT licensed</a>.</footer>`. Add CSS: `.site-footer { text-align: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #dee2e6; font-size: 0.8rem; color: #6c757d; } .site-footer a { color: #6c757d; }` — note an `<a>` selector style is required because the document has no CSS framework reset.
+  - Notes: Keep CSP unchanged (`default-src 'none'; style-src 'unsafe-inline'`). All `<a>` tags in the new footer are anchor-only (no scripts); the CSP does not need to allow `connect-src` or anything else.
+
+- [ ] **Task 4: Add tests for the new behaviors.**
+  - File: `tests/test_services/test_static_page_service.py`
+  - Add the following test cases inside `class TestGenerate`:
+    1. `test_generated_at_subheading_renders_above_areas` — Given an area with one equipment item, when `generate()` runs, then the HTML contains `<div class="generated-at">` and that string's index in the HTML is **less than** the index of the first `<div class="area">`.
+    2. `test_generated_at_uses_local_timezone_not_hardcoded_utc` — Patch `datetime` in the service to return a fixed `datetime` whose `astimezone()` yields an EST/EDT-like tzinfo (or use `datetime.now().astimezone()` and just assert the `UTC` literal does not appear in the new subheading when system tz is non-UTC; otherwise allow `UTC`). Concretely: assert the new sub-heading does **not** end with `' UTC'` UNLESS the test's local `datetime.now().astimezone().tzname() == 'UTC'`. A simpler version: monkey-patch `static_page_service.datetime` so `datetime.now().astimezone()` returns a known timestamp with `tzname() == 'EDT'`, then assert `'2026-05-11 14:32 EDT'` (or similar) appears in the HTML.
+    3. `test_open_records_listed_for_non_green_equipment` — Create equipment with one `make_repair_record(status='In Progress', severity='Down', description='Belt slipping', eta=date(2026, 6, 1))`. Assert HTML contains `'In Progress'`, `'Belt slipping'`, `'[Down]'`, and `'ETA: ' + date(2026, 6, 1).strftime('%b %d, %Y')` AND contains a `class="open-record open-record-red"` substring.
+    4. `test_open_records_omitted_for_green_equipment` — Create equipment with no repair records. Assert HTML does NOT contain `class="open-records-list"`.
+    5. `test_open_records_uses_yellow_class_for_degraded_and_not_sure` — Create two equipment items, one with severity `'Degraded'` and one with `'Not Sure'`. Assert both render `class="open-record open-record-yellow"`.
+    6. `test_open_records_uses_gray_class_for_no_severity` — Create a repair record with `severity=None` (raw). Assert `class="open-record open-record-gray"` appears AND the equipment's color falls back per `_derive_status_from_records` (yellow Degraded). Severity badge `[…]` must NOT appear since severity is `None`.
+    7. `test_open_records_omits_eta_when_unset` — Repair record with `eta=None`. Assert `record-eta` class does not appear in the rendered `<li class="open-record …">` block.
+    8. `test_open_records_ordered_by_created_at_asc` — Create two records on the same equipment, the second with an earlier `created_at`. Assert the earlier record appears first in the HTML (substring index check).
+    9. `test_site_footer_replaces_old_generated_line` — Assert HTML contains `'Jason Antman'`, `'github.com/jantman/equipment-status-board'`, and `'MIT licensed'`, AND does NOT contain `'<div class="footer">'` (the old class name).
+    10. `test_footer_renders_current_year` — Patch `datetime.now()` in `inject_current_year` (or just assert the rendered current year matches `datetime.now(timezone.utc).year`).
+    11. **Update existing `test_includes_generated_timestamp`** — it currently asserts `'UTC' in html`. Replace that assertion with `'Generated:' in html` only (timezone now depends on host); or keep `'UTC'` only if the host TZ is UTC. Safest: change to assert `'Generated:' in html`.
+  - Notes: The fixtures `make_area`, `make_equipment`, `make_repair_record` accept `area`, `name`, `status`, `severity`, `description`, `eta`, etc. as kwargs (per existing tests in this same file).
+
+- [ ] **Task 5: Run lint and full test suite.**
+  - Commands: `make lint` then `make test`.
+  - Expected: All green. Existing test `test_includes_generated_timestamp` was updated in Task 4.11; `test_produces_self_contained_html` continues to pass (no new `<link>` or `<script src=>`).
+
+### Acceptance Criteria
+
+- [ ] **AC 1 (happy path — repair list rendered):** Given a non-archived area with one equipment item whose only open repair record has `status='In Progress'`, `severity='Down'`, `description='Belt slipping'`, `eta=2026-06-01`, when `static_page_service.generate()` is called, then the returned HTML contains a `<ul class="open-records-list">` nested under that equipment's `<li class="equipment-item">` whose single `<li>` includes the substrings `In Progress`, `[Down]`, `Belt slipping`, and `ETA: Jun 01, 2026`, and has CSS class `open-record-red`.
+
+- [ ] **AC 2 (green equipment — no list):** Given a non-archived equipment item with zero open repair records, when `generate()` is called, then the HTML for that equipment contains no `open-records-list` element.
+
+- [ ] **AC 3 (multiple records — ordering):** Given one equipment item with two open repair records (record A `created_at = 2026-04-01`, record B `created_at = 2026-05-01`), when `generate()` is called, then the substring for record A appears before the substring for record B in the HTML (oldest first).
+
+- [ ] **AC 4 (severity color mapping):** Given open repair records with severities `'Down'`, `'Degraded'`, `'Not Sure'`, and `None`, when `generate()` is called, then their `<li class="open-record …">` elements receive classes `open-record-red`, `open-record-yellow`, `open-record-yellow`, and `open-record-gray` respectively, and the `None`-severity record does **not** render a `[…]` severity badge.
+
+- [ ] **AC 5 (ETA optional):** Given an open repair record with `eta=None`, when `generate()` is called, then its rendered `<li class="open-record …">` does not include a `record-eta` span and contains no `ETA:` substring.
+
+- [ ] **AC 6 (top sub-heading present and positioned):** Given any non-empty status dashboard, when `generate()` is called, then the HTML contains exactly one element matching `<div class="generated-at">` whose position in the document is after the closing tag of `<h1>Equipment Status</h1>` and before the first `<div class="area">`. Its inner text starts with `Generated: ` followed by a `YYYY-MM-DD HH:MM ` and a non-empty timezone token.
+
+- [ ] **AC 7 (local timezone, not UTC by default):** Given the host system's local timezone is set to `America/New_York` (`TZ=America/New_York`), when `generate()` is called, then the `<div class="generated-at">` content ends with either `EST` or `EDT` (depending on date), and does NOT contain the literal string `UTC` in the sub-heading. (Acceptance under containerized prod requires `TZ` to be set in `docker-compose.yml` / deployment — see Notes.)
+
+- [ ] **AC 8 (timezone fallback for unnamed offsets):** Given a `datetime.astimezone()` result whose `tzname()` returns `None` or empty string (e.g., a fixed-offset zone), when `generate()` is called, then the sub-heading contains an ISO offset like `+0000` or `-0400` instead of an empty trailing space.
+
+- [ ] **AC 9 (site footer replaces "Generated:" line):** Given any rendering, when `generate()` is called, then the HTML contains a `<footer class="site-footer">` element whose text includes `© <YEAR> Jason Antman`, an anchor to `https://github.com/jantman/equipment-status-board`, and an anchor to `https://opensource.org/license/mit` (text `MIT licensed`), AND the HTML does NOT contain the old `<div class="footer">` element.
+
+- [ ] **AC 10 (year derives from `current_year` context):** Given the current year is 2026, when `generate()` is called, then the rendered footer contains `© 2026 Jason Antman`.
+
+- [ ] **AC 11 (still self-contained):** When `generate()` is called, then the HTML contains no `<link …>` and no `<script src="…">`, and the meta CSP tag `default-src 'none'; style-src 'unsafe-inline'` is unchanged.
+
+- [ ] **AC 12 (existing assertions preserved):** Existing tests in `tests/test_services/test_static_page_service.py` continue to pass after Task 4.11's adjustment of `test_includes_generated_timestamp` (assert only `'Generated:' in html`, drop the `'UTC' in html` assertion).
+
+## Additional Context
+
+### Dependencies
+
+None new — uses existing `datetime`, Flask, Jinja2. No DB migration. No new packages.
+
+### Testing Strategy
+
+**Unit tests (pytest, SQLite in-memory per `TestingConfig`):**
+
+All new tests live in `tests/test_services/test_static_page_service.py` inside `class TestGenerate`. Use the existing fixtures: `app`, `make_area`, `make_equipment`, `make_repair_record`. Assertions are substring / index-position checks against the rendered HTML string returned by `static_page_service.generate()`.
+
+New test cases (one per AC group):
+
+| Test | Covers AC |
+| ---- | --------- |
+| `test_open_records_listed_for_non_green_equipment` | AC 1 |
+| `test_open_records_omitted_for_green_equipment` | AC 2 |
+| `test_open_records_ordered_by_created_at_asc` | AC 3 |
+| `test_open_records_uses_yellow_class_for_degraded_and_not_sure` | AC 4 |
+| `test_open_records_uses_gray_class_for_no_severity` | AC 4 (None severity branch) |
+| `test_open_records_omits_eta_when_unset` | AC 5 |
+| `test_generated_at_subheading_renders_above_areas` | AC 6 |
+| `test_generated_at_uses_local_timezone_not_hardcoded_utc` | AC 7 (monkey-patch system tz via `datetime` patch or `os.environ['TZ']` + `time.tzset()`) |
+| `test_generated_at_falls_back_to_iso_offset_when_tzname_empty` | AC 8 |
+| `test_site_footer_replaces_old_generated_line` | AC 9 |
+| `test_footer_renders_current_year` | AC 10 |
+| (existing) `test_produces_self_contained_html` | AC 11 (no change required; should still pass) |
+| (existing, modified) `test_includes_generated_timestamp` | AC 12 (drop `'UTC' in html` assertion; keep `'Generated:' in html`) |
+
+**Manual / smoke testing:**
+
+1. Apply the changes locally.
+2. Start the dev server (`make db-up && make migrate && make run`).
+3. Create at least one Area, two Equipment items, and one open `RepairRecord` per equipment (one `Down`, one `Degraded`) via the staff UI.
+4. Run `flask shell` and call `from esb.services import static_page_service; print(static_page_service.generate())` (or hit the static export path on disk via `STATIC_PAGE_PUSH_METHOD=local`).
+5. Open the resulting `index.html` in a browser. Verify:
+   - Top right under the title: `Generated: 2026-05-11 14:32 EDT` (or local zone).
+   - Under each non-green equipment item: a bullet-less list with one row per open record, colored by severity, showing status + description + ETA.
+   - Bottom: centered copyright footer with the GitHub and MIT license links.
+   - View source: no `<link>`, no `<script src=...>`, CSP meta tag unchanged.
+
+### Notes
+
+**Production timezone configuration.** The local-timezone behavior depends on the container's `TZ` env var. The current `docker-compose.yml` does not set `TZ` on the `app` or `worker` services, so a default deployment will render `UTC`. To get a true local time, the operator must set `TZ` in the `worker` service environment (it's the `worker` that calls `generate_and_push()` via the notification handler — `app` itself doesn't invoke `generate()` on a request path). This is a deployment-config concern; document it in a follow-up but do NOT modify `docker-compose.yml` as part of this spec.
+
+**Risk: timezone test flakiness.** Tests that assert the timezone abbreviation depend on the runner's `TZ`. The strategy in Task 4 is to monkey-patch the `datetime` object returned in the service (so test outcome is independent of the host TZ). Avoid asserting raw `EDT`/`EST` against the unpatched system clock — CI is typically UTC.
+
+**Risk: live dashboard regression.** Task 1 adds an `open_records` key to the dict returned by `get_area_status_dashboard()`. Existing live templates (`status_dashboard.html`, `kiosk.html`, `kiosk_area.html`) iterate the dict's `equipment` list but reference only `item.equipment` and `item.status`. Verified manually during Step 2; no template change needed for the live site. Run the full test suite (`make test`) after Task 1 to confirm no regressions.
+
+**Risk: `_derive_status_from_records` "Not Sure" mapping.** A repair record with `severity='Not Sure'` produces `color='yellow'` at the equipment level (per `_SEVERITY_STATUS`). The per-record visual treatment in the new repair list also uses yellow for `Not Sure` (Task 3.2 mapping), so the equipment dot and the record's left-border match. A record with `severity=None` is unusual (severity is nullable but the create paths set it); guard with the `gray` fallback so we never crash on a missing key.
+
+**Future / out of scope (do not implement now):**
+- Per-area kiosk static export (would require extending `get_single_area_status_dashboard()` similarly).
+- Sorting open records by severity instead of `created_at` ASC.
+- Showing `specialist_description` or `assignee` on the static page (privacy / clutter concerns).
+- Localizing the timestamp into a non-system timezone via a config var.
+
+GitHub issue #44 text:
+> 1. The static status page currently just shows a list of equipment by area and operational/degraded/down state. For degraded or down equipment this should also include a list of the open repair records, their status, ETA if set, and description.
+> 2. There is currently a small unobtrusive "Generated:" line at the bottom of the static page. Let's replace that with the copyright footer used on the live site, and add a sub-heading near the top right under "Equipment Status" that gives the generated date and time in the local/system timezone.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,9 @@ services:
       # of sync with the healthcheck command below. `environment:` overrides
       # any value coming from env_file, so this is authoritative.
       - WORKER_HEARTBEAT_PATH=/tmp/worker_heartbeat
+      # Local timezone for the static status page's "Generated:" timestamp
+      # and footer year. Override via TZ in .env for non-default deployments.
+      - TZ=${TZ:-America/New_York}
     healthcheck:
       # The worker writes /tmp/worker_heartbeat at startup, after each DB poll
       # returns, and after each individual notification is processed. If that

--- a/docs/administrators.md
+++ b/docs/administrators.md
@@ -93,6 +93,7 @@ Open `http://localhost:5000` in a browser (or the server's IP/hostname on port 5
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to Google Cloud service account JSON key file. Only needed if `STATIC_PAGE_PUSH_METHOD=gcs` and not using instance metadata or Workload Identity. | No | _(empty)_ | `/path/to/service-account.json` |
 | `NEW_RELIC_LICENSE_KEY` | New Relic license key. Enables APM and browser monitoring when set. Leave empty to disable. | No | _(empty)_ | `abc123def456...` |
 | `NEW_RELIC_APP_NAME` | Application name shown in the New Relic dashboard. | No | `Equipment Status Board` | `ESB Production` |
+| `TZ` | IANA timezone name for the worker container. Controls the timezone displayed in the static status page's generation timestamp (sub-heading near top of page) and the year used in the footer. Set this to your local timezone for accurate display. The `worker` service is the only consumer; if you set `TZ` via `.env` it will also propagate to the `app` container (currently unused there) since both services load the same env file. | No | `America/New_York` | `America/Chicago` |
 
 !!! warning
     Always set `SECRET_KEY` to a unique random value in production. The default value is insecure and only suitable for development.
@@ -255,6 +256,8 @@ Set the push method via the `STATIC_PAGE_PUSH_METHOD` environment variable:
 - **`gcs`** — Uploads the static page to a Google Cloud Storage bucket specified by `STATIC_PAGE_PUSH_TARGET`. Uses Google's default credential chain (`GOOGLE_APPLICATION_CREDENTIALS` environment variable, GCE instance metadata, or Workload Identity). When using Docker with a service account key file, add a volume mount for the credentials file in `docker-compose.yml` (e.g., `- ./service-account.json:/app/service-account.json:ro`) and set `GOOGLE_APPLICATION_CREDENTIALS=/app/service-account.json`.
 
 The static page is pushed by the background worker whenever it detects a status change during its polling cycle.
+
+The static page's generation timestamp reflects the `worker` container's `TZ` environment variable. The variable resolves against the OS tzdata database (`/usr/share/zoneinfo`), which is provided by the `tzdata` system package. Both the `python:3.14-slim` base image and this image's Dockerfile install list include `tzdata`; do not remove it. To use a non-default zone, set `TZ` in `.env` before running `docker compose up`.
 
 ## New Relic Monitoring (Optional)
 

--- a/esb/services/static_page_service.py
+++ b/esb/services/static_page_service.py
@@ -2,12 +2,37 @@
 
 import logging
 import os
+from datetime import datetime
 
 from flask import current_app, render_template
 
 from esb.utils.logging import log_mutation
 
 logger = logging.getLogger(__name__)
+
+
+def _compute_generated_at() -> tuple[str, int]:
+    """Compute the generation timestamp string and year in the system's local timezone.
+
+    Returns:
+        (timestamp_str, year) where timestamp_str is formatted like
+        '2026-05-11 14:32:15 EDT'. year is the local-tz year of the
+        same instant (datetime.astimezone() returns a datetime whose
+        .year reflects the converted zone, not the source UTC year).
+
+    Raises:
+        RuntimeError: if the local timezone has no resolvable tzname
+            (indicates the runtime is missing tzdata, e.g. a stripped
+            Docker image). The Dockerfile pins tzdata; this guard is
+            defense-in-depth against future image-content drift.
+    """
+    dt = datetime.now().astimezone()
+    tzname = dt.tzname()
+    if not tzname:
+        raise RuntimeError(
+            "Local timezone has no resolvable tzname; tzdata may be missing."
+        )
+    return (dt.strftime('%Y-%m-%d %H:%M:%S ') + tzname, dt.year)
 
 
 def generate() -> str:
@@ -19,13 +44,18 @@ def generate() -> str:
     Returns:
         Rendered HTML string (self-contained, no external dependencies).
     """
-    from datetime import UTC, datetime
-
+    from esb.models.repair_record import REPAIR_SEVERITIES
     from esb.services import status_service
 
     areas = status_service.get_area_status_dashboard()
-    generated_at = datetime.now(UTC).strftime('%Y-%m-%d %H:%M UTC')
-    return render_template('public/static_page.html', areas=areas, generated_at=generated_at)
+    generated_at, generated_year = _compute_generated_at()
+    return render_template(
+        'public/static_page.html',
+        areas=areas,
+        generated_at=generated_at,
+        generated_year=generated_year,
+        repair_severities=REPAIR_SEVERITIES,
+    )
 
 
 def push(html_content: str) -> None:

--- a/esb/services/status_service.py
+++ b/esb/services/status_service.py
@@ -253,17 +253,13 @@ def get_area_status_dashboard() -> list[dict]:
         .all()
     )
 
-    # Group open records by equipment_id
+    # Group open records by equipment_id. Lists stay in the prefetch's
+    # (created_at, id) ASC order so `_derive_status_from_records` sees the
+    # input it documents (oldest-first). `open_records` for the static page
+    # needs a different order, so we sort a copy below.
     records_by_equipment: dict[int, list[RepairRecord]] = {}
     for record in open_records:
         records_by_equipment.setdefault(record.equipment_id, []).append(record)
-
-    # Sort each per-equipment list by (severity priority, created_at) ASC.
-    # Stable sort preserves the prefetch's (created_at, id) ASC order on
-    # priority ties, so `_derive_status_from_records`'s oldest-wins tie-break
-    # is unaffected.
-    for records in records_by_equipment.values():
-        records.sort(key=_open_records_sort_key)
 
     result = []
     for area in areas:
@@ -271,10 +267,14 @@ def get_area_status_dashboard() -> list[dict]:
         for equip in equipment_by_area.get(area.id, []):
             equip_records = records_by_equipment.get(equip.id, [])
             status = _derive_status_from_records(equip_records)
+            # Sorted copy: severity-priority order for at-a-glance display
+            # on the static page. The derivation above used the original
+            # (created_at, id) ASC order per its documented contract.
+            open_records_sorted = sorted(equip_records, key=_open_records_sort_key)
             equip_statuses.append({
                 'equipment': equip,
                 'status': status,
-                'open_records': equip_records,
+                'open_records': open_records_sorted,
             })
 
         result.append({

--- a/esb/services/status_service.py
+++ b/esb/services/status_service.py
@@ -206,8 +206,8 @@ def get_area_status_dashboard() -> list[dict]:
     each equipment item, sorted by ``(severity priority ASC, created_at ASC)``.
     Unknown severities and ``None`` fold to the ``Not Sure`` priority (matching
     the equipment-level status fallback). Ties on those fields preserve the
-    prefetch query's ``(created_at, id) ASC`` order (Python's ``list.sort()``
-    is stable).
+    prefetch query's ``(created_at, id) ASC`` order (Python's ``sorted()`` is
+    stable).
     """
     areas = (
         db.session.execute(

--- a/esb/services/status_service.py
+++ b/esb/services/status_service.py
@@ -20,6 +20,22 @@ _SEVERITY_STATUS = {
     'Not Sure': ('yellow', 'Degraded', 2),
 }
 
+_NOT_SURE_PRIORITY = _SEVERITY_STATUS['Not Sure'][2]
+
+
+def _open_records_sort_key(rec):
+    """Sort key for open repair records.
+
+    Returns ``(severity priority, created_at)``. Unknown severities and
+    ``None`` fold to the ``Not Sure`` priority — same fallback the
+    equipment-level status derivation uses — so a per-record list and
+    its equipment-level dot cannot disagree about which records sort
+    above which.
+    """
+    sev_entry = _SEVERITY_STATUS.get(rec.severity)
+    priority = sev_entry[2] if sev_entry else _NOT_SURE_PRIORITY
+    return (priority, rec.created_at)
+
 
 def _get_open_records(equipment_id: int) -> list:
     """Query open (non-closed) repair records for an equipment item.
@@ -177,13 +193,21 @@ def get_area_status_dashboard() -> list[dict]:
                 'equipment': [
                     {
                         'equipment': Equipment instance,
-                        'status': {color, label, issue_description, severity, eta, assignee_name}
+                        'status': {color, label, issue_description, severity, eta, assignee_name},
+                        'open_records': [RepairRecord, ...],
                     },
                     ...
                 ]
             },
             ...
         ]
+
+    ``open_records`` is the list of non-closed ``RepairRecord`` instances for
+    each equipment item, sorted by ``(severity priority ASC, created_at ASC)``.
+    Unknown severities and ``None`` fold to the ``Not Sure`` priority (matching
+    the equipment-level status fallback). Ties on those fields preserve the
+    prefetch query's ``(created_at, id) ASC`` order (Python's ``list.sort()``
+    is stable).
     """
     areas = (
         db.session.execute(
@@ -234,6 +258,13 @@ def get_area_status_dashboard() -> list[dict]:
     for record in open_records:
         records_by_equipment.setdefault(record.equipment_id, []).append(record)
 
+    # Sort each per-equipment list by (severity priority, created_at) ASC.
+    # Stable sort preserves the prefetch's (created_at, id) ASC order on
+    # priority ties, so `_derive_status_from_records`'s oldest-wins tie-break
+    # is unaffected.
+    for records in records_by_equipment.values():
+        records.sort(key=_open_records_sort_key)
+
     result = []
     for area in areas:
         equip_statuses = []
@@ -243,6 +274,7 @@ def get_area_status_dashboard() -> list[dict]:
             equip_statuses.append({
                 'equipment': equip,
                 'status': status,
+                'open_records': equip_records,
             })
 
         result.append({

--- a/esb/templates/public/static_page.html
+++ b/esb/templates/public/static_page.html
@@ -8,11 +8,13 @@
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #212529; background: #f8f9fa; padding: 1rem; }
-        h1 { font-size: 1.5rem; margin-bottom: 1rem; text-align: center; }
+        h1 { font-size: 1.5rem; margin-bottom: 0.25rem; text-align: center; }
+        .generated-at { text-align: right; font-size: 0.85rem; color: #6c757d; margin-bottom: 1rem; }
         .area { margin-bottom: 1.5rem; }
         .area h2 { font-size: 1.1rem; border-bottom: 2px solid #dee2e6; padding-bottom: 0.3rem; margin-bottom: 0.5rem; }
         .equipment-list { list-style: none; }
-        .equipment-item { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; padding: 0.25rem 0; }
+        .equipment-item { display: block; padding: 0.25rem 0; }
+        .equipment-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
         .status-dot { width: 12px; height: 12px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
         .status-green { background-color: #198754; }
         .status-yellow { background-color: #ffc107; }
@@ -21,11 +23,22 @@
         .status-label { font-size: 0.8rem; color: #6c757d; }
         .eta-label { font-size: 0.8rem; color: #6c757d; margin-left: 0.25rem; }
         .no-equipment { color: #6c757d; font-size: 0.9rem; }
-        .footer { text-align: center; margin-top: 2rem; font-size: 0.75rem; color: #6c757d; }
+        .open-records-list { list-style: none; margin: 0.4rem 0 0.6rem 1.5rem; }
+        .open-record { font-size: 0.85rem; padding: 0.25rem 0.4rem; margin-bottom: 0.2rem; border-left: 3px solid #6c757d; background: #fff; }
+        .open-record-red { border-left-color: #dc3545; }
+        .open-record-yellow { border-left-color: #ffc107; }
+        .open-record-gray { border-left-color: #6c757d; }
+        .record-status { font-weight: 600; }
+        .record-severity { color: #6c757d; }
+        .record-description { white-space: pre-wrap; overflow-wrap: anywhere; }
+        .record-eta { color: #6c757d; margin-left: 0.25rem; }
+        .site-footer { text-align: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #dee2e6; font-size: 0.8rem; color: #6c757d; word-break: break-word; }
+        .site-footer a { color: #6c757d; }
     </style>
 </head>
 <body>
     <h1>Equipment Status</h1>
+    <div class="generated-at">Generated: {{ generated_at }}</div>
     {% for area_data in areas %}
     <div class="area">
         <h2>{{ area_data.area.name }}</h2>
@@ -33,10 +46,28 @@
         <ul class="equipment-list">
             {% for item in area_data.equipment %}
             <li class="equipment-item">
-                <span class="status-dot status-{{ item.status.color }}" aria-hidden="true"></span>
-                <span class="equipment-name">{{ item.equipment.name }}</span>
-                <span class="status-label">{{ item.status.label }}</span>
-                {% if item.status.eta %}<span class="eta-label">ETA: {{ item.status.eta|format_date }}</span>{% endif %}
+                <div class="equipment-row">
+                    <span class="status-dot status-{{ item.status.color }}" aria-hidden="true"></span>
+                    <span class="equipment-name">{{ item.equipment.name }}</span>
+                    <span class="status-label">{{ item.status.label }}</span>
+                    {% if item.status.eta %}<span class="eta-label">ETA: {{ item.status.eta|format_date }}</span>{% endif %}
+                </div>
+                {% if item.status.color != 'green' and item.open_records %}
+                {# The color chain below is intentionally hardcoded against the
+                   three canonical severities, NOT derived from `repair_severities`:
+                   color is a per-severity semantic decision (red/yellow/gray) that
+                   must be made deliberately when a new severity is added to
+                   REPAIR_SEVERITIES. The badge guard `rec.severity in
+                   repair_severities` is auto-derived for the same reason — text
+                   surfacing is safe to extend automatically, color isn't. #}
+                <ul class="open-records-list">
+                    {% for rec in item.open_records %}
+                    <li class="open-record open-record-{{ 'red' if rec.severity == 'Down' else 'yellow' if rec.severity in ('Degraded', 'Not Sure') else 'gray' }}">
+                        <span class="record-status">{{ rec.status }}</span>{% if rec.severity in repair_severities %} <span class="record-severity">[{{ rec.severity }}]</span>{% endif %} <span class="record-description">{{ rec.description }}</span>{% if rec.eta %} <span class="record-eta">ETA: {{ rec.eta|format_date }}</span>{% endif %}
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
             </li>
             {% endfor %}
         </ul>
@@ -45,8 +76,8 @@
         {% endif %}
     </div>
     {% endfor %}
-    <div class="footer">
-        Generated: {{ generated_at }}
-    </div>
+    <footer class="site-footer" role="contentinfo" aria-label="Site copyright and license">
+        <small>&copy; {{ generated_year }} Jason Antman. <a href="https://github.com/jantman/equipment-status-board" rel="noopener noreferrer" aria-label="Source code on GitHub">github.com/jantman/equipment-status-board</a> <a href="https://opensource.org/license/mit" rel="noopener noreferrer" aria-label="MIT License (opensource.org)">MIT licensed</a>.</small>
+    </footer>
 </body>
 </html>

--- a/tests/test_services/test_static_page_service.py
+++ b/tests/test_services/test_static_page_service.py
@@ -156,7 +156,12 @@ class TestGenerate:
             html = static_page_service.generate()
 
         assert 'Generated: 2026-05-11 14:32:15 EDT' in html
-        assert '2026' in html
+        # Scope the year check to <footer> with the entity prefix so a regression
+        # to a wrong footer year isn't masked by the timestamp's '2026'.
+        footer_start = html.find('<footer class="site-footer"')
+        footer_end = html.find('</footer>', footer_start)
+        assert footer_start != -1 and footer_end != -1
+        assert '&copy; 2026 Jason Antman' in html[footer_start:footer_end]
 
     def test_compute_generated_at_formats_tzname(self, app):
         """_compute_generated_at() formats datetime + tzname correctly."""

--- a/tests/test_services/test_static_page_service.py
+++ b/tests/test_services/test_static_page_service.py
@@ -282,8 +282,16 @@ class TestGenerate:
 
         html = static_page_service.generate()
 
-        assert 'open-record-gray' in html
-        assert '<span class="record-severity">' not in html
+        # Scope to the open-records-list and anchor on the rendered element
+        # form, not the bare class name (which also appears in the inline
+        # CSS rule .open-record-gray { ... }).
+        list_start = html.find('<ul class="open-records-list">')
+        list_end = html.find('</ul>', list_start)
+        assert list_start != -1 and list_end != -1
+        record_block = html[list_start:list_end]
+
+        assert 'class="open-record open-record-gray"' in record_block
+        assert '<span class="record-severity">' not in record_block
 
     def test_open_records_uses_gray_class_and_suppresses_badge_for_unknown_severity(
         self, app, make_area, make_equipment, make_repair_record,
@@ -295,9 +303,17 @@ class TestGenerate:
 
         html = static_page_service.generate()
 
-        assert 'open-record-gray' in html
-        assert '<span class="record-severity">' not in html
-        assert '[Critical]' not in html
+        # Scope to the open-records-list and anchor on the rendered element
+        # form, not the bare class name (which also appears in the inline
+        # CSS rule .open-record-gray { ... }).
+        list_start = html.find('<ul class="open-records-list">')
+        list_end = html.find('</ul>', list_start)
+        assert list_start != -1 and list_end != -1
+        record_block = html[list_start:list_end]
+
+        assert 'class="open-record open-record-gray"' in record_block
+        assert '<span class="record-severity">' not in record_block
+        assert '[Critical]' not in record_block
 
     def test_open_records_omits_eta_when_unset(
         self, app, make_area, make_equipment, make_repair_record,

--- a/tests/test_services/test_static_page_service.py
+++ b/tests/test_services/test_static_page_service.py
@@ -2,9 +2,13 @@
 
 import json
 import os
+import re
+from datetime import UTC, date, datetime, tzinfo
 from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
 
 import pytest
+from jinja2.exceptions import TemplateNotFound
 
 from esb.services import static_page_service
 
@@ -43,23 +47,33 @@ class TestGenerate:
         assert 'status-green' in html
 
     def test_includes_generated_timestamp(self, app, make_area, make_equipment):
-        """generate() includes a generation timestamp."""
+        """generate() includes a generation timestamp in the expected position and format."""
         area = make_area(name='TestArea')
         make_equipment(name='TestEquip', area=area)
 
         html = static_page_service.generate()
 
         assert 'Generated:' in html
-        assert 'UTC' in html
+        # Pin format end-to-end: the helper output must actually be interpolated
+        # into the .generated-at sub-heading (not just exist somewhere on the page).
+        assert re.search(
+            r'<div class="generated-at">Generated: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \S+</div>',
+            html,
+        )
 
-    def test_includes_csp_meta_tag(self, app, make_area, make_equipment):
-        """generate() includes Content-Security-Policy meta tag."""
+    def test_csp_meta_tag_directive_unchanged(self, app, make_area, make_equipment):
+        """generate() includes the exact CSP directive on the meta tag (no policy weakening)."""
         area = make_area(name='TestArea')
         make_equipment(name='TestEquip', area=area)
 
         html = static_page_service.generate()
 
-        assert 'Content-Security-Policy' in html
+        # Pin the directive to the <meta> element to catch a regression that
+        # moves the same string into a comment / data attribute / unrelated tag.
+        assert (
+            '<meta http-equiv="Content-Security-Policy" '
+            'content="default-src \'none\'; style-src \'unsafe-inline\';">'
+        ) in html
 
     def test_renders_yellow_status_for_degraded_equipment(self, app, make_area, make_equipment, make_repair_record):
         """generate() renders status-yellow for equipment with Degraded severity repair."""
@@ -113,6 +127,409 @@ class TestGenerate:
         )
         html = static_page_service.generate()
         assert 'ETA:' not in html
+
+    def test_generated_at_subheading_renders_above_areas(self, app, make_area, make_equipment):
+        """The generated-at sub-heading renders below the <h1> and above the first area."""
+        area = make_area(name='TestArea')
+        make_equipment(name='TestEquip', area=area)
+
+        html = static_page_service.generate()
+
+        h1_close = html.find('</h1>')
+        gen_at = html.find('<div class="generated-at">')
+        first_area = html.find('<div class="area">')
+        assert h1_close != -1
+        assert gen_at != -1
+        assert first_area != -1
+        assert h1_close < gen_at < first_area
+
+    def test_generated_at_uses_local_timezone_helper(self, app, make_area, make_equipment):
+        """generate() interpolates the helper's timestamp string and year."""
+        area = make_area(name='TestArea')
+        make_equipment(name='TestEquip', area=area)
+
+        with patch.object(
+            static_page_service,
+            '_compute_generated_at',
+            return_value=('2026-05-11 14:32:15 EDT', 2026),
+        ):
+            html = static_page_service.generate()
+
+        assert 'Generated: 2026-05-11 14:32:15 EDT' in html
+        assert '2026' in html
+
+    def test_compute_generated_at_formats_tzname(self, app):
+        """_compute_generated_at() formats datetime + tzname correctly."""
+        fixed_dt = datetime(2026, 7, 15, 14, 32, 15, tzinfo=ZoneInfo('America/New_York'))
+        with patch.object(static_page_service, 'datetime') as mock_datetime:
+            mock_datetime.now.return_value.astimezone.return_value = fixed_dt
+            result = static_page_service._compute_generated_at()
+        assert result == ('2026-07-15 14:32:15 EDT', 2026)
+
+    def test_compute_generated_at_raises_on_empty_tzname(self, app):
+        """_compute_generated_at() raises RuntimeError on empty/missing tzname."""
+
+        class _EmptyTZ(tzinfo):
+            def utcoffset(self, dt):
+                from datetime import timedelta
+                return timedelta(0)
+
+            def tzname(self, dt):
+                return ''
+
+            def dst(self, dt):
+                from datetime import timedelta
+                return timedelta(0)
+
+        fixed_dt = datetime(2026, 1, 1, 12, 0, 0, tzinfo=_EmptyTZ())
+        with patch.object(static_page_service, 'datetime') as mock_datetime:
+            mock_datetime.now.return_value.astimezone.return_value = fixed_dt
+            with pytest.raises(RuntimeError, match='tzname'):
+                static_page_service._compute_generated_at()
+
+    def test_compute_generated_at_raises_on_none_tzname(self, app):
+        """AC 7c covers both None and empty-string; pin the None branch too."""
+
+        class _NoneTZ(tzinfo):
+            def utcoffset(self, dt):
+                from datetime import timedelta
+                return timedelta(0)
+
+            def tzname(self, dt):
+                return None
+
+            def dst(self, dt):
+                from datetime import timedelta
+                return timedelta(0)
+
+        fixed_dt = datetime(2026, 1, 1, 12, 0, 0, tzinfo=_NoneTZ())
+        with patch.object(static_page_service, 'datetime') as mock_datetime:
+            mock_datetime.now.return_value.astimezone.return_value = fixed_dt
+            with pytest.raises(RuntimeError, match='tzname'):
+                static_page_service._compute_generated_at()
+
+    def test_compute_generated_at_format_matches_regex(self, app):
+        """End-to-end (unpatched) helper output matches the expected format."""
+        result = static_page_service._compute_generated_at()
+        assert re.fullmatch(r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \S+', result[0])
+
+    def test_open_records_listed_for_non_green_equipment(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """A non-green equipment item renders its open records nested under it."""
+        area = make_area(name='Shop')
+        eq = make_equipment(name='Lathe', area=area)
+        make_repair_record(
+            equipment=eq, status='In Progress', severity='Down',
+            description='Belt slipping', eta=date(2026, 6, 1),
+        )
+
+        html = static_page_service.generate()
+
+        # Scope per-record assertions to inside the open-records-list so they
+        # don't accidentally match the equipment-row eta-label (which mirrors
+        # the same date via item.status.eta).
+        list_start = html.find('<ul class="open-records-list">')
+        list_end = html.find('</ul>', list_start)
+        assert list_start != -1 and list_end != -1
+        record_block = html[list_start:list_end]
+
+        assert 'In Progress' in record_block
+        assert '[Down]' in record_block
+        assert 'Belt slipping' in record_block
+        eta_str = date(2026, 6, 1).strftime('%b %d, %Y')
+        assert f'<span class="record-eta">ETA: {eta_str}</span>' in record_block
+        assert 'class="open-record open-record-red"' in record_block
+
+    def test_open_records_omitted_for_green_equipment(
+        self, app, make_area, make_equipment,
+    ):
+        """Green equipment items do not render an <ul class=\"open-records-list\">."""
+        area = make_area(name='Shop')
+        make_equipment(name='Lathe', area=area)
+
+        html = static_page_service.generate()
+
+        # The class name appears in the inline CSS rule; only the element
+        # presence is meaningful, so match the rendered element form.
+        assert '<ul class="open-records-list">' not in html
+
+    def test_open_records_uses_yellow_class_for_degraded_and_not_sure(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """Degraded and Not Sure both render with the yellow severity class and a text badge."""
+        area = make_area(name='Shop')
+        eq1 = make_equipment(name='ToolA', area=area)
+        eq2 = make_equipment(name='ToolB', area=area)
+        make_repair_record(equipment=eq1, severity='Degraded', description='deg-issue')
+        make_repair_record(equipment=eq2, severity='Not Sure', description='ns-issue')
+
+        html = static_page_service.generate()
+
+        # Anchor to the rendered element form, not the bare class name (which
+        # also appears in the inline CSS rule .open-record-yellow { ... }).
+        assert html.count('class="open-record open-record-yellow"') == 2
+        assert '[Degraded]' in html
+        assert '[Not Sure]' in html
+
+    def test_open_records_uses_gray_class_for_no_severity(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """severity=None renders the gray class and suppresses the text badge (R3F3)."""
+        area = make_area(name='Shop')
+        eq = make_equipment(name='ToolN', area=area)
+        make_repair_record(equipment=eq, severity=None, description='no-sev-issue')
+
+        html = static_page_service.generate()
+
+        assert 'open-record-gray' in html
+        assert '<span class="record-severity">' not in html
+
+    def test_open_records_uses_gray_class_and_suppresses_badge_for_unknown_severity(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """Unknown severity strings render gray with no text badge (R3F3)."""
+        area = make_area(name='Shop')
+        eq = make_equipment(name='ToolU', area=area)
+        make_repair_record(equipment=eq, severity='Critical', description='unknown-sev')
+
+        html = static_page_service.generate()
+
+        assert 'open-record-gray' in html
+        assert '<span class="record-severity">' not in html
+        assert '[Critical]' not in html
+
+    def test_open_records_omits_eta_when_unset(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """Records with eta=None render no <span class=\"record-eta\">."""
+        area = make_area(name='Shop')
+        eq = make_equipment(name='OnlyOne', area=area)
+        make_repair_record(equipment=eq, severity='Down', eta=None)
+
+        html = static_page_service.generate()
+
+        # The class name appears in the inline CSS rule; only the element
+        # presence is meaningful, so match the rendered element form.
+        assert '<span class="record-eta">' not in html
+
+    def test_open_records_sorted_by_severity_priority_then_created_at(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """Open records are rendered in (severity priority, created_at) ASC order."""
+        area = make_area(name='Shop')
+        eq = make_equipment(name='OneTool', area=area)
+        make_repair_record(
+            equipment=eq, severity='Down',
+            created_at=datetime(2026, 5, 1, tzinfo=UTC),
+            description='down-newer',
+        )
+        make_repair_record(
+            equipment=eq, severity='Not Sure',
+            created_at=datetime(2026, 4, 1, tzinfo=UTC),
+            description='notsure-older',
+        )
+        make_repair_record(
+            equipment=eq, severity='Degraded',
+            created_at=datetime(2026, 4, 15, tzinfo=UTC),
+            description='degraded-mid',
+        )
+
+        html = static_page_service.generate()
+
+        i_down = html.find('down-newer')
+        i_deg = html.find('degraded-mid')
+        i_ns = html.find('notsure-older')
+        assert -1 < i_down < i_deg < i_ns
+
+    def test_site_footer_replaces_old_generated_line(
+        self, app, make_area, make_equipment,
+    ):
+        """Footer markup pins role, aria-labels, and link text; old <div class=\"footer\"> is gone."""
+        area = make_area(name='Shop')
+        make_equipment(name='Tool', area=area)
+
+        html = static_page_service.generate()
+
+        assert '<footer class="site-footer"' in html
+        assert 'role="contentinfo"' in html
+        assert 'aria-label="Site copyright and license"' in html
+        assert '<small>' in html
+        assert 'Jason Antman' in html
+        assert 'aria-label="Source code on GitHub"' in html
+        assert 'aria-label="MIT License (opensource.org)"' in html
+        assert 'github.com/jantman/equipment-status-board' in html
+        assert 'MIT licensed' in html
+        assert '<div class="footer">' not in html
+
+    def test_footer_renders_local_tz_year_as_entity(
+        self, app, make_area, make_equipment,
+    ):
+        """The footer renders the local-tz year with a literal &copy; entity (Jinja does not decode)."""
+        area = make_area(name='Shop')
+        make_equipment(name='Tool', area=area)
+
+        with patch.object(
+            static_page_service,
+            '_compute_generated_at',
+            return_value=('2027-01-01 00:00:00 EST', 2027),
+        ):
+            html = static_page_service.generate()
+
+        # Scope to inside <footer> so a regression that leaks the copyright
+        # text into .generated-at (or elsewhere) doesn't accidentally pass.
+        footer_start = html.find('<footer class="site-footer"')
+        footer_end = html.find('</footer>', footer_start)
+        assert footer_start != -1 and footer_end != -1
+        assert '&copy; 2027 Jason Antman' in html[footer_start:footer_end]
+
+    def test_footer_text_pin(self, app, make_area, make_equipment):
+        """The static page contains the load-bearing substrings from _footer.html (R3F13)."""
+        area = make_area(name='Shop')
+        make_equipment(name='Tool', area=area)
+
+        try:
+            source = app.jinja_env.loader.get_source(
+                app.jinja_env, 'components/_footer.html',
+            )[0]
+        except TemplateNotFound as e:
+            raise AssertionError(
+                "_footer.html not found — has it been moved or renamed? "
+                "Update this pin test's path."
+            ) from e
+
+        # Sanity: the substrings we are pinning actually appear in the source.
+        for needle in (
+            'Jason Antman',
+            'https://github.com/jantman/equipment-status-board',
+            'https://opensource.org/license/mit',
+        ):
+            assert needle in source
+
+        html = static_page_service.generate()
+        for needle in (
+            'Jason Antman',
+            'https://github.com/jantman/equipment-status-board',
+            'https://opensource.org/license/mit',
+        ):
+            assert needle in html
+
+    def test_description_is_html_escaped(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """Repair-record descriptions are HTML-escaped (XSS defense)."""
+        area = make_area(name='Shop')
+        eq = make_equipment(name='Tool', area=area)
+        make_repair_record(
+            equipment=eq, severity='Down',
+            description='<script>alert(1)</script><img src=x onerror=y>',
+        )
+
+        html = static_page_service.generate()
+
+        assert '&lt;script&gt;' in html
+        assert '<script>alert(1)</script>' not in html
+
+    def test_description_escapes_entity_content(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """Entity-content in descriptions is autoescaped (R3F11)."""
+        area = make_area(name='Shop')
+        eq = make_equipment(name='Tool', area=area)
+        make_repair_record(
+            equipment=eq, severity='Down',
+            description='Bob & Alice broke it; price was 50%<',
+        )
+
+        html = static_page_service.generate()
+
+        assert 'Bob &amp; Alice broke it' in html
+        assert '50%&lt;' in html
+        assert 'Bob & Alice' not in html
+
+    def test_equipment_row_keeps_dot_name_label_on_one_line(
+        self, app, make_area, make_equipment,
+    ):
+        """The dot/name/label substrings appear within the equipment-row wrapper in order."""
+        area = make_area(name='Shop')
+        make_equipment(name='Tool', area=area)
+
+        html = static_page_service.generate()
+
+        row_start = html.find('<div class="equipment-row">')
+        assert row_start != -1
+        row_end = html.find('</div>', row_start)
+        assert row_end != -1
+        slice_ = html[row_start:row_end]
+        i_dot = slice_.find('status-dot')
+        i_name = slice_.find('equipment-name')
+        i_label = slice_.find('status-label')
+        assert -1 < i_dot < i_name < i_label
+
+    def test_description_uses_prewrap_styles(self, app):
+        """The pre-wrap CSS rule appears verbatim in the inline style block."""
+        html = static_page_service.generate()
+        assert (
+            '.record-description { white-space: pre-wrap; overflow-wrap: anywhere; }'
+            in html
+        )
+
+    def test_archived_areas_and_equipment_are_excluded(
+        self, app, make_area, make_equipment,
+    ):
+        """Archived areas and archived equipment do not appear in the rendered HTML."""
+        # Archived area, with one equipment item, should not appear.
+        from esb.extensions import db as _db
+        from esb.models.area import Area
+
+        archived_area = Area(name='Archived Area', is_archived=True)
+        _db.session.add(archived_area)
+        _db.session.commit()
+        make_equipment(name='Archived Tool', area=archived_area)
+
+        active_area = make_area(name='Active Area')
+        make_equipment(name='Active Tool', area=active_area)
+
+        html = static_page_service.generate()
+        assert 'Active Area' in html
+        assert 'Archived Area' not in html
+
+        # Within an active area: archived equipment is excluded.
+        area = make_area(name='Visible Area', slack_channel='#visible')
+        make_equipment(name='Visible Tool', area=area)
+        make_equipment(name='Retired Tool', area=area, is_archived=True)
+
+        html2 = static_page_service.generate()
+        assert 'Visible Tool' in html2
+        assert 'Retired Tool' not in html2
+
+    def test_empty_dashboard_renders_skeleton(self, app):
+        """With no non-archived areas, the page still renders the skeleton."""
+        html = static_page_service.generate()
+
+        assert '<h1>Equipment Status</h1>' in html
+        assert '<div class="generated-at">' in html
+        assert '<footer class="site-footer"' in html
+        assert '<div class="area">' not in html
+
+    def test_two_equipment_with_same_name_in_different_areas(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """Same equipment name in different areas: records appear under correct area."""
+        area_a = make_area(name='Area A', slack_channel='#area-a')
+        area_b = make_area(name='Area B', slack_channel='#area-b')
+        eq_a = make_equipment(name='Drill Press', area=area_a)
+        eq_b = make_equipment(name='Drill Press', area=area_b)
+        make_repair_record(equipment=eq_a, severity='Down', description='a-issue')
+        make_repair_record(equipment=eq_b, severity='Down', description='b-issue')
+
+        html = static_page_service.generate()
+
+        i_a = html.find('Area A')
+        i_a_issue = html.find('a-issue')
+        i_b = html.find('Area B')
+        i_b_issue = html.find('b-issue')
+        assert -1 < i_a < i_a_issue < i_b < i_b_issue
 
 
 class TestPushLocal:

--- a/tests/test_services/test_status_service.py
+++ b/tests/test_services/test_status_service.py
@@ -273,6 +273,73 @@ class TestGetAreaStatusDashboard:
         area_names = [r['area'].name for r in result]
         assert area_names == ['Electronics Lab', 'Metal Shop', 'Woodshop']
 
+    def test_includes_open_records_list_per_equipment(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """open_records is a list of non-closed RepairRecord instances."""
+        from esb.models.repair_record import RepairRecord
+
+        area = make_area(name='Shop')
+        eq = make_equipment(name='Tool', area=area)
+        make_repair_record(equipment=eq, status='New', severity='Down', description='one')
+        make_repair_record(equipment=eq, status='In Progress', severity='Degraded', description='two')
+        make_repair_record(equipment=eq, status='Resolved', severity='Down', description='closed')
+
+        result = status_service.get_area_status_dashboard()
+
+        records = result[0]['equipment'][0]['open_records']
+        assert isinstance(records, list)
+        assert len(records) == 2
+        assert all(isinstance(r, RepairRecord) for r in records)
+        descriptions = {r.description for r in records}
+        assert descriptions == {'one', 'two'}
+
+    def test_open_records_sorted_by_severity_then_created_at(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """Sort key: (severity priority ASC, created_at ASC). Unknown sev folds to Not Sure priority."""
+        from datetime import UTC, datetime
+
+        area = make_area(name='Shop')
+        eq = make_equipment(name='Tool', area=area)
+        make_repair_record(
+            equipment=eq, status='New', severity='Down', description='down',
+            created_at=datetime(2026, 5, 1, tzinfo=UTC),
+        )
+        make_repair_record(
+            equipment=eq, status='New', severity='Not Sure', description='notsure',
+            created_at=datetime(2026, 4, 1, tzinfo=UTC),
+        )
+        make_repair_record(
+            equipment=eq, status='New', severity='Degraded', description='degraded',
+            created_at=datetime(2026, 4, 15, tzinfo=UTC),
+        )
+        make_repair_record(
+            equipment=eq, status='New', severity=None, description='nosev',
+            created_at=datetime(2026, 3, 1, tzinfo=UTC),
+        )
+        make_repair_record(
+            equipment=eq, status='New', severity='Critical', description='unknown',
+            created_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+
+        result = status_service.get_area_status_dashboard()
+        records = result[0]['equipment'][0]['open_records']
+        descriptions = [r.description for r in records]
+        # Down (priority 0), Degraded (priority 1), then priority 2 tied on
+        # created_at ASC: Critical (Feb), nosev (Mar), Not Sure (Apr).
+        assert descriptions == ['down', 'degraded', 'unknown', 'nosev', 'notsure']
+
+    def test_empty_open_records_list_for_green_equipment(
+        self, app, make_area, make_equipment,
+    ):
+        """Equipment with no open records has open_records == []."""
+        area = make_area(name='Shop')
+        make_equipment(name='Tool', area=area)
+
+        result = status_service.get_area_status_dashboard()
+        assert result[0]['equipment'][0]['open_records'] == []
+
 
 class TestGetEquipmentStatusDetail:
     """Tests for get_equipment_status_detail()."""


### PR DESCRIPTION
Closes #44.

## Summary
- Static status page now lists each non-green equipment item's open repair records (status, canonical-severity textual badge, description, ETA), color-coded by severity.
- Bottom "Generated:" line replaced with a proper site footer (copyright + a11y attributes) mirroring the live site's `_footer.html`.
- Generation timestamp moved to a right-aligned sub-heading near the top, rendered in the worker container's local timezone (`TZ=${TZ:-America/New_York}` by default).
- `tzdata` defensively pinned in the Dockerfile against future base-image drift.

## Test plan
- [x] `make lint` clean
- [x] `make test` — 1422 tests passing
- [ ] Manual smoke: run `make db-up && make migrate && make run`, create areas + equipment + open repair records (mix of `Down`, `Degraded`, `Not Sure`, `None`/unknown severities; one multi-line description; one 200+ char description), then call `flask shell` → `from esb.services import static_page_service; print(static_page_service.generate())` and inspect output for layout, color, sort order, footer markup
- [ ] Docker production smoke: `TZ=America/New_York docker compose run --rm worker python -c "from esb.services.static_page_service import _compute_generated_at; print(_compute_generated_at())"` — confirm output like `('2026-05-12 14:32:15 EDT', 2026)`
- [ ] If pushing to S3/GCS: verify the new HTML uploads correctly and no CSP violations in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)