### PR TITLE
Issue #43: Duplicate repair association

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-duplicate-repair-association.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-duplicate-repair-association.md
@@ -15,11 +15,14 @@ tech_stack:
   - 'pytest + Flask test client'
 files_to_modify:
   - 'esb/models/repair_record.py'
+  - 'esb/models/repair_timeline_entry.py'
   - 'esb/services/repair_service.py'
+  - 'esb/extensions.py'
   - 'esb/forms/repair_forms.py'
   - 'esb/views/repairs.py'
   - 'esb/templates/repairs/edit.html'
   - 'esb/templates/repairs/detail.html'
+  - 'esb/templates/components/_timeline_entry.html'
   - 'esb/slack/forms.py'
   - 'esb/slack/handlers.py'
   - 'migrations/versions/{new}_add_duplicated_repair_id.py'
@@ -84,6 +87,10 @@ Add a nullable `duplicated_repair_id` foreign key on `repair_records` pointing b
 - Audit logging: the existing `update_repair_record` audit-changes mechanism already produces an entry like `'duplicated_repair_id': [old_str, new_str]` — no extra code beyond adding the field to `_REPAIR_UPDATABLE_FIELDS`.
 - Tests covering: model column + relationship, service validation (positive + each negative case), web view form rendering + submission, Slack action modal flow including zero-candidates edge case, and Slack create modal filter.
 
+**Authorization (unchanged):**
+
+- No new authorization surfaces. The web edit route is already gated by `@role_required('technician')` (`esb/views/repairs.py:289`) and the Slack action modal flow already gates on `esb_user.role in ('technician', 'staff')` (`esb/slack/handlers.py:538-542`). Both gates apply unchanged to the new field — members cannot reach the duplicate-of dropdown via any path.
+
 **Out of Scope:**
 
 - Backfilling existing rows that already have `Closed - Duplicate` status — they keep `duplicated_repair_id = NULL`. Editing such legacy rows for non-status fields must remain possible (see Technical Decisions §3.c).
@@ -115,6 +122,7 @@ Add a nullable `duplicated_repair_id` foreign key on `repair_records` pointing b
 | ---- | ------- |
 | `esb/models/repair_record.py` (lines 23-59) | Add `duplicated_repair_id` column + `duplicated_repair` self-relationship. `REPAIR_STATUSES` constant (lines 7-18) already contains `'Closed - Duplicate'` — no enum change. |
 | `esb/services/repair_service.py` (line 22) | Add `'duplicated_repair_id'` to `_REPAIR_UPDATABLE_FIELDS`. |
+| `esb/models/repair_timeline_entry.py` (lines 7-14 `TIMELINE_ENTRY_TYPES`) | Append `'duplicated_repair_id_change'` so the constant remains authoritative. |
 | `esb/services/repair_service.py` (lines 470-637) | Modify `update_repair_record`: add validation block (see Technical Decisions §3), add timeline entry for the field, the rest of the existing flow handles audit/log. |
 | `esb/services/repair_service.py` (after line 217) | New `list_duplicate_candidates(repair_record_id)` helper near `list_repair_records`. |
 | `esb/services/repair_service.py` (line 220 `CLOSED_STATUSES`) | Reference: already includes `'Closed - Duplicate'`. |
@@ -138,25 +146,25 @@ Add a nullable `duplicated_repair_id` foreign key on `repair_records` pointing b
 
 2. **No status-enum change.** `Closed - Duplicate` is already in `REPAIR_STATUSES` (model line 17). We're adding a paired-field constraint, not a new status value.
 
-3. **Validation lives in the service layer, conditionally.** Three rules in `update_repair_record`:
+3. **Validation lives in the service layer, conditionally.** Three rules in `update_repair_record`. **All rules key on real *transitions*, not idempotent re-submissions** — the web form always POSTs the current `status` value, so `'status' in changes` is true even when the value matches the record. To avoid breaking the legacy carve-out, the rules check `changes['status'] != record.status` before treating something as a transition.
 
-   **a. Status transition to `Closed - Duplicate` requires a target.**
-   If `'status' in changes and changes['status'] == 'Closed - Duplicate'`:
+   **a. Status transition *to* `Closed - Duplicate` requires a target.**
+   If `'status' in changes and changes['status'] == 'Closed - Duplicate' and record.status != 'Closed - Duplicate'`:
    - `effective_dup_id = changes.get('duplicated_repair_id', record.duplicated_repair_id)`
    - `effective_dup_id` must not be `None` → else `ValidationError("'Closed - Duplicate' requires a duplicated_repair_id")`.
    - `effective_dup_id != repair_record_id` → else `ValidationError("A repair cannot be a duplicate of itself")`.
    - target = `db.session.get(RepairRecord, effective_dup_id)` must exist → else `ValidationError(f"Duplicated repair {effective_dup_id} not found")`.
    - `target.equipment_id == record.equipment_id` → else `ValidationError("Duplicated repair must be on the same equipment")`.
 
-   **b. Explicitly setting `duplicated_repair_id` to non-None requires status to be `Closed - Duplicate`.**
+   **b. Explicitly setting `duplicated_repair_id` to non-None requires status is/becomes `Closed - Duplicate`.**
    If `'duplicated_repair_id' in changes and changes['duplicated_repair_id'] is not None`:
-   - `effective_status = changes.get('status', record.status)` must equal `'Closed - Duplicate'` → else `ValidationError("duplicated_repair_id may only be set when status is 'Closed - Duplicate'")`.
+   - `effective_status = changes.get('status', record.status)` must equal `'Closed - Duplicate'` → else `ValidationError("duplicated_repair_id cannot be set unless status is 'Closed - Duplicate' (defense-in-depth: web UI hides the field and Slack omits it from non-Closed-Duplicate flows)")`.
    - Plus same-equipment / non-self / target-exists checks as in (a).
 
-   **c. Status moving *away* from `Closed - Duplicate` auto-clears `duplicated_repair_id`.**
-   If `'status' in changes and changes['status'] != 'Closed - Duplicate'` and `record.duplicated_repair_id is not None` and `'duplicated_repair_id' not in changes`: implicitly inject `changes['duplicated_repair_id'] = None`. This is the only "silent" mutation — it audit-logs as `{'duplicated_repair_id': [old, None]}` via the normal flow.
+   **c. Status transition *away* from `Closed - Duplicate` auto-clears `duplicated_repair_id`.**
+   If `'status' in changes and changes['status'] != 'Closed - Duplicate' and record.status == 'Closed - Duplicate'` and `record.duplicated_repair_id is not None` and `'duplicated_repair_id' not in changes`: implicitly inject `changes['duplicated_repair_id'] = None`. This is the only "silent" mutation — it audit-logs as `{'duplicated_repair_id': [old, None]}` via the normal flow. **UX requirement:** callers (web view, Slack handler) must detect that this auto-clear happened (by comparing pre-update `record.duplicated_repair_id` vs post-update value) and surface a user-visible notice so the disappearing link is not silent at the UI layer.
 
-   **Legacy-record carve-out:** Note that rule (a) only fires when `'status' in changes` — i.e., a status *transition* to `Closed - Duplicate`. A row that already has `status='Closed - Duplicate'` and `duplicated_repair_id=NULL` (legacy data) can still be edited for unrelated fields (e.g., a note, a specialist_description) without tripping validation. This is intentional.
+   **Legacy-record carve-out:** Because rule (a) requires `record.status != 'Closed - Duplicate'` (a real transition), a legacy row with `status='Closed - Duplicate'` and `duplicated_repair_id=NULL` can be edited for unrelated fields (note, specialist_description) without tripping validation — the form re-asserting the existing status is a no-op transition. Rule (b) also tolerates legacy state: it only fires when a non-None `duplicated_repair_id` is explicitly set, and a legacy record's NULL value passed through the form stays NULL (treated as no-op since `record.duplicated_repair_id is None == changes['duplicated_repair_id'] is None`).
 
 4. **The duplicate target's status is unrestricted.** A repair can be marked as a duplicate of any other repair on the same equipment, including another `Closed - Duplicate` one or an already-resolved one. Avoids forcing users to find the "root" duplicate; staff can follow the chain if needed. **No cycle detection** — chains are operationally harmless and detection adds complexity.
 
@@ -166,7 +174,16 @@ Add a nullable `duplicated_repair_id` foreign key on `repair_records` pointing b
 
 7. **Web UI: conditional JS show/hide on status select.** Inline `<script>` watches the status `<select>` `change` event; toggles `style.display` on the duplicate-block wrapper. Default visibility on GET matches `record.status == 'Closed - Duplicate'`. The duplicate dropdown is always rendered server-side with full candidate list (no AJAX), regardless of the current status — display is a CSS concern only. **No-JS fallback:** without JS the block is always visible (`display:block` default) — degraded but functional; users can still submit. This matches the simplicity of the existing form; the repo has no client-side framework.
 
-8. **Description excerpt cap of 60 chars in dropdown labels.** Slack `static_select` option `text.text` has a 75-char limit. Format `#{id} [{status}] {desc[:60]}` worst-case: `#999999 [Closed - No Issue Found] ` ≈ 35 chars + 60 chars = ~95 chars. We further truncate the whole label with `[:75]` (consistent with `build_equipment_options` lines 184). Web select option text is rendered HTML — same 60-char excerpt for visual consistency.
+8. **Status-aware description budget in dropdown labels.** Slack `static_select` option `text.text` has a 75-char limit. Naive `desc[:60]` plus a worst-case prefix overflows: `#999999 [Closed - No Issue Found] ` is 35 chars; that leaves only 40 chars for the description before hitting 75, and naive `[:75]` truncation would slice mid-string with no ellipsis. The spec uses a *status-aware* budget computed at option-build time:
+    ```python
+    def _build_label(r):
+        prefix = f'#{r.id} [{r.status}] '
+        budget = 75 - len(prefix)
+        if len(r.description) <= budget:
+            return prefix + r.description
+        return prefix + r.description[: max(0, budget - 1)].rstrip() + '…'
+    ```
+    This guarantees the label fits in 75 chars and emits an ellipsis when truncated. The Slack implementation should also call the existing `_truncate` helper (`esb/slack/forms.py:13-17`) for consistency where applicable. Web `<select>` option text uses the same logic for visual consistency.
 
 9. **Self-referential FK with `remote_side`:** the model relationship uses `db.relationship('RepairRecord', remote_side=[id])` to disambiguate "the one I duplicate" from the implicit reverse "the ones that duplicate me." We do not add a `backref` for the reverse direction (deferred — out of scope per issue scope).
 
@@ -174,7 +191,7 @@ Add a nullable `duplicated_repair_id` foreign key on `repair_records` pointing b
 
 11. **Web UI create form is not affected.** `RepairRecordCreateForm` doesn't expose `status` (status is hardcoded to `'New'` by `create_repair_record`), so no filter is needed on the web create path.
 
-12. **Timeline entry for duplicated_repair_id changes.** Add a new `entry_type='duplicated_repair_id_change'` with `old_value`/`new_value` as stringified IDs (or `None` for absent). Renders in the existing timeline component (`components/_timeline_entry.html`) — verify it handles unknown entry_types gracefully or extend that template if needed (small follow-up task).
+12. **Timeline entry for duplicated_repair_id changes.** Add a new `entry_type='duplicated_repair_id_change'` with `old_value`/`new_value` as stringified IDs (or `None` for absent). **Both the model-level constant `TIMELINE_ENTRY_TYPES` (`esb/models/repair_timeline_entry.py`) and the template `components/_timeline_entry.html` must be updated together** — the constant is authoritative, and the template currently renders only the six existing types (unknown types render as blank list items). Tasks 5 step 4 and Task 11 cover these respectively.
 
 ## Implementation Plan
 
@@ -194,10 +211,27 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
   - Action: Per CLAUDE.md migration workflow: `docker compose up -d db`, `docker inspect equipment-status-board-db-1 --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'`, then `DATABASE_URL="mysql+pymysql://root:esb_dev_password@<IP>/esb" venv/bin/flask db migrate -m "Add duplicated_repair_id to repair_records"`. Inspect the generated file and ensure: `op.batch_alter_table('repair_records')` adds the column, the FK constraint includes `ondelete='SET NULL'`, and the index `ix_repair_records_duplicated_repair_id` is created. Add the index manually if Alembic missed it. Verify `downgrade()` drops index → constraint → column in reverse order. Apply with `flask db upgrade`.
   - Notes: Alembic sometimes drops `ondelete='SET NULL'` from autogen — verify and patch.
 
-- [ ] **Task 3: Model-layer tests.**
-  - File: `tests/test_models/test_repair_record.py`
-  - Action: Add tests asserting (a) the new column is nullable on a fresh record, (b) setting `duplicated_repair_id` and accessing `.duplicated_repair` loads the target, (c) deleting the target via `db.session.delete(target); commit()` nulls the child's FK on refresh.
-  - Notes: SQLite enforces FK ON DELETE SET NULL only when `PRAGMA foreign_keys=ON` — confirm the testing config enables this, or accept that the FK-cascade test is skipped under SQLite and add an integration smoke note instead.
+- [ ] **Task 3: Model-layer tests + SQLite FK pragma enablement.**
+  - Files: `tests/test_models/test_repair_record.py`, `esb/extensions.py` (or wherever the SQLAlchemy engine is configured for tests).
+  - Action:
+    1. **Enable SQLite FK enforcement in the test config.** SQLite does NOT enforce `ON DELETE SET NULL` by default. Add a SQLAlchemy `engine_connect` (or `connect`) event listener — gated to SQLite dialects only — that issues `PRAGMA foreign_keys=ON` per connection. Standard pattern:
+       ```python
+       from sqlalchemy import event
+       from sqlalchemy.engine import Engine
+
+       @event.listens_for(Engine, 'connect')
+       def _sqlite_fk_pragma(dbapi_conn, _):
+           # Only the SQLite driver exposes a cursor that accepts PRAGMA.
+           # MariaDB connections will fail this isinstance check and skip.
+           import sqlite3
+           if isinstance(dbapi_conn, sqlite3.Connection):
+               cursor = dbapi_conn.cursor()
+               cursor.execute('PRAGMA foreign_keys=ON')
+               cursor.close()
+       ```
+       Place this in a module that loads at app/test startup (e.g., near the bottom of `esb/extensions.py` after `db = SQLAlchemy()`). If a similar listener already exists, just confirm it's active in the test config.
+    2. Add tests asserting (a) the new column is nullable on a fresh record, (b) setting `duplicated_repair_id` and accessing `.duplicated_repair` loads the target, (c) deleting the target via `db.session.delete(target); commit()` nulls the child's FK on refresh.
+  - Notes: If enabling the pragma globally is undesirable (it changes behavior for the whole test suite, which could surface latent FK violations in unrelated tests), the fallback is to mark AC-2's automated test `@pytest.mark.skipif` for SQLite and verify ON DELETE SET NULL only in a manual integration smoke against MariaDB. Prefer enabling the pragma — surfacing latent FK violations is a feature, not a regression.
 
 #### Phase 2: Service Layer
 
@@ -222,15 +256,25 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
   - File: `esb/services/repair_service.py`
   - Action:
     1. Line 22: append `'duplicated_repair_id'` to `_REPAIR_UPDATABLE_FIELDS`.
-    2. In `update_repair_record` (line 470+), after the existing input validations (after line 507, before `note = changes.pop(...)`), insert the validation block per Technical Decisions §3:
+    2. In `update_repair_record` (line 470+), after the existing input validations (after line 507, before `note = changes.pop(...)`), insert the validation block per Technical Decisions §3. **Note the transition guards — all rules require `record.status` to differ from `changes['status']` so the web form re-asserting an unchanged status is a no-op (preserves the legacy carve-out):**
        ```python
        effective_status = changes.get('status', record.status)
        effective_dup_id = changes.get('duplicated_repair_id', record.duplicated_repair_id)
 
-       transitioning_to_closed_dup = 'status' in changes and changes['status'] == 'Closed - Duplicate'
-       setting_dup_explicit = 'duplicated_repair_id' in changes and changes['duplicated_repair_id'] is not None
+       transitioning_to_closed_dup = (
+           'status' in changes
+           and changes['status'] == 'Closed - Duplicate'
+           and record.status != 'Closed - Duplicate'
+       )
+       setting_dup_explicit = (
+           'duplicated_repair_id' in changes
+           and changes['duplicated_repair_id'] is not None
+           and changes['duplicated_repair_id'] != record.duplicated_repair_id
+       )
        transitioning_away_from_closed_dup = (
-           'status' in changes and changes['status'] != 'Closed - Duplicate'
+           'status' in changes
+           and changes['status'] != 'Closed - Duplicate'
+           and record.status == 'Closed - Duplicate'
        )
 
        if transitioning_to_closed_dup:
@@ -241,7 +285,7 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
        if setting_dup_explicit:
            if effective_status != 'Closed - Duplicate':
                raise ValidationError(
-                   "duplicated_repair_id may only be set when status is 'Closed - Duplicate'",
+                   "duplicated_repair_id cannot be set unless status is 'Closed - Duplicate'",
                )
        if transitioning_to_closed_dup or setting_dup_explicit:
            target_id = effective_dup_id
@@ -255,7 +299,8 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
                    'Duplicated repair must be on the same equipment',
                )
 
-       # Silent clear when status moves away from Closed - Duplicate
+       # Silent clear when status transitions away from Closed - Duplicate.
+       # Callers must surface a user-visible notice -- see Tasks 8 and 15.
        if (
            transitioning_away_from_closed_dup
            and record.duplicated_repair_id is not None
@@ -264,6 +309,7 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
            changes['duplicated_repair_id'] = None
        ```
     3. In the per-field timeline-entry loop (line 519+), add an `elif field_name == 'duplicated_repair_id':` branch emitting `RepairTimelineEntry(repair_record_id=record.id, entry_type='duplicated_repair_id_change', author_id=author_id, author_name=updated_by, old_value=str(old_value) if old_value is not None else None, new_value=str(new_value) if new_value is not None else None)`.
+    4. In `esb/models/repair_timeline_entry.py`, append `'duplicated_repair_id_change'` to `TIMELINE_ENTRY_TYPES` (line 7-14). This constant is the authoritative list of legal entry_type values; adding the new type without updating it leaves the constant stale and breaks any future code that validates against it.
   - Notes: `audit_changes['duplicated_repair_id']` and `log_mutation` flow through automatically because the field is now in `_REPAIR_UPDATABLE_FIELDS`. Place validation BEFORE the unknown-keys check at line 513.
 
 - [ ] **Task 6: Service-layer tests.**
@@ -285,36 +331,38 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
     ```
   - Notes: `0` is the unselected sentinel (consistent with `assignee_id`).
 
-- [ ] **Task 8: Populate dropdown choices and pass through in `repairs.edit` view.**
+- [ ] **Task 8: Populate dropdown choices, pass through in `repairs.edit` view, and surface silent-clear UX.**
   - File: `esb/views/repairs.py`
   - Action: In `edit()` (line 288+):
-    1. After the assignee choices (around line 306), add:
+    1. After the assignee choices (around line 306), add (use `_truncate` from `esb/slack/forms.py` or inline equivalent to budget the label safely; see Technical Decisions §8):
        ```python
        candidates = repair_service.list_duplicate_candidates(id)
+       def _candidate_label(c):
+           prefix = f'#{c.id} [{c.status}] '
+           budget = 75 - len(prefix)
+           desc = c.description if len(c.description) <= budget else c.description[: max(0, budget - 1)].rstrip() + '…'
+           return prefix + desc
        form.duplicated_repair_id.choices = [(0, '-- Select duplicate of --')] + [
-           (c.id, f'#{c.id} [{c.status}] {c.description[:60]}') for c in candidates
+           (c.id, _candidate_label(c)) for c in candidates
        ]
        ```
     2. On GET (~line 308-314) add `form.duplicated_repair_id.data = record.duplicated_repair_id or 0`.
-    3. In the validated POST branch (line 316+), add to the `update_repair_record(...)` call:
-       ```python
-       duplicated_repair_id=(
-           form.duplicated_repair_id.data if form.duplicated_repair_id.data != 0 else None
-       ),
-       ```
-  - Notes: Service raises `ValidationError` on invalid combos → existing `flash + re-render` flow handles it.
+    3. In the validated POST branch (line 316+):
+       a. **Before** calling `update_repair_record`, capture `had_dup_link = (record.status == 'Closed - Duplicate' and record.duplicated_repair_id is not None)` and `target_status = form.status.data`.
+       b. Pass into the service call: `duplicated_repair_id=(form.duplicated_repair_id.data if form.duplicated_repair_id.data != 0 else None)`.
+       c. **After** the call returns successfully (before the existing success-flash + redirect), surface the silent-clear when it happened: if `had_dup_link and target_status != 'Closed - Duplicate'`, flash an `info` message: `'Duplicate link cleared because status changed away from "Closed - Duplicate".'`
+  - Notes:
+    - Service `ValidationError` surfaces via the existing `flash(str(e), 'danger')` + re-render flow (lines 329-331). It does **NOT** populate `form.duplicated_repair_id.errors`; the inline form-error rendering in the template is a no-op for this field (no WTForms-layer validators are defined that would produce errors), and is kept only for consistency with sibling fields.
+    - The silent-clear flash MUST fire before the "Repair record updated successfully." flash so users see both messages in order.
 
 - [ ] **Task 9: Conditional duplicate-block in `repairs/edit.html`.**
   - File: `esb/templates/repairs/edit.html`
-  - Action: After the status block (after line 26), insert:
+  - Action: After the status block (after line 26), insert (note: no inline `form.duplicated_repair_id.errors` block — WTForms-layer validation does not apply to this field; the only errors come from the service layer and are surfaced via flash messages, not field errors):
     ```html
     <div id="duplicate-block" class="mb-3"{% if form.status.data != 'Closed - Duplicate' %} style="display: none;"{% endif %}>
         <label for="duplicated_repair_id" class="form-label">Duplicate of *</label>
-        {{ form.duplicated_repair_id(class="form-select" ~ (" is-invalid" if form.duplicated_repair_id.errors else "")) }}
+        {{ form.duplicated_repair_id(class="form-select") }}
         <div class="form-text">Required when status is "Closed - Duplicate".</div>
-        {% for error in form.duplicated_repair_id.errors %}
-        <div class="invalid-feedback">{{ error }}</div>
-        {% endfor %}
     </div>
     ```
     Inside `{% block content %}`, after the closing `</form>` and before `{% endblock %}`, append:
@@ -329,7 +377,9 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
     })();
     </script>
     ```
-  - Notes: No-JS fallback is `display:block` (visible). Inline script is consistent with the repo's no-framework template style.
+  - Notes:
+    - No-JS fallback is `display:block` (visible). Inline script is consistent with the repo's no-framework template style.
+    - Service `ValidationError` surfaces through `flash(str(e), 'danger')` (existing pattern at `views/repairs.py:329-331`), rendered by the layout's flash component on the re-rendered edit page. Do NOT route service errors through `form.duplicated_repair_id.errors` — keep the layers separated as in sibling fields.
 
 - [ ] **Task 10: Render "Marked as duplicate of" link on the detail page.**
   - File: `esb/templates/repairs/detail.html`
@@ -358,7 +408,7 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
 
 - [ ] **Task 12: Web view tests.**
   - File: `tests/test_views/test_repair_views.py`
-  - Action: Extend `TestRepairEdit` (line 183+) with tests covering AC-14 through AC-19 (form rendering, valid submit, missing-dup-id error, status-away clearing, detail-page link).
+  - Action: Extend `TestRepairEdit` (line 183+) with tests covering AC-14 through AC-18, including the silent-clear info flash assertion (AC-18 explicit requirement: response body of the redirected detail page contains the string `'Duplicate link cleared'`). Use `follow_redirects=True` for AC-18's flash assertion so the redirected page is rendered.
 
 #### Phase 4: Slack
 
@@ -366,17 +416,35 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
   - File: `esb/slack/forms.py`
   - Action: In `build_repair_create_modal` (line 318+, status block at ~line 396-413), change the options comprehension to `[ ... for s in REPAIR_STATUSES if s != 'Closed - Duplicate']`.
 
-- [ ] **Task 14: Add duplicate-of block to `build_repair_action_modal`; handle zero-candidates.**
+- [ ] **Task 14: Add duplicate-of block to `build_repair_action_modal`; handle zero-candidates; replace hardcoded status options.**
   - File: `esb/slack/forms.py`
   - Action: In `build_repair_action_modal(repair_record)` (line 626+):
-    1. At the top of the function, call `from esb.services import repair_service` then `candidates = repair_service.list_duplicate_candidates(repair_record.id)`.
-    2. Compute `status_options` for the status dropdown: start from the current hardcoded list (`In Progress`, `Closed - Duplicate`, `Closed - No Issue Found`); if `not candidates`, drop `Closed - Duplicate`.
-    3. Use `status_options` to populate the status block (replacing the hardcoded options list at lines 698-702).
-    4. After the note block, if `candidates`:
+    1. **First**, near the top of the function body, fetch candidates via a function-local (lazy) import to avoid any future circular-import risk between `slack/forms.py` and `services/repair_service.py`:
        ```python
+       from esb.services import repair_service  # local: avoid module-level cycle
+       candidates = repair_service.list_duplicate_candidates(repair_record.id)
+       ```
+    2. **Compute `status_options` dynamically.** Start from `[('In Progress', 'In Progress'), ('Closed - Duplicate', 'Closed - Duplicate'), ('Closed - No Issue Found', 'Closed - No Issue Found')]`. If `not candidates`, drop the `Closed - Duplicate` tuple.
+    3. **DELETE the hardcoded options list currently at lines 698-702** (the `'options': [{'text': ..., 'text': 'In Progress'} ... ]` literal in the status block) and replace it with options built from `status_options`:
+       ```python
+       'options': [
+           {'text': {'type': 'plain_text', 'text': label}, 'value': value}
+           for value, label in status_options
+       ],
+       ```
+       **This deletion is the most error-prone step** — a developer who appends new logic without removing the literal will leave `Closed - Duplicate` always present and silently break AC-20.
+    4. After the note block, if `candidates`, append the duplicate block. Use the status-aware label helper (Technical Decisions §8):
+       ```python
+       def _label(r):
+           prefix = f'#{r.id} [{r.status}] '
+           budget = 75 - len(prefix)
+           if len(r.description) <= budget:
+               return prefix + r.description
+           return prefix + r.description[: max(0, budget - 1)].rstrip() + '…'
+
        dup_options = [
            {
-               'text': {'type': 'plain_text', 'text': f'#{r.id} [{r.status}] {r.description[:60]}'[:75]},
+               'text': {'type': 'plain_text', 'text': _label(r)},
                'value': str(r.id),
            }
            for r in candidates
@@ -394,38 +462,45 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
            'label': {'type': 'plain_text', 'text': "Duplicate of (used when 'Set Status → Closed - Duplicate' chosen)"},
        })
        ```
-  - Notes: `optional: True` so the modal can be submitted with action != set_status. Server-side validation enforces presence when needed.
+       (Alternatively, lift `_label` to module scope or import `_truncate` from this file and use it for the description portion.)
+  - Notes: `optional: True` so the modal can be submitted with action != set_status. Server-side validation enforces presence when needed. The lazy import in step 1 follows the same pattern used in `repair_service.py:38` (`from esb.services import notification_service`).
 
-- [ ] **Task 15: Handle duplicate selection in `handle_repair_action_submission`.**
+- [ ] **Task 15: Handle duplicate selection (and silent-clear UX) in `handle_repair_action_submission`.**
   - File: `esb/slack/handlers.py`
-  - Action: In the `elif action == 'set_status':` branch (~line 598-605), after `changes['status'] = status_opt['value']`, add:
-    ```python
-    if changes['status'] == 'Closed - Duplicate':
-        dup_opt = (
-            values.get('duplicate_block', {})
-            .get('duplicated_repair_id', {})
-            .get('selected_option')
-        )
-        if not dup_opt:
-            ack(response_action='errors', errors={
-                'duplicate_block': 'Selecting which repair this duplicates is required.',
-            })
-            return
-        try:
-            changes['duplicated_repair_id'] = int(dup_opt['value'])
-        except (KeyError, TypeError, ValueError):
-            ack(response_action='errors', errors={
-                'duplicate_block': 'Invalid duplicate selection.',
-            })
-            return
-    ```
-  - Notes: Service-layer ValidationError (e.g., cross-equipment from a stale modal) still surfaces on `action_block` via the existing exception handler.
+  - Action:
+    1. In the `elif action == 'set_status':` branch (~line 598-605), after `changes['status'] = status_opt['value']`, add:
+       ```python
+       if changes['status'] == 'Closed - Duplicate':
+           dup_opt = (
+               values.get('duplicate_block', {})
+               .get('duplicated_repair_id', {})
+               .get('selected_option')
+           )
+           if not dup_opt:
+               ack(response_action='errors', errors={
+                   'duplicate_block': 'Selecting which repair this duplicates is required.',
+               })
+               return
+           try:
+               changes['duplicated_repair_id'] = int(dup_opt['value'])
+           except (KeyError, TypeError, ValueError):
+               ack(response_action='errors', errors={
+                   'duplicate_block': 'Invalid duplicate selection.',
+               })
+               return
+       ```
+    2. Capture pre-update state for the silent-clear UX surface (place this earlier, alongside the existing record fetch on line ~554):
+       ```python
+       had_dup_link = (record.status == 'Closed - Duplicate' and record.duplicated_repair_id is not None)
+       ```
+    3. In the post-success ephemeral message section (~line 658-671), when the action is `set_status` and `had_dup_link and changes.get('status') != 'Closed - Duplicate'`, append a second line to the ephemeral text or post a second ephemeral message: `':information_source: Duplicate link cleared because status changed away from "Closed - Duplicate".'`
+  - Notes: Service-layer ValidationError (e.g., cross-equipment from a stale modal — see AC-25 race-condition case) still surfaces on `action_block` via the existing exception handler.
 
 - [ ] **Task 16: Slack tests.**
   - Files: `tests/test_slack/test_handlers.py`, `tests/test_slack/test_forms.py`
   - Action:
-    - `test_forms.py`: tests for AC-20 (action modal with candidates includes duplicate_block), AC-21 (zero candidates omits block + filters status option), AC-22 (create modal filters status option).
-    - `test_handlers.py`: extend `TestRepairActionSubmission` with AC-23 (successful Closed-Dup submission), AC-24 (missing duplicate selection returns inline error).
+    - `test_forms.py`: tests for AC-19 (action modal with candidates includes duplicate_block), AC-20 (zero candidates omits block + filters status option), AC-21 (create modal filters status option), plus a test for the status-aware label budget (Technical Decisions §8) — assert no option's `text.text` exceeds 75 chars when the candidate's description is artificially long.
+    - `test_handlers.py`: extend `TestRepairActionSubmission` with AC-22 (successful Closed-Dup submission, including silent-clear ephemeral assertion when applicable), AC-23 (missing duplicate selection returns inline error), and AC-24 (stale-modal race: target deleted between modal-build and submit — assert service ValidationError surfaces via `ack(response_action='errors', errors={'action_block': ...})` and that `update_repair_record`'s effect is rolled back / R1 unchanged).
 
 #### Phase 5: Verify
 
@@ -446,7 +521,7 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
 
 - **AC-4** Given an open repair R1 and another open repair R2 on the same equipment, when `update_repair_record(R1.id, updated_by='u', author_id=u.id, status='Closed - Duplicate', duplicated_repair_id=R2.id)` is called, then R1.status becomes `'Closed - Duplicate'`, R1.duplicated_repair_id becomes R2.id, a timeline entry of type `duplicated_repair_id_change` is created with `new_value == str(R2.id)`, and `repair_record.updated` is emitted in the mutation log with `changes['duplicated_repair_id'] == [None, str(R2.id)]`.
 
-- **AC-5** Given an open repair R1, when `update_repair_record(R1.id, status='Closed - Duplicate', ...)` is called WITHOUT `duplicated_repair_id`, then `ValidationError` is raised with a message containing `'Closed - Duplicate'` and `duplicated_repair_id`, and R1 is unchanged.
+- **AC-5** Given an open repair R1 with current `status != 'Closed - Duplicate'`, when `update_repair_record(R1.id, status='Closed - Duplicate', ...)` is called WITHOUT `duplicated_repair_id`, then `ValidationError` is raised with a message containing `'Closed - Duplicate'` and `duplicated_repair_id`, and R1 is unchanged. (Validation fires only on real transitions; idempotent re-submissions of the same status are handled by AC-11.)
 
 - **AC-6** Given an open repair R1, when `update_repair_record(R1.id, status='Closed - Duplicate', duplicated_repair_id=R1.id, ...)` is called, then `ValidationError` is raised with "cannot be a duplicate of itself".
 
@@ -458,7 +533,7 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
 
 - **AC-10** Given a repair R1 with `status='Closed - Duplicate'` and `duplicated_repair_id=R2.id`, when `update_repair_record(R1.id, status='In Progress', ...)` is called, then R1.duplicated_repair_id becomes NULL, `audit_changes['duplicated_repair_id'] == [str(R2.id), None]`, and a `duplicated_repair_id_change` timeline entry is created with `new_value is None`.
 
-- **AC-11** (Legacy carve-out) Given a repair R1 with `status='Closed - Duplicate'` and `duplicated_repair_id=None` (legacy data), when `update_repair_record(R1.id, specialist_description='x', ...)` is called, then the call succeeds without raising `ValidationError` and R1.specialist_description equals `'x'`.
+- **AC-11** (Legacy carve-out) Given a repair R1 with `status='Closed - Duplicate'` and `duplicated_repair_id=None` (legacy data), when `update_repair_record(R1.id, status='Closed - Duplicate', specialist_description='x', ...)` is called (with `status` re-asserted by the form but unchanged from the record), then the call succeeds without raising `ValidationError` and R1.specialist_description equals `'x'`. This is the path the web edit form exercises whenever a staff member edits a legacy `Closed - Duplicate` record for any non-status field; Rule 3a's transition guard (`record.status != 'Closed - Duplicate'`) makes the idempotent re-assertion a no-op.
 
 **Service layer — helper**
 
@@ -476,7 +551,7 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
 
 - **AC-17** Given an open repair R1, when a staff client POSTs `/repairs/R1/edit` with `status='Closed - Duplicate'` and `duplicated_repair_id=0`, then the response is `200` (no redirect), a `flash` of category `danger` is rendered containing the service ValidationError message, and `db.session.get(RepairRecord, R1.id).status` is unchanged.
 
-- **AC-18** Given a repair R1 with `status='Closed - Duplicate'` and `duplicated_repair_id=R2.id`, when a staff client POSTs `/repairs/R1/edit` with `status='In Progress'` (no duplicated_repair_id in the form), then the response is `302`, `R1.duplicated_repair_id` is `None`, and the detail page no longer shows the "Marked as duplicate of" row.
+- **AC-18** Given a repair R1 with `status='Closed - Duplicate'` and `duplicated_repair_id=R2.id`, when a staff client POSTs `/repairs/R1/edit` with `status='In Progress'` (no duplicated_repair_id in the form), then the response is `302`, `R1.duplicated_repair_id` is `None`, the detail page no longer shows the "Marked as duplicate of" row, AND an `info` flash containing the string `'Duplicate link cleared'` is rendered on the redirected detail page.
 
 **Slack**
 
@@ -490,10 +565,12 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
 
 - **AC-23** Given an open repair R1 and another R2 on the same equipment, when the action-modal handler is invoked with `action=set_status`, status=`Closed - Duplicate`, and no `duplicate_block.duplicated_repair_id.selected_option`, then `ack` is called with `response_action='errors'` and `errors['duplicate_block']` set to the "Selecting which repair this duplicates is required." string, and `update_repair_record` is NOT called.
 
+- **AC-24** (Stale-modal race) Given an open repair R1, when (a) `build_repair_action_modal(R1)` is called and the resulting view contains an option for R2; (b) R2 is then deleted from the database in another session; (c) the Slack handler is invoked with that view's submitted state (action=`set_status`, status=`Closed - Duplicate`, `duplicate_block.duplicated_repair_id.selected_option.value == str(R2.id)`); then the service raises `ValidationError("Duplicated repair {R2.id} not found")`, the handler calls `ack(response_action='errors', errors={'action_block': <message>})`, R1 is unchanged, and no ephemeral confirmation is posted. (This race is acceptable — the service is the source of truth — but the test asserts the failure surfaces cleanly rather than crashing the handler.)
+
 **Cross-cutting**
 
-- **AC-24** `make lint` reports no new violations after all changes.
-- **AC-25** `make test` passes with the new tests included.
+- **AC-25** `make lint` reports no new violations after all changes.
+- **AC-26** `make test` passes with the new tests included.
 
 ## Additional Context
 
@@ -505,12 +582,12 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
 
 ### Testing Strategy
 
-- **Unit tests (model layer):** model column nullability, FK behavior, relationship loading. See Task 3.
-- **Unit tests (service layer):** `TestListDuplicateCandidates` (4 cases) + `TestDuplicatedRepairId` (8 cases covering AC-4 through AC-11). See Task 6.
-- **Unit tests (Slack forms):** modal-builder dict-shape assertions (AC-19, AC-20, AC-21). See Task 16a.
-- **Integration tests (Slack handlers):** action-modal submission via `_register_and_capture` helper with MagicMock client (AC-22, AC-23). See Task 16b.
-- **Integration tests (web views):** Flask test client POSTs with `follow_redirects=False`, asserting redirects, DB state, and rendered HTML (AC-14 through AC-18). See Task 12.
-- **Manual smoke test:** after `make run` + `make worker`, exercise the full flow in a browser: create two repairs on one equipment, transition one to `Closed - Duplicate` with the other as target, verify the detail page link, verify the timeline entry. Then via Slack (if `SLACK_SOCKET_MODE_CONNECT=true`): `/esb-repair`, pick the repair, `Set Status → Closed - Duplicate`, pick the duplicate, verify ephemeral confirmation and DB state.
+- **Unit tests (model layer):** model column nullability, FK behavior (with SQLite `PRAGMA foreign_keys=ON` enabled per Task 3), relationship loading. See Task 3.
+- **Unit tests (service layer):** `TestListDuplicateCandidates` (4 cases) + `TestDuplicatedRepairId` (8 cases covering AC-4 through AC-11, including the legacy carve-out's transition-guard semantics from Technical Decisions §3). See Task 6.
+- **Unit tests (Slack forms):** modal-builder dict-shape assertions (AC-19, AC-20, AC-21) + label-budget assertion (no option text exceeds 75 chars). See Task 16.
+- **Integration tests (Slack handlers):** action-modal submission via `_register_and_capture` helper with MagicMock client (AC-22, AC-23, AC-24 stale-modal race). See Task 16.
+- **Integration tests (web views):** Flask test client POSTs with `follow_redirects=False` for redirect+DB-state assertions; `follow_redirects=True` for the silent-clear flash assertion (AC-18). Covers AC-14 through AC-18. See Task 12.
+- **Manual smoke test:** after `make run` + `make worker`, exercise the full flow in a browser: create two repairs on one equipment, transition one to `Closed - Duplicate` with the other as target, verify the detail page link, verify the timeline entry, then transition back to `In Progress` and verify the info flash about the cleared duplicate link. Then via Slack (if `SLACK_SOCKET_MODE_CONNECT=true`): `/esb-repair`, pick the repair, `Set Status → Closed - Duplicate`, pick the duplicate, verify ephemeral confirmation and DB state, then transition back and verify the second-line ephemeral about the cleared link.
 
 ### Notes
 

--- a/_bmad-output/implementation-artifacts/tech-spec-duplicate-repair-association.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-duplicate-repair-association.md
@@ -1,0 +1,523 @@
+---
+title: 'Duplicate Repair Association'
+slug: 'duplicate-repair-association'
+created: '2026-05-13'
+status: 'ready-for-dev'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack:
+  - 'Python 3.14'
+  - 'Flask + Flask-SQLAlchemy 3.x'
+  - 'Alembic (via Flask-Migrate)'
+  - 'Flask-WTF / WTForms'
+  - 'Slack Bolt SDK (Socket Mode)'
+  - 'Jinja2 + Bootstrap (server-rendered templates)'
+  - 'MariaDB 12.x (prod), SQLite in-memory (tests)'
+  - 'pytest + Flask test client'
+files_to_modify:
+  - 'esb/models/repair_record.py'
+  - 'esb/services/repair_service.py'
+  - 'esb/forms/repair_forms.py'
+  - 'esb/views/repairs.py'
+  - 'esb/templates/repairs/edit.html'
+  - 'esb/templates/repairs/detail.html'
+  - 'esb/slack/forms.py'
+  - 'esb/slack/handlers.py'
+  - 'migrations/versions/{new}_add_duplicated_repair_id.py'
+  - 'tests/test_models/test_repair_record.py'
+  - 'tests/test_services/test_repair_service.py'
+  - 'tests/test_views/test_repair_views.py'
+  - 'tests/test_slack/test_handlers.py'
+  - 'tests/test_slack/test_forms.py'
+code_patterns:
+  - 'service-layer mutations with ValidationError + log_mutation after commit'
+  - '_REPAIR_UPDATABLE_FIELDS allowlist + **changes kwargs in update_repair_record'
+  - 'Flask-WTF SelectField with choices populated in view (coerce=int, 0-sentinel for None)'
+  - 'Slack Block Kit static_select; all action-modal fields visible, server resolves which apply'
+  - 'Audit log changes dict with [old, new] pairs; per-field timeline entries'
+  - 'Alembic batch_alter_table for adding columns/FKs/indexes'
+test_patterns:
+  - 'pytest classes grouping by behavior; fixtures `make_equipment`, `make_repair_record`, `staff_client`, `tech_client`, `capture`'
+  - 'service-layer tests assert DB state via `_db.session.get(RepairRecord, id)` after expire_all()'
+  - 'Slack handler tests use _register_and_capture helper, MagicMock client, build view dicts inline'
+  - 'View tests post form data with follow_redirects=False and assert 302 Location'
+issue: 43
+---
+
+# Tech-Spec: Duplicate Repair Association
+
+**Created:** 2026-05-13
+
+**GitHub Issue:** [#43 Duplicate Repair Association](https://github.com/jantman/equipment-status-board/issues/43)
+
+## Overview
+
+### Problem Statement
+
+When a repair record is closed with status `Closed - Duplicate` (via Web UI or Slack), the system only records the status string. There is no captured reference to which other repair record on the same equipment is being duplicated. This makes it impossible to query correlations (e.g. "show me all the repairs that were duplicates of repair #123") and forces staff to scan repair descriptions or timelines to figure out which prior report a duplicate refers to.
+
+### Solution
+
+Add a nullable `duplicated_repair_id` foreign key on `repair_records` pointing back to `repair_records.id`. Whenever a user transitions a repair to `Closed - Duplicate` — in the Web UI edit form or the Slack action modal — they are required to pick which repair on the **same equipment** the current repair duplicates. Selection uses a dropdown / `static_select` populated with the equipment's other repair records, sorted newest-first, each option labeled `#{id} [{status}] {description excerpt}`. The service layer enforces the invariant that **a status transition to `Closed - Duplicate` requires `duplicated_repair_id` to be set**, and the chosen target must belong to the same equipment and not be the record itself. The repair detail view renders the link; audit-log entries record the `duplicated_repair_id` change.
+
+### Scope
+
+**In Scope:**
+
+- New nullable `duplicated_repair_id` column on `repair_records` (FK → `repair_records.id`, `ON DELETE SET NULL`, indexed).
+- Alembic migration adding the column + FK + index, via `op.batch_alter_table` (MariaDB-compatible pattern used throughout this repo).
+- `RepairRecord` model: add the column and a self-referential `duplicated_repair` relationship (`remote_side=[id]`).
+- `repair_service.update_repair_record()`:
+  - Add `'duplicated_repair_id'` to `_REPAIR_UPDATABLE_FIELDS` so it flows through the existing change-detection / timeline / audit pipeline.
+  - Add validation (see **Technical Decisions §3** for the precise rule).
+  - Emit a timeline entry for the change (entry_type `duplicated_repair_id_change`, old/new IDs as strings).
+- `repair_service.list_duplicate_candidates(repair_record_id)` — new helper returning the equipment's other repair records (excluding the record itself), ordered `created_at DESC`.
+- Web UI:
+  - `RepairRecordUpdateForm` adds `duplicated_repair_id = SelectField(..., coerce=int, validators=[Optional()])`. `0` is the sentinel for "none".
+  - `views/repairs.py::edit()` populates `form.duplicated_repair_id.choices` from `list_duplicate_candidates(id)` on both GET and POST, passes the chosen value (or `None` if `0`) into `update_repair_record()`.
+  - `templates/repairs/edit.html`: render the new dropdown in a wrapper `<div id="duplicate-block">` that is shown iff `form.status.data == 'Closed - Duplicate'` on initial render. Add a small inline `<script>` toggling visibility when the status `<select>` changes.
+  - `templates/repairs/detail.html`: render a "Marked as duplicate of #N" row in the Repair Information `<dl>` when `record.duplicated_repair_id` is set, with a link to that repair's detail page.
+- Slack:
+  - `build_repair_action_modal(repair_record)` adds an optional `static_select` block (`block_id='duplicate_block'`, `action_id='duplicated_repair_id'`) populated by querying `repair_service.list_duplicate_candidates(repair_record.id)`. Block label: `"Duplicate of (used when 'Set Status → Closed - Duplicate' chosen)"`. Each option text: `f'#{r.id} [{r.status}] {r.description[:60]}'` truncated to 75 chars.
+  - **If the equipment has zero other repairs, remove `Closed - Duplicate` from the status dropdown options entirely** and omit the duplicate block. The user cannot mark a one-and-only repair as a duplicate.
+  - `handle_repair_action_submission()`: when `action == 'set_status'` and `status_opt['value'] == 'Closed - Duplicate'`, read `duplicated_repair_id` from the same view state and pass both into `update_repair_record()`. If missing → return Slack inline error on `duplicate_block`. ValidationError from the service is surfaced on `status_block`.
+- `build_repair_create_modal`: filter `Closed - Duplicate` out of the status dropdown options (a repair cannot be created already-duplicate; the create flow does not have access to a target repair).
+- Audit logging: the existing `update_repair_record` audit-changes mechanism already produces an entry like `'duplicated_repair_id': [old_str, new_str]` — no extra code beyond adding the field to `_REPAIR_UPDATABLE_FIELDS`.
+- Tests covering: model column + relationship, service validation (positive + each negative case), web view form rendering + submission, Slack action modal flow including zero-candidates edge case, and Slack create modal filter.
+
+**Out of Scope:**
+
+- Backfilling existing rows that already have `Closed - Duplicate` status — they keep `duplicated_repair_id = NULL`. Editing such legacy rows for non-status fields must remain possible (see Technical Decisions §3.c).
+- A reverse-direction view ("repairs that were duplicates of *this* repair") — possible later via SQLAlchemy `backref`, but not built in this story.
+- Auto-suggesting likely duplicates based on description similarity.
+- Cross-equipment duplicates.
+- Changing the duplicate target by editing the repair *after* the close — technically allowed by the service rules (since `duplicated_repair_id` is just a field), but no UI affordance is provided. Out of scope as a feature; the field is editable via direct DB or future admin tooling.
+- A `CHECK` constraint coupling `status` and `duplicated_repair_id` at the DB layer. Enforced in service layer only (consistency with existing patterns).
+- Cycle detection in duplicate chains.
+
+## Context for Development
+
+### Codebase Patterns
+
+- **Service-layer business logic:** All validation and writes go through `esb/services/repair_service.py`. Views and Slack handlers never query or commit directly. Invariants raise `ValidationError` (from `esb.utils.exceptions`) — the exception type used throughout `repair_service.py` (see `update_repair_record` status validation at line 500-501). **Not** bare `ValueError`.
+- **`update_repair_record` kwargs pattern:** signature is `(repair_record_id, updated_by, author_id=None, **changes)`. It validates inbound values, pops `note` (it's not a model field), then enforces an allowlist via `_REPAIR_UPDATABLE_FIELDS = ('status', 'severity', 'assignee_id', 'eta', 'specialist_description')` (line 22): any unknown keys raise `ValidationError(f'Unknown fields: ...')` (line 513-515). Adding a new updatable field requires extending this tuple. Change-detection compares `getattr(record, field) != changes[field]` and emits a per-field timeline entry inside the same transaction.
+- **`create_repair_record` does NOT accept a `status` argument** (hardcodes `status='New'` at line 110). The Slack create-modal handler emulates "create with status" by calling `create_repair_record` then `update_repair_record(status=...)` (`handlers.py:244-253` with the comment "Setting non-"New" status requires a second service call"). So defense for the duplicated_repair_id invariant lives entirely in `update_repair_record`.
+- **Audit logging:** `log_mutation('repair_record.updated', updated_by, {'id': ..., 'changes': audit_changes})` is called after `db.session.commit()`. `audit_changes` is a dict of `{field: [old_serialized, new_serialized]}`. Adding `'duplicated_repair_id'` to `_REPAIR_UPDATABLE_FIELDS` automatically routes it through this flow; no extra `log_mutation` calls are needed.
+- **Timeline entry creation in `update_repair_record`:** the loop at line 519-560 handles `status`, `assignee_id`, and `eta` specially (with custom entry_types). For other allowlisted fields it currently emits NO timeline entry (specialist_description doesn't either). We need to add a `duplicated_repair_id_change` entry type so the change is visible in the timeline — see Tasks.
+- **Form pattern:** Flask-WTF forms in `esb/forms/repair_forms.py`; `SelectField` with `coerce=int` uses `0` as the "unselected" sentinel (see `assignee_id`-from-`RepairRecordUpdateForm`, paired with `assignee_id if form.assignee_id.data != 0 else None` in views/repairs.py:324).
+- **Slack modal pattern:** `esb/slack/forms.py` defines `build_*_modal()` Block Kit dict builders; `esb/slack/handlers.py` `handle_*_submission()` parses `view['state']['values']`. The action modal already follows the pattern of "show all possibly-needed inputs, server resolves which apply based on the radio choice" (see ETA / status / note blocks). The new duplicate block extends this pattern; no new modal-push is needed.
+- **Slack app-context wrapper:** All handlers wrap their body with `with _ensure_app_context(app):` (defined at `handlers.py:11-27`). The new validation flow runs through `update_repair_record`, which is already wrapped by the caller.
+- **Migrations:** `migrations/versions/{revisionid}_{slug}.py` using `op.batch_alter_table`. The `revisionid` is generated by Alembic via the `flask db migrate` workflow documented in CLAUDE.md — must be generated against the live MariaDB container (port 3306 not host-mapped).
+- **Testing:** SQLite in-memory in `TestingConfig`; CSRF disabled. Fixtures: `make_equipment`, `make_repair_record`, `staff_client`, `tech_client`, `capture` (mutation log capture). Test class pattern: one class per behavior, e.g. `TestCreateRepairRecord`, `TestRepairActionSubmission`. View tests post form data with `follow_redirects=False` and assert `302` Location header. Service tests assert DB state via `_db.session.get(...)` after `expire_all()`.
+
+### Files to Reference
+
+| File | Purpose |
+| ---- | ------- |
+| `esb/models/repair_record.py` (lines 23-59) | Add `duplicated_repair_id` column + `duplicated_repair` self-relationship. `REPAIR_STATUSES` constant (lines 7-18) already contains `'Closed - Duplicate'` — no enum change. |
+| `esb/services/repair_service.py` (line 22) | Add `'duplicated_repair_id'` to `_REPAIR_UPDATABLE_FIELDS`. |
+| `esb/services/repair_service.py` (lines 470-637) | Modify `update_repair_record`: add validation block (see Technical Decisions §3), add timeline entry for the field, the rest of the existing flow handles audit/log. |
+| `esb/services/repair_service.py` (after line 217) | New `list_duplicate_candidates(repair_record_id)` helper near `list_repair_records`. |
+| `esb/services/repair_service.py` (line 220 `CLOSED_STATUSES`) | Reference: already includes `'Closed - Duplicate'`. |
+| `esb/forms/repair_forms.py` (line 29-45 `RepairRecordUpdateForm`) | Add `duplicated_repair_id = SelectField(..., coerce=int, validators=[Optional()])`. |
+| `esb/views/repairs.py` (line 288-336 `edit()`) | Populate `form.duplicated_repair_id.choices` on both GET and POST; map `0` sentinel to `None`; pass through to service. |
+| `esb/views/repairs.py` (line 190-216 `detail()`) | No change needed — `record.duplicated_repair` will load lazily in the template. (Optionally eager-load for clarity.) |
+| `esb/templates/repairs/edit.html` (lines 17-26 status block) | Insert wrapper `<div id="duplicate-block">` after the status block; add inline JS toggling `display` when status `<select>` changes. |
+| `esb/templates/repairs/detail.html` (Repair Information `<dl>`, lines 50-80) | Add a conditional `<dt>/<dd>` pair for "Marked as duplicate of #N" with a link via `url_for('repairs.detail', id=record.duplicated_repair_id)`. |
+| `esb/slack/forms.py` (lines 626-728 `build_repair_action_modal`) | Add duplicate-of block; filter `Closed - Duplicate` from status options when the equipment has no other repairs. |
+| `esb/slack/forms.py` (lines 318-422 `build_repair_create_modal`) | Filter `Closed - Duplicate` from status options (always). |
+| `esb/slack/handlers.py` (lines 517-677 `handle_repair_action_submission`) | In the `set_status` branch, when status is `Closed - Duplicate`, read `duplicate_block.duplicated_repair_id.selected_option`, validate-non-empty, include in `update_repair_record` call. ValidationError already surfaces as inline `action_block` error; consider surfacing on `duplicate_block` instead for clarity. |
+| `migrations/versions/7bd5caedf749_add_repair_records_repair_timeline_.py` | Reference: most recent migration; pattern for `op.batch_alter_table` + indexes + foreign keys. |
+| `tests/conftest.py` (lines 133-152) | Reference: `make_repair_record` factory accepts `equipment=`, `status=`, `description=`, `**kwargs` — we'll pass `duplicated_repair_id=` once the column exists. |
+| `tests/test_services/test_repair_service.py` (classes around line 185+) | Reference: `TestStaticPagePush`, `TestSlackNotificationHooks` style; add a new `TestDuplicatedRepairId` class. |
+| `tests/test_slack/test_handlers.py` (lines 1086+ `TestRepairActionSubmission`) | Reference: extend with duplicate-flow scenarios; uses `_build_view`, `_register_and_capture`, `MagicMock` client. |
+| `tests/test_views/test_repair_views.py` (lines 183+ edit tests) | Reference: extend `TestRepairEdit` class with duplicate-of cases. |
+
+### Technical Decisions
+
+1. **`duplicated_repair_id` is nullable, with `ON DELETE SET NULL`.** A repair may not be a duplicate (the common case), and we don't want deletion of the target repair to cascade-delete the duplicate. `SET NULL` semantics preserve the historical "this was marked as a duplicate" status even if the original target is later deleted; staff can investigate via audit log.
+
+2. **No status-enum change.** `Closed - Duplicate` is already in `REPAIR_STATUSES` (model line 17). We're adding a paired-field constraint, not a new status value.
+
+3. **Validation lives in the service layer, conditionally.** Three rules in `update_repair_record`:
+
+   **a. Status transition to `Closed - Duplicate` requires a target.**
+   If `'status' in changes and changes['status'] == 'Closed - Duplicate'`:
+   - `effective_dup_id = changes.get('duplicated_repair_id', record.duplicated_repair_id)`
+   - `effective_dup_id` must not be `None` → else `ValidationError("'Closed - Duplicate' requires a duplicated_repair_id")`.
+   - `effective_dup_id != repair_record_id` → else `ValidationError("A repair cannot be a duplicate of itself")`.
+   - target = `db.session.get(RepairRecord, effective_dup_id)` must exist → else `ValidationError(f"Duplicated repair {effective_dup_id} not found")`.
+   - `target.equipment_id == record.equipment_id` → else `ValidationError("Duplicated repair must be on the same equipment")`.
+
+   **b. Explicitly setting `duplicated_repair_id` to non-None requires status to be `Closed - Duplicate`.**
+   If `'duplicated_repair_id' in changes and changes['duplicated_repair_id'] is not None`:
+   - `effective_status = changes.get('status', record.status)` must equal `'Closed - Duplicate'` → else `ValidationError("duplicated_repair_id may only be set when status is 'Closed - Duplicate'")`.
+   - Plus same-equipment / non-self / target-exists checks as in (a).
+
+   **c. Status moving *away* from `Closed - Duplicate` auto-clears `duplicated_repair_id`.**
+   If `'status' in changes and changes['status'] != 'Closed - Duplicate'` and `record.duplicated_repair_id is not None` and `'duplicated_repair_id' not in changes`: implicitly inject `changes['duplicated_repair_id'] = None`. This is the only "silent" mutation — it audit-logs as `{'duplicated_repair_id': [old, None]}` via the normal flow.
+
+   **Legacy-record carve-out:** Note that rule (a) only fires when `'status' in changes` — i.e., a status *transition* to `Closed - Duplicate`. A row that already has `status='Closed - Duplicate'` and `duplicated_repair_id=NULL` (legacy data) can still be edited for unrelated fields (e.g., a note, a specialist_description) without tripping validation. This is intentional.
+
+4. **The duplicate target's status is unrestricted.** A repair can be marked as a duplicate of any other repair on the same equipment, including another `Closed - Duplicate` one or an already-resolved one. Avoids forcing users to find the "root" duplicate; staff can follow the chain if needed. **No cycle detection** — chains are operationally harmless and detection adds complexity.
+
+5. **Slack: single-modal approach, no nested modal push.** The action modal already follows the pattern of "show all possibly-needed inputs (ETA, status, note), server resolves which apply based on the radio choice." Adding the duplicate `static_select` as another always-visible-but-optional block extends this pattern. The alternative — pushing a third modal after the user picks `Closed - Duplicate` — would require Slack's `ack(response_action='push', view=...)` from within an already-pushed modal (3-level deep stack). Single-modal is simpler, has fewer race conditions, and matches the existing UX.
+
+6. **Slack: zero-candidates edge case.** When `list_duplicate_candidates(record.id)` returns an empty list (the equipment has only this one repair, ever), `build_repair_action_modal` **removes `'Closed - Duplicate'` from the status dropdown options** and **omits the duplicate block entirely**. The user cannot pick an unsatisfiable status. (This is preferred over showing the option and letting the server reject — better UX, less confusing.)
+
+7. **Web UI: conditional JS show/hide on status select.** Inline `<script>` watches the status `<select>` `change` event; toggles `style.display` on the duplicate-block wrapper. Default visibility on GET matches `record.status == 'Closed - Duplicate'`. The duplicate dropdown is always rendered server-side with full candidate list (no AJAX), regardless of the current status — display is a CSS concern only. **No-JS fallback:** without JS the block is always visible (`display:block` default) — degraded but functional; users can still submit. This matches the simplicity of the existing form; the repo has no client-side framework.
+
+8. **Description excerpt cap of 60 chars in dropdown labels.** Slack `static_select` option `text.text` has a 75-char limit. Format `#{id} [{status}] {desc[:60]}` worst-case: `#999999 [Closed - No Issue Found] ` ≈ 35 chars + 60 chars = ~95 chars. We further truncate the whole label with `[:75]` (consistent with `build_equipment_options` lines 184). Web select option text is rendered HTML — same 60-char excerpt for visual consistency.
+
+9. **Self-referential FK with `remote_side`:** the model relationship uses `db.relationship('RepairRecord', remote_side=[id])` to disambiguate "the one I duplicate" from the implicit reverse "the ones that duplicate me." We do not add a `backref` for the reverse direction (deferred — out of scope per issue scope).
+
+10. **`Closed - Duplicate` removed from `build_repair_create_modal` status options.** A repair cannot meaningfully be *created* already-duplicate via Slack: the create flow has no UI for the dup-target dropdown, and the follow-up `update_repair_record` would fail validation. Filter at the option-list construction site rather than surfacing a confusing error.
+
+11. **Web UI create form is not affected.** `RepairRecordCreateForm` doesn't expose `status` (status is hardcoded to `'New'` by `create_repair_record`), so no filter is needed on the web create path.
+
+12. **Timeline entry for duplicated_repair_id changes.** Add a new `entry_type='duplicated_repair_id_change'` with `old_value`/`new_value` as stringified IDs (or `None` for absent). Renders in the existing timeline component (`components/_timeline_entry.html`) — verify it handles unknown entry_types gracefully or extend that template if needed (small follow-up task).
+
+## Implementation Plan
+
+### Tasks
+
+Tasks are ordered by dependency: schema → service → web → Slack → verification. Each phase's tests live alongside the source change so the test suite stays green between phases.
+
+#### Phase 1: Data Layer
+
+- [ ] **Task 1: Add `duplicated_repair_id` column + self-relationship to `RepairRecord` model.**
+  - File: `esb/models/repair_record.py`
+  - Action: After `specialist_description` (line 41) add `duplicated_repair_id = db.Column(db.Integer, db.ForeignKey('repair_records.id', ondelete='SET NULL'), nullable=True, index=True)`. After the existing `assignee` relationship (line 56) add `duplicated_repair = db.relationship('RepairRecord', remote_side=[id])`.
+  - Notes: No `backref` (out of scope). `remote_side=[id]` is the SQLAlchemy idiom for self-referential many-to-one.
+
+- [ ] **Task 2: Create Alembic migration for the new column.**
+  - File: `migrations/versions/{auto}_add_duplicated_repair_id.py` (new file)
+  - Action: Per CLAUDE.md migration workflow: `docker compose up -d db`, `docker inspect equipment-status-board-db-1 --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'`, then `DATABASE_URL="mysql+pymysql://root:esb_dev_password@<IP>/esb" venv/bin/flask db migrate -m "Add duplicated_repair_id to repair_records"`. Inspect the generated file and ensure: `op.batch_alter_table('repair_records')` adds the column, the FK constraint includes `ondelete='SET NULL'`, and the index `ix_repair_records_duplicated_repair_id` is created. Add the index manually if Alembic missed it. Verify `downgrade()` drops index → constraint → column in reverse order. Apply with `flask db upgrade`.
+  - Notes: Alembic sometimes drops `ondelete='SET NULL'` from autogen — verify and patch.
+
+- [ ] **Task 3: Model-layer tests.**
+  - File: `tests/test_models/test_repair_record.py`
+  - Action: Add tests asserting (a) the new column is nullable on a fresh record, (b) setting `duplicated_repair_id` and accessing `.duplicated_repair` loads the target, (c) deleting the target via `db.session.delete(target); commit()` nulls the child's FK on refresh.
+  - Notes: SQLite enforces FK ON DELETE SET NULL only when `PRAGMA foreign_keys=ON` — confirm the testing config enables this, or accept that the FK-cascade test is skipped under SQLite and add an integration smoke note instead.
+
+#### Phase 2: Service Layer
+
+- [ ] **Task 4: Add `list_duplicate_candidates` helper.**
+  - File: `esb/services/repair_service.py`
+  - Action: After `list_repair_records` (line 217), add:
+    ```python
+    def list_duplicate_candidates(repair_record_id: int) -> list[RepairRecord]:
+        """Return same-equipment repair records (excluding self), newest first."""
+        record = get_repair_record(repair_record_id)
+        query = (
+            db.select(RepairRecord)
+            .filter(RepairRecord.equipment_id == record.equipment_id)
+            .filter(RepairRecord.id != record.id)
+            .order_by(RepairRecord.created_at.desc())
+        )
+        return list(db.session.execute(query).scalars().all())
+    ```
+  - Notes: `get_repair_record` raises `ValidationError` if the id is missing — propagates naturally.
+
+- [ ] **Task 5: Extend `_REPAIR_UPDATABLE_FIELDS` and add validation + timeline entry to `update_repair_record`.**
+  - File: `esb/services/repair_service.py`
+  - Action:
+    1. Line 22: append `'duplicated_repair_id'` to `_REPAIR_UPDATABLE_FIELDS`.
+    2. In `update_repair_record` (line 470+), after the existing input validations (after line 507, before `note = changes.pop(...)`), insert the validation block per Technical Decisions §3:
+       ```python
+       effective_status = changes.get('status', record.status)
+       effective_dup_id = changes.get('duplicated_repair_id', record.duplicated_repair_id)
+
+       transitioning_to_closed_dup = 'status' in changes and changes['status'] == 'Closed - Duplicate'
+       setting_dup_explicit = 'duplicated_repair_id' in changes and changes['duplicated_repair_id'] is not None
+       transitioning_away_from_closed_dup = (
+           'status' in changes and changes['status'] != 'Closed - Duplicate'
+       )
+
+       if transitioning_to_closed_dup:
+           if effective_dup_id is None:
+               raise ValidationError(
+                   "'Closed - Duplicate' status requires a duplicated_repair_id",
+               )
+       if setting_dup_explicit:
+           if effective_status != 'Closed - Duplicate':
+               raise ValidationError(
+                   "duplicated_repair_id may only be set when status is 'Closed - Duplicate'",
+               )
+       if transitioning_to_closed_dup or setting_dup_explicit:
+           target_id = effective_dup_id
+           if target_id == repair_record_id:
+               raise ValidationError('A repair cannot be a duplicate of itself')
+           target = db.session.get(RepairRecord, target_id)
+           if target is None:
+               raise ValidationError(f'Duplicated repair {target_id} not found')
+           if target.equipment_id != record.equipment_id:
+               raise ValidationError(
+                   'Duplicated repair must be on the same equipment',
+               )
+
+       # Silent clear when status moves away from Closed - Duplicate
+       if (
+           transitioning_away_from_closed_dup
+           and record.duplicated_repair_id is not None
+           and 'duplicated_repair_id' not in changes
+       ):
+           changes['duplicated_repair_id'] = None
+       ```
+    3. In the per-field timeline-entry loop (line 519+), add an `elif field_name == 'duplicated_repair_id':` branch emitting `RepairTimelineEntry(repair_record_id=record.id, entry_type='duplicated_repair_id_change', author_id=author_id, author_name=updated_by, old_value=str(old_value) if old_value is not None else None, new_value=str(new_value) if new_value is not None else None)`.
+  - Notes: `audit_changes['duplicated_repair_id']` and `log_mutation` flow through automatically because the field is now in `_REPAIR_UPDATABLE_FIELDS`. Place validation BEFORE the unknown-keys check at line 513.
+
+- [ ] **Task 6: Service-layer tests.**
+  - File: `tests/test_services/test_repair_service.py`
+  - Action: Add two new test classes:
+    1. `TestListDuplicateCandidates` — covers ordering newest-first, self-exclusion, equipment filtering, missing-record `ValidationError`, empty result for single-repair equipment.
+    2. `TestDuplicatedRepairId` — covers the eight ACs in the Service Layer section below (AC-4 through AC-11).
+  - Notes: Use `make_equipment` and `make_repair_record` factories; assert via `_db.session.get(RepairRecord, id)` after `_db.session.expire_all()`.
+
+#### Phase 3: Web UI
+
+- [ ] **Task 7: Add `duplicated_repair_id` field to `RepairRecordUpdateForm`.**
+  - File: `esb/forms/repair_forms.py`
+  - Action: After `specialist_description` (line 43) on `RepairRecordUpdateForm` add:
+    ```python
+    duplicated_repair_id = SelectField(
+        'Duplicate of', coerce=int, validators=[Optional()],
+    )
+    ```
+  - Notes: `0` is the unselected sentinel (consistent with `assignee_id`).
+
+- [ ] **Task 8: Populate dropdown choices and pass through in `repairs.edit` view.**
+  - File: `esb/views/repairs.py`
+  - Action: In `edit()` (line 288+):
+    1. After the assignee choices (around line 306), add:
+       ```python
+       candidates = repair_service.list_duplicate_candidates(id)
+       form.duplicated_repair_id.choices = [(0, '-- Select duplicate of --')] + [
+           (c.id, f'#{c.id} [{c.status}] {c.description[:60]}') for c in candidates
+       ]
+       ```
+    2. On GET (~line 308-314) add `form.duplicated_repair_id.data = record.duplicated_repair_id or 0`.
+    3. In the validated POST branch (line 316+), add to the `update_repair_record(...)` call:
+       ```python
+       duplicated_repair_id=(
+           form.duplicated_repair_id.data if form.duplicated_repair_id.data != 0 else None
+       ),
+       ```
+  - Notes: Service raises `ValidationError` on invalid combos → existing `flash + re-render` flow handles it.
+
+- [ ] **Task 9: Conditional duplicate-block in `repairs/edit.html`.**
+  - File: `esb/templates/repairs/edit.html`
+  - Action: After the status block (after line 26), insert:
+    ```html
+    <div id="duplicate-block" class="mb-3"{% if form.status.data != 'Closed - Duplicate' %} style="display: none;"{% endif %}>
+        <label for="duplicated_repair_id" class="form-label">Duplicate of *</label>
+        {{ form.duplicated_repair_id(class="form-select" ~ (" is-invalid" if form.duplicated_repair_id.errors else "")) }}
+        <div class="form-text">Required when status is "Closed - Duplicate".</div>
+        {% for error in form.duplicated_repair_id.errors %}
+        <div class="invalid-feedback">{{ error }}</div>
+        {% endfor %}
+    </div>
+    ```
+    Inside `{% block content %}`, after the closing `</form>` and before `{% endblock %}`, append:
+    ```html
+    <script>
+    (function () {
+        const statusSelect = document.querySelector('select[name="status"]');
+        const dupBlock = document.getElementById('duplicate-block');
+        if (!statusSelect || !dupBlock) return;
+        const sync = () => { dupBlock.style.display = statusSelect.value === 'Closed - Duplicate' ? '' : 'none'; };
+        statusSelect.addEventListener('change', sync);
+    })();
+    </script>
+    ```
+  - Notes: No-JS fallback is `display:block` (visible). Inline script is consistent with the repo's no-framework template style.
+
+- [ ] **Task 10: Render "Marked as duplicate of" link on the detail page.**
+  - File: `esb/templates/repairs/detail.html`
+  - Action: In the Repair Information `<dl>` (lines 50-80), between the Status and Severity rows, add:
+    ```html
+    {% if record.duplicated_repair_id %}
+    <dt class="col-sm-3">Marked as duplicate of</dt>
+    <dd class="col-sm-9"><a href="{{ url_for('repairs.detail', id=record.duplicated_repair_id) }}">Repair #{{ record.duplicated_repair_id }}</a></dd>
+    {% endif %}
+    ```
+
+- [ ] **Task 11: Add `duplicated_repair_id_change` rendering to the timeline component.**
+  - File: `esb/templates/components/_timeline_entry.html`
+  - Action: Add a new `{% elif entry.entry_type == 'duplicated_repair_id_change' %}` branch after the `eta_update` branch:
+    ```html
+    {% elif entry.entry_type == 'duplicated_repair_id_change' %}
+    <span class="badge bg-secondary me-1">Duplicate</span>
+    <strong>
+        {% if entry.new_value %}
+        Marked as duplicate of <a href="{{ url_for('repairs.detail', id=entry.new_value|int) }}">#{{ entry.new_value }}</a>
+        {% else %}
+        Unlinked from duplicate{% if entry.old_value %} #{{ entry.old_value }}{% endif %}
+        {% endif %}
+    </strong>
+    ```
+
+- [ ] **Task 12: Web view tests.**
+  - File: `tests/test_views/test_repair_views.py`
+  - Action: Extend `TestRepairEdit` (line 183+) with tests covering AC-14 through AC-19 (form rendering, valid submit, missing-dup-id error, status-away clearing, detail-page link).
+
+#### Phase 4: Slack
+
+- [ ] **Task 13: Filter `Closed - Duplicate` out of `build_repair_create_modal` status options.**
+  - File: `esb/slack/forms.py`
+  - Action: In `build_repair_create_modal` (line 318+, status block at ~line 396-413), change the options comprehension to `[ ... for s in REPAIR_STATUSES if s != 'Closed - Duplicate']`.
+
+- [ ] **Task 14: Add duplicate-of block to `build_repair_action_modal`; handle zero-candidates.**
+  - File: `esb/slack/forms.py`
+  - Action: In `build_repair_action_modal(repair_record)` (line 626+):
+    1. At the top of the function, call `from esb.services import repair_service` then `candidates = repair_service.list_duplicate_candidates(repair_record.id)`.
+    2. Compute `status_options` for the status dropdown: start from the current hardcoded list (`In Progress`, `Closed - Duplicate`, `Closed - No Issue Found`); if `not candidates`, drop `Closed - Duplicate`.
+    3. Use `status_options` to populate the status block (replacing the hardcoded options list at lines 698-702).
+    4. After the note block, if `candidates`:
+       ```python
+       dup_options = [
+           {
+               'text': {'type': 'plain_text', 'text': f'#{r.id} [{r.status}] {r.description[:60]}'[:75]},
+               'value': str(r.id),
+           }
+           for r in candidates
+       ]
+       blocks.append({
+           'type': 'input',
+           'block_id': 'duplicate_block',
+           'optional': True,
+           'element': {
+               'type': 'static_select',
+               'action_id': 'duplicated_repair_id',
+               'placeholder': {'type': 'plain_text', 'text': 'Select duplicated repair'},
+               'options': dup_options,
+           },
+           'label': {'type': 'plain_text', 'text': "Duplicate of (used when 'Set Status → Closed - Duplicate' chosen)"},
+       })
+       ```
+  - Notes: `optional: True` so the modal can be submitted with action != set_status. Server-side validation enforces presence when needed.
+
+- [ ] **Task 15: Handle duplicate selection in `handle_repair_action_submission`.**
+  - File: `esb/slack/handlers.py`
+  - Action: In the `elif action == 'set_status':` branch (~line 598-605), after `changes['status'] = status_opt['value']`, add:
+    ```python
+    if changes['status'] == 'Closed - Duplicate':
+        dup_opt = (
+            values.get('duplicate_block', {})
+            .get('duplicated_repair_id', {})
+            .get('selected_option')
+        )
+        if not dup_opt:
+            ack(response_action='errors', errors={
+                'duplicate_block': 'Selecting which repair this duplicates is required.',
+            })
+            return
+        try:
+            changes['duplicated_repair_id'] = int(dup_opt['value'])
+        except (KeyError, TypeError, ValueError):
+            ack(response_action='errors', errors={
+                'duplicate_block': 'Invalid duplicate selection.',
+            })
+            return
+    ```
+  - Notes: Service-layer ValidationError (e.g., cross-equipment from a stale modal) still surfaces on `action_block` via the existing exception handler.
+
+- [ ] **Task 16: Slack tests.**
+  - Files: `tests/test_slack/test_handlers.py`, `tests/test_slack/test_forms.py`
+  - Action:
+    - `test_forms.py`: tests for AC-20 (action modal with candidates includes duplicate_block), AC-21 (zero candidates omits block + filters status option), AC-22 (create modal filters status option).
+    - `test_handlers.py`: extend `TestRepairActionSubmission` with AC-23 (successful Closed-Dup submission), AC-24 (missing duplicate selection returns inline error).
+
+#### Phase 5: Verify
+
+- [ ] **Task 17: Run lint and full test suite.**
+  - Action: `make lint && make test`. Address any ruff complaints (120-char lines, target Python 3.13). All existing tests must still pass.
+
+### Acceptance Criteria
+
+**Schema**
+
+- **AC-1** Given a freshly migrated database, when introspecting `repair_records`, then a `duplicated_repair_id` column exists (nullable Integer) with a FK to `repair_records.id` (ON DELETE SET NULL) and an index `ix_repair_records_duplicated_repair_id`.
+
+- **AC-2** Given a RepairRecord A with `duplicated_repair_id = B.id`, when B is deleted from the database, then A.duplicated_repair_id is NULL (and A is preserved).
+
+- **AC-3** Given a RepairRecord A with `duplicated_repair_id = B.id`, when accessing `A.duplicated_repair`, then it returns the RepairRecord B instance.
+
+**Service layer — happy path & errors**
+
+- **AC-4** Given an open repair R1 and another open repair R2 on the same equipment, when `update_repair_record(R1.id, updated_by='u', author_id=u.id, status='Closed - Duplicate', duplicated_repair_id=R2.id)` is called, then R1.status becomes `'Closed - Duplicate'`, R1.duplicated_repair_id becomes R2.id, a timeline entry of type `duplicated_repair_id_change` is created with `new_value == str(R2.id)`, and `repair_record.updated` is emitted in the mutation log with `changes['duplicated_repair_id'] == [None, str(R2.id)]`.
+
+- **AC-5** Given an open repair R1, when `update_repair_record(R1.id, status='Closed - Duplicate', ...)` is called WITHOUT `duplicated_repair_id`, then `ValidationError` is raised with a message containing `'Closed - Duplicate'` and `duplicated_repair_id`, and R1 is unchanged.
+
+- **AC-6** Given an open repair R1, when `update_repair_record(R1.id, status='Closed - Duplicate', duplicated_repair_id=R1.id, ...)` is called, then `ValidationError` is raised with "cannot be a duplicate of itself".
+
+- **AC-7** Given repair R1 on equipment E1 and repair R2 on equipment E2, when `update_repair_record(R1.id, status='Closed - Duplicate', duplicated_repair_id=R2.id, ...)` is called, then `ValidationError` is raised with "must be on the same equipment".
+
+- **AC-8** Given an open repair R1 and a non-existent id 99999, when `update_repair_record(R1.id, status='Closed - Duplicate', duplicated_repair_id=99999, ...)` is called, then `ValidationError` is raised with "Duplicated repair 99999 not found".
+
+- **AC-9** Given a repair R1 with `status='Resolved'`, when `update_repair_record(R1.id, duplicated_repair_id=R2.id, ...)` is called without changing status, then `ValidationError` is raised with "may only be set when status is 'Closed - Duplicate'".
+
+- **AC-10** Given a repair R1 with `status='Closed - Duplicate'` and `duplicated_repair_id=R2.id`, when `update_repair_record(R1.id, status='In Progress', ...)` is called, then R1.duplicated_repair_id becomes NULL, `audit_changes['duplicated_repair_id'] == [str(R2.id), None]`, and a `duplicated_repair_id_change` timeline entry is created with `new_value is None`.
+
+- **AC-11** (Legacy carve-out) Given a repair R1 with `status='Closed - Duplicate'` and `duplicated_repair_id=None` (legacy data), when `update_repair_record(R1.id, specialist_description='x', ...)` is called, then the call succeeds without raising `ValidationError` and R1.specialist_description equals `'x'`.
+
+**Service layer — helper**
+
+- **AC-12** Given a repair R1 on equipment E and three other repairs R2 (newest), R3, R4 (oldest) on E plus R5 on another equipment, when `list_duplicate_candidates(R1.id)` is called, then it returns `[R2, R3, R4]` in that order — R5 excluded (different equipment), R1 excluded (self).
+
+- **AC-13** When `list_duplicate_candidates(99999)` is called with a non-existent id, then `ValidationError` is raised.
+
+**Web UI**
+
+- **AC-14** Given a logged-in technician fetches `/repairs/{id}/edit` for a repair whose status is `'In Progress'`, then the response HTML contains a `<div id="duplicate-block"` element with inline `style="display: none;"`.
+
+- **AC-15** Given a logged-in technician fetches `/repairs/{id}/edit` for a repair whose status is `'Closed - Duplicate'` and `duplicated_repair_id` is set, then the duplicate-block has no `display: none` style AND the target repair's `<option>` carries `selected`.
+
+- **AC-16** Given an open repair R1 and another repair R2 on the same equipment, when a staff client POSTs `/repairs/R1/edit` with form data `status='Closed - Duplicate'`, `duplicated_repair_id=R2.id`, then the response is `302` to `/repairs/R1`, `db.session.get(RepairRecord, R1.id).duplicated_repair_id == R2.id`, and a follow-up GET of `/repairs/R1` contains the string "Marked as duplicate of #{R2.id}".
+
+- **AC-17** Given an open repair R1, when a staff client POSTs `/repairs/R1/edit` with `status='Closed - Duplicate'` and `duplicated_repair_id=0`, then the response is `200` (no redirect), a `flash` of category `danger` is rendered containing the service ValidationError message, and `db.session.get(RepairRecord, R1.id).status` is unchanged.
+
+- **AC-18** Given a repair R1 with `status='Closed - Duplicate'` and `duplicated_repair_id=R2.id`, when a staff client POSTs `/repairs/R1/edit` with `status='In Progress'` (no duplicated_repair_id in the form), then the response is `302`, `R1.duplicated_repair_id` is `None`, and the detail page no longer shows the "Marked as duplicate of" row.
+
+**Slack**
+
+- **AC-19** Given two open repairs R1 and R2 on the same equipment, when `build_repair_action_modal(R1)` is called, then the returned view contains a block with `block_id == 'duplicate_block'` whose `static_select` options include an entry with `value == str(R2.id)` and `text.text` starting with `f'#{R2.id} [{R2.status}]'`.
+
+- **AC-20** Given a repair R1 that is the only repair on its equipment, when `build_repair_action_modal(R1)` is called, then NO block in the returned view has `block_id == 'duplicate_block'` AND the `status_block`'s options do NOT include any option with `value == 'Closed - Duplicate'`.
+
+- **AC-21** When `build_repair_create_modal(equipment_options, user_options)` is called, then no option in the `status_block` has `value == 'Closed - Duplicate'`.
+
+- **AC-22** Given an open repair R1 and another R2 on the same equipment, when the registered `view:repair_action_submission` handler is invoked with `private_metadata=str(R1.id)`, action=`set_status`, status=`Closed - Duplicate`, and `duplicate_block.duplicated_repair_id.selected_option.value=str(R2.id)`, then `update_repair_record` is called with `status='Closed - Duplicate'` and `duplicated_repair_id=R2.id`, `ack()` is called with no kwargs, and an ephemeral confirmation is posted.
+
+- **AC-23** Given an open repair R1 and another R2 on the same equipment, when the action-modal handler is invoked with `action=set_status`, status=`Closed - Duplicate`, and no `duplicate_block.duplicated_repair_id.selected_option`, then `ack` is called with `response_action='errors'` and `errors['duplicate_block']` set to the "Selecting which repair this duplicates is required." string, and `update_repair_record` is NOT called.
+
+**Cross-cutting**
+
+- **AC-24** `make lint` reports no new violations after all changes.
+- **AC-25** `make test` passes with the new tests included.
+
+## Additional Context
+
+### Dependencies
+
+- **No new third-party dependencies.** Uses existing Flask-SQLAlchemy 3.x self-referential FK support (`remote_side=[id]`), Flask-WTF `SelectField(coerce=int)`, Slack Bolt SDK `views_open` / view-submission handlers, Alembic `batch_alter_table`.
+- **Service-internal dependency:** `build_repair_action_modal` becomes coupled to `repair_service.list_duplicate_candidates`. This is acceptable since `forms.py` already imports models (line 173, line 197) and the Slack layer already has a hard service dependency.
+- **Database:** requires MariaDB up + migration applied before service-layer code is exercised against the real DB. SQLite-in-memory testing config picks up the column automatically via `db.create_all()`.
+
+### Testing Strategy
+
+- **Unit tests (model layer):** model column nullability, FK behavior, relationship loading. See Task 3.
+- **Unit tests (service layer):** `TestListDuplicateCandidates` (4 cases) + `TestDuplicatedRepairId` (8 cases covering AC-4 through AC-11). See Task 6.
+- **Unit tests (Slack forms):** modal-builder dict-shape assertions (AC-19, AC-20, AC-21). See Task 16a.
+- **Integration tests (Slack handlers):** action-modal submission via `_register_and_capture` helper with MagicMock client (AC-22, AC-23). See Task 16b.
+- **Integration tests (web views):** Flask test client POSTs with `follow_redirects=False`, asserting redirects, DB state, and rendered HTML (AC-14 through AC-18). See Task 12.
+- **Manual smoke test:** after `make run` + `make worker`, exercise the full flow in a browser: create two repairs on one equipment, transition one to `Closed - Duplicate` with the other as target, verify the detail page link, verify the timeline entry. Then via Slack (if `SLACK_SOCKET_MODE_CONNECT=true`): `/esb-repair`, pick the repair, `Set Status → Closed - Duplicate`, pick the duplicate, verify ephemeral confirmation and DB state.
+
+### Notes
+
+- **No backfill of legacy data.** Any rows that already have `status='Closed - Duplicate'` will have `duplicated_repair_id=NULL` post-migration. Staff who want to retroactively record the link can edit those records via the web UI now that the field is exposed. The legacy carve-out (AC-11) means editing such a row for unrelated fields doesn't force a re-link.
+- **No CHECK constraint.** Coupling status and `duplicated_repair_id` at the DB layer would be ideal, but MariaDB CHECK enforcement of cross-column rules has been spotty historically, and the rest of this codebase enforces invariants in the service layer. We follow that precedent.
+- **No reverse-direction view.** "Which repairs are duplicates of this one?" is not in scope. A future story can add a `backref` on the relationship and a section on the detail page; the data is fully queryable as soon as this is shipped.
+- **Cycle detection deferred.** Duplicate chains (R1 → R2 → R3 → R1) are operationally harmless — staff would notice while clicking through — and adding cycle detection complicates the validation logic for no real benefit.
+- **Slack 3-modal-stack avoided.** The original design instinct was to push a second modal after the user selects `Closed - Duplicate`. Single-modal with always-visible-but-optional fields (matching the existing ETA/status/note pattern) is simpler, has no race window between modal pushes, and is consistent with the codebase.
+- **Migration revision id:** Alembic generates this; the slug portion should be `add_duplicated_repair_id`. CLAUDE.md documents the container-IP workflow.
+- **Issue tracking:** This work resolves [#43](https://github.com/jantman/equipment-status-board/issues/43). Commits must be prefixed `Issue #43:` per repo convention.

--- a/_bmad-output/implementation-artifacts/tech-spec-duplicate-repair-association.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-duplicate-repair-association.md
@@ -240,7 +240,11 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
   - Action: After `list_repair_records` (line 217), add:
     ```python
     def list_duplicate_candidates(repair_record_id: int) -> list[RepairRecord]:
-        """Return same-equipment repair records (excluding self), newest first."""
+        """Return same-equipment repair records (excluding self), newest first.
+
+        Raises:
+            ValidationError: if ``repair_record_id`` does not exist.
+        """
         record = get_repair_record(repair_record_id)
         query = (
             db.select(RepairRecord)
@@ -255,7 +259,7 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
 - [ ] **Task 5: Extend `_REPAIR_UPDATABLE_FIELDS` and add validation + timeline entry to `update_repair_record`.**
   - File: `esb/services/repair_service.py`
   - Action:
-    1. Line 22: append `'duplicated_repair_id'` to `_REPAIR_UPDATABLE_FIELDS`.
+    1. Line 22: extend `_REPAIR_UPDATABLE_FIELDS` to include the new field. The constant is a `tuple` (no `.append()` method), so rewrite the literal in place: `_REPAIR_UPDATABLE_FIELDS = ('status', 'severity', 'assignee_id', 'eta', 'specialist_description', 'duplicated_repair_id')`.
     2. In `update_repair_record` (line 470+), after the existing input validations (after line 507, before `note = changes.pop(...)`), insert the validation block per Technical Decisions §3. **Note the transition guards — all rules require `record.status` to differ from `changes['status']` so the web form re-asserting an unchanged status is a no-op (preserves the legacy carve-out):**
        ```python
        effective_status = changes.get('status', record.status)
@@ -310,7 +314,9 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
        ```
     3. In the per-field timeline-entry loop (line 519+), add an `elif field_name == 'duplicated_repair_id':` branch emitting `RepairTimelineEntry(repair_record_id=record.id, entry_type='duplicated_repair_id_change', author_id=author_id, author_name=updated_by, old_value=str(old_value) if old_value is not None else None, new_value=str(new_value) if new_value is not None else None)`.
     4. In `esb/models/repair_timeline_entry.py`, append `'duplicated_repair_id_change'` to `TIMELINE_ENTRY_TYPES` (line 7-14). This constant is the authoritative list of legal entry_type values; adding the new type without updating it leaves the constant stale and breaks any future code that validates against it.
-  - Notes: `audit_changes['duplicated_repair_id']` and `log_mutation` flow through automatically because the field is now in `_REPAIR_UPDATABLE_FIELDS`. Place validation BEFORE the unknown-keys check at line 513.
+  - Notes:
+    - `audit_changes['duplicated_repair_id']` and `log_mutation` flow through automatically because the field is now in `_REPAIR_UPDATABLE_FIELDS`.
+    - **Timeline entry ordering when both fields change in one call:** the per-field loop iterates over `_REPAIR_UPDATABLE_FIELDS` in its declared order (`status`, `severity`, `assignee_id`, `eta`, `specialist_description`, `duplicated_repair_id`), so a `status_change` entry is emitted *before* a `duplicated_repair_id_change` entry when both occur in the same `update_repair_record` call. This is deterministic and matches the order users will read the timeline (status first, then duplicate-link change).
 
 - [ ] **Task 6: Service-layer tests.**
   - File: `tests/test_services/test_repair_service.py`
@@ -565,7 +571,7 @@ Tasks are ordered by dependency: schema → service → web → Slack → verifi
 
 - **AC-23** Given an open repair R1 and another R2 on the same equipment, when the action-modal handler is invoked with `action=set_status`, status=`Closed - Duplicate`, and no `duplicate_block.duplicated_repair_id.selected_option`, then `ack` is called with `response_action='errors'` and `errors['duplicate_block']` set to the "Selecting which repair this duplicates is required." string, and `update_repair_record` is NOT called.
 
-- **AC-24** (Stale-modal race) Given an open repair R1, when (a) `build_repair_action_modal(R1)` is called and the resulting view contains an option for R2; (b) R2 is then deleted from the database in another session; (c) the Slack handler is invoked with that view's submitted state (action=`set_status`, status=`Closed - Duplicate`, `duplicate_block.duplicated_repair_id.selected_option.value == str(R2.id)`); then the service raises `ValidationError("Duplicated repair {R2.id} not found")`, the handler calls `ack(response_action='errors', errors={'action_block': <message>})`, R1 is unchanged, and no ephemeral confirmation is posted. (This race is acceptable — the service is the source of truth — but the test asserts the failure surfaces cleanly rather than crashing the handler.)
+- **AC-24** (Stale-modal race) Given an open repair R1, when (a) `build_repair_action_modal(R1)` is called and the resulting view contains an option for R2; (b) R2 is then deleted from the database in another session; (c) the Slack handler is invoked with that view's submitted state (action=`set_status`, status=`Closed - Duplicate`, `duplicate_block.duplicated_repair_id.selected_option.value == str(R2.id)`); then the service raises `ValidationError("Duplicated repair {R2.id} not found")`, the handler calls `ack(response_action='errors', errors={'action_block': "Duplicated repair {R2.id} not found"})`, R1 is unchanged, and no ephemeral confirmation is posted. **User-visible wording note:** the Slack user sees the literal service message (`"Duplicated repair {id} not found"`); the spec does not require a special "this was deleted" copy — the service message is acceptable because the race is rare and the wording is clear enough for a user to retry. The test asserts the failure surfaces cleanly rather than crashing the handler.
 
 **Cross-cutting**
 

--- a/esb/extensions.py
+++ b/esb/extensions.py
@@ -4,10 +4,14 @@ All extensions are created here and initialized in the app factory
 via ext.init_app(app).
 """
 
+import sqlite3
+
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_wtf.csrf import CSRFProtect
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
 
 db = SQLAlchemy()
 login_manager = LoginManager()
@@ -15,3 +19,13 @@ migrate = Migrate()
 csrf = CSRFProtect()
 
 login_manager.login_view = 'auth.login'
+
+
+@event.listens_for(Engine, 'connect')
+def _sqlite_fk_pragma(dbapi_conn, _):
+    # SQLite does not enforce ON DELETE SET NULL unless this pragma is on.
+    # MariaDB connections fail the isinstance check and skip.
+    if isinstance(dbapi_conn, sqlite3.Connection):
+        cursor = dbapi_conn.cursor()
+        cursor.execute('PRAGMA foreign_keys=ON')
+        cursor.close()

--- a/esb/forms/repair_forms.py
+++ b/esb/forms/repair_forms.py
@@ -41,6 +41,9 @@ class RepairRecordUpdateForm(FlaskForm):
         'Specialist Description',
         validators=[Optional(), Length(max=5000)],
     )
+    duplicated_repair_id = SelectField(
+        'Duplicate of', coerce=int, validators=[Optional()],
+    )
     note = TextAreaField('Add Note', validators=[Optional(), Length(max=5000)])
     submit = SubmitField('Save Changes')
 

--- a/esb/models/repair_record.py
+++ b/esb/models/repair_record.py
@@ -39,6 +39,12 @@ class RepairRecord(db.Model):
     )
     eta = db.Column(db.Date, nullable=True)
     specialist_description = db.Column(db.Text, nullable=True)
+    duplicated_repair_id = db.Column(
+        db.Integer,
+        db.ForeignKey('repair_records.id', ondelete='SET NULL'),
+        nullable=True,
+        index=True,
+    )
     has_safety_risk = db.Column(db.Boolean, nullable=False, default=False)
     is_consumable = db.Column(db.Boolean, nullable=False, default=False)
     created_at = db.Column(
@@ -54,6 +60,7 @@ class RepairRecord(db.Model):
     # Relationships
     equipment = db.relationship('Equipment', backref=db.backref('repair_records', lazy='dynamic'))
     assignee = db.relationship('User', backref=db.backref('assigned_repairs', lazy='dynamic'))
+    duplicated_repair = db.relationship('RepairRecord', remote_side=[id])
 
     def __repr__(self):
         return f'<RepairRecord {self.id} [{self.status}]>'

--- a/esb/models/repair_timeline_entry.py
+++ b/esb/models/repair_timeline_entry.py
@@ -11,6 +11,7 @@ TIMELINE_ENTRY_TYPES = [
     'assignee_change',
     'eta_update',
     'photo',
+    'duplicated_repair_id_change',
 ]
 
 

--- a/esb/services/repair_service.py
+++ b/esb/services/repair_service.py
@@ -503,6 +503,13 @@ def update_repair_record(
         assignee_id (int | None): New assignee user ID, or None to unassign.
         eta (date | None): New ETA date, or None to clear.
         specialist_description (str | None): Free-text description for specialist needs.
+        duplicated_repair_id (int | None): Repair this record duplicates. Must be a
+            different record on the same equipment. Required iff status is
+            ``'Closed - Duplicate'``. Transitioning status away from
+            ``'Closed - Duplicate'`` clears this field (silently when the kwarg
+            is omitted by the caller; the web edit flow forces None explicitly).
+            Cannot be set non-None when status is anything other than
+            ``'Closed - Duplicate'``. See module-level docs for full rules.
         note (str | None): Optional note text to add to timeline.
 
     Returns:

--- a/esb/services/repair_service.py
+++ b/esb/services/repair_service.py
@@ -19,7 +19,10 @@ from esb.utils.logging import log_mutation
 # Ordered tuple for deterministic timeline entry creation order.
 # specialist_description is intentionally saved regardless of status -- the AC
 # requires it available when status is "Needs Specialist", not restricted to it.
-_REPAIR_UPDATABLE_FIELDS = ('status', 'severity', 'assignee_id', 'eta', 'specialist_description')
+_REPAIR_UPDATABLE_FIELDS = (
+    'status', 'severity', 'assignee_id', 'eta', 'specialist_description',
+    'duplicated_repair_id',
+)
 
 
 def _serialize(value):
@@ -215,6 +218,22 @@ def list_repair_records(
     if eager_load_assignee:
         scalars = scalars.unique()
     return list(scalars.all())
+
+
+def list_duplicate_candidates(repair_record_id: int) -> list[RepairRecord]:
+    """Return same-equipment repair records (excluding self), newest first.
+
+    Raises:
+        ValidationError: if ``repair_record_id`` does not exist.
+    """
+    record = get_repair_record(repair_record_id)
+    query = (
+        db.select(RepairRecord)
+        .filter(RepairRecord.equipment_id == record.equipment_id)
+        .filter(RepairRecord.id != record.id)
+        .order_by(RepairRecord.created_at.desc())
+    )
+    return list(db.session.execute(query).scalars().all())
 
 
 CLOSED_STATUSES = ('Resolved', 'Closed - No Issue Found', 'Closed - Duplicate')
@@ -506,6 +525,56 @@ def update_repair_record(
         if assignee is None:
             raise ValidationError(f'User with id {changes["assignee_id"]} not found')
 
+    # duplicated_repair_id validation -- keyed on real *status transitions*,
+    # not idempotent form re-submissions. See tech-spec Technical Decisions §3.
+    effective_dup_id = changes.get('duplicated_repair_id', record.duplicated_repair_id)
+    effective_status = changes.get('status', record.status)
+    transitioning_to_closed_dup = (
+        'status' in changes
+        and changes['status'] == 'Closed - Duplicate'
+        and record.status != 'Closed - Duplicate'
+    )
+    setting_dup_explicit = (
+        'duplicated_repair_id' in changes
+        and changes['duplicated_repair_id'] is not None
+        and changes['duplicated_repair_id'] != record.duplicated_repair_id
+    )
+    transitioning_away_from_closed_dup = (
+        'status' in changes
+        and changes['status'] != 'Closed - Duplicate'
+        and record.status == 'Closed - Duplicate'
+    )
+
+    if transitioning_to_closed_dup and effective_dup_id is None:
+        raise ValidationError(
+            "'Closed - Duplicate' status requires a duplicated_repair_id",
+        )
+    if setting_dup_explicit and effective_status != 'Closed - Duplicate':
+        raise ValidationError(
+            "duplicated_repair_id may only be set when status is 'Closed - Duplicate'",
+        )
+    if transitioning_to_closed_dup or setting_dup_explicit:
+        target_id = effective_dup_id
+        if target_id == repair_record_id:
+            raise ValidationError('A repair cannot be a duplicate of itself')
+        target = db.session.get(RepairRecord, target_id)
+        if target is None:
+            raise ValidationError(f'Duplicated repair {target_id} not found')
+        if target.equipment_id != record.equipment_id:
+            raise ValidationError(
+                'Duplicated repair must be on the same equipment',
+            )
+
+    # Silent clear when status transitions away from Closed - Duplicate.
+    # Callers must surface a user-visible notice -- see views/repairs.py edit()
+    # and slack/handlers.py handle_repair_action_submission.
+    if (
+        transitioning_away_from_closed_dup
+        and record.duplicated_repair_id is not None
+        and 'duplicated_repair_id' not in changes
+    ):
+        changes['duplicated_repair_id'] = None
+
     # Extract note separately (not a model field)
     note = changes.pop('note', None)
 
@@ -557,6 +626,15 @@ def update_repair_record(
                 author_name=updated_by,
                 old_value=str(old_value) if old_value else None,
                 new_value=str(new_value) if new_value else None,
+            ))
+        elif field_name == 'duplicated_repair_id':
+            db.session.add(RepairTimelineEntry(
+                repair_record_id=record.id,
+                entry_type='duplicated_repair_id_change',
+                author_id=author_id,
+                author_name=updated_by,
+                old_value=str(old_value) if old_value is not None else None,
+                new_value=str(new_value) if new_value is not None else None,
             ))
 
     # Create note timeline entry if note provided

--- a/esb/services/repair_service.py
+++ b/esb/services/repair_service.py
@@ -549,6 +549,18 @@ def update_repair_record(
         raise ValidationError(
             "'Closed - Duplicate' status requires a duplicated_repair_id",
         )
+    # Forbid clearing an existing dup_id to NULL while status stays Closed - Duplicate.
+    # The legacy carve-out (record.duplicated_repair_id is None) is preserved so
+    # legacy rows with NULL dup_id can still be edited for unrelated fields.
+    if (
+        effective_status == 'Closed - Duplicate'
+        and 'duplicated_repair_id' in changes
+        and changes['duplicated_repair_id'] is None
+        and record.duplicated_repair_id is not None
+    ):
+        raise ValidationError(
+            "'Closed - Duplicate' status requires a duplicated_repair_id",
+        )
     if setting_dup_explicit and effective_status != 'Closed - Duplicate':
         raise ValidationError(
             "duplicated_repair_id may only be set when status is 'Closed - Duplicate'",
@@ -565,9 +577,11 @@ def update_repair_record(
                 'Duplicated repair must be on the same equipment',
             )
 
-    # Silent clear when status transitions away from Closed - Duplicate.
-    # Callers must surface a user-visible notice -- see views/repairs.py edit()
-    # and slack/handlers.py handle_repair_action_submission.
+    # Silent clear for callers that pass status but omit duplicated_repair_id
+    # when transitioning away from Closed - Duplicate. The web edit flow does
+    # NOT rely on this path -- it explicitly forces duplicated_repair_id=None
+    # at the view layer so the per-field loop handles the clear deterministically.
+    # This branch protects future callers (CLI, REST) that send a partial update.
     if (
         transitioning_away_from_closed_dup
         and record.duplicated_repair_id is not None

--- a/esb/slack/forms.py
+++ b/esb/slack/forms.py
@@ -731,10 +731,7 @@ def build_repair_action_modal(repair_record):
     if candidates:
         def _label(r):
             prefix = f'#{r.id} [{r.status}] '
-            budget = 75 - len(prefix)
-            if len(r.description) <= budget:
-                return prefix + r.description
-            return prefix + r.description[: max(0, budget - 1)].rstrip() + '…'
+            return prefix + _truncate(r.description, 75 - len(prefix))
 
         dup_options = [
             {

--- a/esb/slack/forms.py
+++ b/esb/slack/forms.py
@@ -406,7 +406,7 @@ def build_repair_create_modal(equipment_options, user_options, preselected_equip
             },
             'options': [
                 {'text': {'type': 'plain_text', 'text': s}, 'value': s}
-                for s in REPAIR_STATUSES
+                for s in REPAIR_STATUSES if s != 'Closed - Duplicate'
             ],
         },
         'label': {'type': 'plain_text', 'text': 'Status'},
@@ -637,10 +637,22 @@ def build_repair_action_modal(repair_record):
     Returns:
         Block Kit modal view dict; ``private_metadata`` carries the id.
     """
+    from esb.services import repair_service  # local: avoid module-level cycle
+
+    candidates = repair_service.list_duplicate_candidates(repair_record.id)
+
     equipment = repair_record.equipment
     area_name = equipment.area.name if equipment and equipment.area else 'No Area'
     equipment_name = equipment.name if equipment else 'Unknown'
     severity_label = repair_record.severity or '\u2014'
+
+    status_options = [
+        ('In Progress', 'In Progress'),
+        ('Closed - Duplicate', 'Closed - Duplicate'),
+        ('Closed - No Issue Found', 'Closed - No Issue Found'),
+    ]
+    if not candidates:
+        status_options = [opt for opt in status_options if opt[0] != 'Closed - Duplicate']
 
     blocks = [
         {
@@ -696,9 +708,8 @@ def build_repair_action_modal(repair_record):
             'action_id': 'status',
             'placeholder': {'type': 'plain_text', 'text': 'Select a status'},
             'options': [
-                {'text': {'type': 'plain_text', 'text': 'In Progress'}, 'value': 'In Progress'},
-                {'text': {'type': 'plain_text', 'text': 'Closed - Duplicate'}, 'value': 'Closed - Duplicate'},
-                {'text': {'type': 'plain_text', 'text': 'Closed - No Issue Found'}, 'value': 'Closed - No Issue Found'},
+                {'text': {'type': 'plain_text', 'text': label}, 'value': value}
+                for value, label in status_options
             ],
         },
         'label': {'type': 'plain_text', 'text': "New Status (used when 'Set Status' chosen)"},
@@ -716,6 +727,37 @@ def build_repair_action_modal(repair_record):
         },
         'label': {'type': 'plain_text', 'text': 'Note (required when resolving)'},
     })
+
+    if candidates:
+        def _label(r):
+            prefix = f'#{r.id} [{r.status}] '
+            budget = 75 - len(prefix)
+            if len(r.description) <= budget:
+                return prefix + r.description
+            return prefix + r.description[: max(0, budget - 1)].rstrip() + '…'
+
+        dup_options = [
+            {
+                'text': {'type': 'plain_text', 'text': _label(r)},
+                'value': str(r.id),
+            }
+            for r in candidates
+        ]
+        blocks.append({
+            'type': 'input',
+            'block_id': 'duplicate_block',
+            'optional': True,
+            'element': {
+                'type': 'static_select',
+                'action_id': 'duplicated_repair_id',
+                'placeholder': {'type': 'plain_text', 'text': 'Select duplicated repair'},
+                'options': dup_options,
+            },
+            'label': {
+                'type': 'plain_text',
+                'text': "Duplicate of (used when 'Set Status → Closed - Duplicate' chosen)",
+            },
+        })
 
     return {
         'type': 'modal',

--- a/esb/slack/handlers.py
+++ b/esb/slack/handlers.py
@@ -603,6 +603,24 @@ def register_handlers(bolt_app, app):
                     })
                     return
                 changes['status'] = status_opt['value']
+                if changes['status'] == 'Closed - Duplicate':
+                    dup_opt = (
+                        values.get('duplicate_block', {})
+                        .get('duplicated_repair_id', {})
+                        .get('selected_option')
+                    )
+                    if not dup_opt:
+                        ack(response_action='errors', errors={
+                            'duplicate_block': 'Selecting which repair this duplicates is required.',
+                        })
+                        return
+                    try:
+                        changes['duplicated_repair_id'] = int(dup_opt['value'])
+                    except (KeyError, TypeError, ValueError):
+                        ack(response_action='errors', errors={
+                            'duplicate_block': 'Invalid duplicate selection.',
+                        })
+                        return
             elif action == 'resolve_with_note':
                 note_val = values.get('note_block', {}).get('note', {}).get('value')
                 if not note_val or not note_val.strip():

--- a/esb/slack/handlers.py
+++ b/esb/slack/handlers.py
@@ -369,13 +369,16 @@ def register_handlers(bolt_app, app):
             from esb.models.repair_record import REPAIR_SEVERITIES, REPAIR_STATUSES
             from esb.slack.forms import build_repair_update_modal, build_user_options
 
-            # Exclude Closed - Duplicate: this modal has no dup-target selector,
-            # and the service rejects status='Closed - Duplicate' without a target.
-            # Users wanting to mark as duplicate must use the action modal
-            # (/esb-repair → pick → Set Status).
+            # Exclude Closed - Duplicate so users cannot *newly* select it via
+            # this modal (no dup-target selector here, service would reject).
+            # BUT if the record's current status is already Closed - Duplicate
+            # we must keep the option, otherwise Slack rejects the modal -- the
+            # builder sets initial_option to record.status, which must exist in
+            # the options list.
             status_options = [
                 {'text': {'type': 'plain_text', 'text': s}, 'value': s}
-                for s in REPAIR_STATUSES if s != 'Closed - Duplicate'
+                for s in REPAIR_STATUSES
+                if s != 'Closed - Duplicate' or record.status == 'Closed - Duplicate'
             ]
             severity_options = [
                 {'text': {'type': 'plain_text', 'text': s}, 'value': s}

--- a/esb/slack/handlers.py
+++ b/esb/slack/handlers.py
@@ -369,9 +369,13 @@ def register_handlers(bolt_app, app):
             from esb.models.repair_record import REPAIR_SEVERITIES, REPAIR_STATUSES
             from esb.slack.forms import build_repair_update_modal, build_user_options
 
+            # Exclude Closed - Duplicate: this modal has no dup-target selector,
+            # and the service rejects status='Closed - Duplicate' without a target.
+            # Users wanting to mark as duplicate must use the action modal
+            # (/esb-repair → pick → Set Status).
             status_options = [
                 {'text': {'type': 'plain_text', 'text': s}, 'value': s}
-                for s in REPAIR_STATUSES
+                for s in REPAIR_STATUSES if s != 'Closed - Duplicate'
             ]
             severity_options = [
                 {'text': {'type': 'plain_text', 'text': s}, 'value': s}

--- a/esb/templates/components/_timeline_entry.html
+++ b/esb/templates/components/_timeline_entry.html
@@ -16,6 +16,15 @@
             {% elif entry.entry_type == 'eta_update' %}
             <span class="badge bg-secondary me-1">ETA</span>
             <strong>ETA {% if entry.new_value %}set to {{ entry.new_value|format_date }}{% else %}removed{% endif %}</strong>
+            {% elif entry.entry_type == 'duplicated_repair_id_change' %}
+            <span class="badge bg-secondary me-1">Duplicate</span>
+            <strong>
+                {% if entry.new_value %}
+                Marked as duplicate of <a href="{{ url_for('repairs.detail', id=entry.new_value|int) }}">#{{ entry.new_value }}</a>
+                {% else %}
+                Unlinked from duplicate{% if entry.old_value %} #{{ entry.old_value }}{% endif %}
+                {% endif %}
+            </strong>
             {% elif entry.entry_type == 'photo' %}
             <span class="badge bg-dark me-1">Photo</span>
             <strong>Photo uploaded</strong>

--- a/esb/templates/repairs/detail.html
+++ b/esb/templates/repairs/detail.html
@@ -57,6 +57,10 @@
             </dd>
             <dt class="col-sm-3">Status</dt>
             <dd class="col-sm-9"><span class="badge bg-info text-dark">{{ record.status }}</span></dd>
+            {% if record.duplicated_repair_id %}
+            <dt class="col-sm-3">Marked as duplicate of</dt>
+            <dd class="col-sm-9"><a href="{{ url_for('repairs.detail', id=record.duplicated_repair_id) }}">Repair #{{ record.duplicated_repair_id }}</a></dd>
+            {% endif %}
             <dt class="col-sm-3">Severity</dt>
             <dd class="col-sm-9">{{ record.severity or 'Not set' }}</dd>
             <dt class="col-sm-3">Assignee</dt>

--- a/esb/templates/repairs/edit.html
+++ b/esb/templates/repairs/edit.html
@@ -25,6 +25,12 @@
                 {% endfor %}
             </div>
 
+            <div id="duplicate-block" class="mb-3"{% if form.status.data != 'Closed - Duplicate' %} style="display: none;"{% endif %}>
+                <label for="duplicated_repair_id" class="form-label">Duplicate of *</label>
+                {{ form.duplicated_repair_id(class="form-select") }}
+                <div class="form-text">Required when status is "Closed - Duplicate".</div>
+            </div>
+
             <div class="row">
                 <div class="col-md-6 mb-3">
                     <label for="severity" class="form-label">Severity</label>
@@ -73,6 +79,17 @@
                 <a href="{{ url_for('repairs.detail', id=record.id) }}" class="btn btn-outline-secondary">Cancel</a>
             </div>
         </form>
+        <script>
+        (function () {
+            const statusSelect = document.querySelector('select[name="status"]');
+            const dupBlock = document.getElementById('duplicate-block');
+            if (!statusSelect || !dupBlock) return;
+            const sync = () => {
+                dupBlock.style.display = statusSelect.value === 'Closed - Duplicate' ? '' : 'none';
+            };
+            statusSelect.addEventListener('change', sync);
+        })();
+        </script>
     </div>
 </div>
 {% endblock %}

--- a/esb/templates/repairs/edit.html
+++ b/esb/templates/repairs/edit.html
@@ -25,7 +25,7 @@
                 {% endfor %}
             </div>
 
-            <div id="duplicate-block" class="mb-3"{% if form.status.data != 'Closed - Duplicate' %} style="display: none;"{% endif %}>
+            <div id="duplicate-block" class="mb-3">
                 <label for="duplicated_repair_id" class="form-label">Duplicate of *</label>
                 {{ form.duplicated_repair_id(class="form-select") }}
                 <div class="form-text">Required when status is "Closed - Duplicate".</div>
@@ -87,6 +87,9 @@
             const sync = () => {
                 dupBlock.style.display = statusSelect.value === 'Closed - Duplicate' ? '' : 'none';
             };
+            // Run on load so JS users see the block hidden when not Closed - Duplicate.
+            // No-JS users see the block always (degraded but functional).
+            sync();
             statusSelect.addEventListener('change', sync);
         })();
         </script>

--- a/esb/views/repairs.py
+++ b/esb/views/repairs.py
@@ -305,15 +305,34 @@ def edit(id):
         (u.id, u.username) for u in users
     ]
 
+    candidates = repair_service.list_duplicate_candidates(id)
+
+    def _candidate_label(c):
+        prefix = f'#{c.id} [{c.status}] '
+        budget = 75 - len(prefix)
+        if len(c.description) <= budget:
+            return prefix + c.description
+        return prefix + c.description[: max(0, budget - 1)].rstrip() + '…'
+
+    form.duplicated_repair_id.choices = [(0, '-- Select duplicate of --')] + [
+        (c.id, _candidate_label(c)) for c in candidates
+    ]
+
     if request.method == 'GET':
         form.status.data = record.status
         form.severity.data = record.severity or ''
         form.assignee_id.data = record.assignee_id or 0
         form.eta.data = record.eta
         form.specialist_description.data = record.specialist_description or ''
+        form.duplicated_repair_id.data = record.duplicated_repair_id or 0
         form.note.data = ''
 
     if form.validate_on_submit():
+        had_dup_link = (
+            record.status == 'Closed - Duplicate'
+            and record.duplicated_repair_id is not None
+        )
+        target_status = form.status.data
         try:
             repair_service.update_repair_record(
                 repair_record_id=id,
@@ -324,12 +343,22 @@ def edit(id):
                 assignee_id=form.assignee_id.data if form.assignee_id.data != 0 else None,
                 eta=form.eta.data,
                 specialist_description=form.specialist_description.data or None,
+                duplicated_repair_id=(
+                    form.duplicated_repair_id.data
+                    if form.duplicated_repair_id.data != 0
+                    else None
+                ),
                 note=form.note.data or None,
             )
         except ValidationError as e:
             flash(str(e), 'danger')
             return render_template('repairs/edit.html', form=form, record=record)
 
+        if had_dup_link and target_status != 'Closed - Duplicate':
+            flash(
+                'Duplicate link cleared because status changed away from "Closed - Duplicate".',
+                'info',
+            )
         flash('Repair record updated successfully.', 'success')
         return redirect(url_for('repairs.detail', id=id))
 

--- a/esb/views/repairs.py
+++ b/esb/views/repairs.py
@@ -344,8 +344,12 @@ def edit(id):
                 eta=form.eta.data,
                 specialist_description=form.specialist_description.data or None,
                 duplicated_repair_id=(
-                    form.duplicated_repair_id.data
-                    if form.duplicated_repair_id.data != 0
+                    # Force None when status is not Closed - Duplicate so the
+                    # service receives an explicit clear. The JS only toggles
+                    # the dropdown's display -- it does not reset the value --
+                    # so a browser will otherwise POST the stale dup_id.
+                    (form.duplicated_repair_id.data if form.duplicated_repair_id.data != 0 else None)
+                    if form.status.data == 'Closed - Duplicate'
                     else None
                 ),
                 note=form.note.data or None,

--- a/migrations/versions/b2aa842a2c53_add_duplicated_repair_id_to_repair_.py
+++ b/migrations/versions/b2aa842a2c53_add_duplicated_repair_id_to_repair_.py
@@ -1,0 +1,42 @@
+"""Add duplicated_repair_id to repair_records
+
+Revision ID: b2aa842a2c53
+Revises: 374030acbd33
+Create Date: 2026-05-13 18:34:49.672116
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b2aa842a2c53'
+down_revision = '374030acbd33'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('repair_records', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('duplicated_repair_id', sa.Integer(), nullable=True))
+        batch_op.create_index(
+            batch_op.f('ix_repair_records_duplicated_repair_id'),
+            ['duplicated_repair_id'],
+            unique=False,
+        )
+        batch_op.create_foreign_key(
+            'fk_repair_records_duplicated_repair_id',
+            'repair_records',
+            ['duplicated_repair_id'],
+            ['id'],
+            ondelete='SET NULL',
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('repair_records', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_repair_records_duplicated_repair_id'))
+        batch_op.drop_constraint(
+            'fk_repair_records_duplicated_repair_id', type_='foreignkey',
+        )
+        batch_op.drop_column('duplicated_repair_id')

--- a/tests/test_models/test_repair_record.py
+++ b/tests/test_models/test_repair_record.py
@@ -102,6 +102,57 @@ class TestRepairRecordCreation:
         assert repr(record) == f'<RepairRecord {record.id} [New]>'
 
 
+class TestDuplicatedRepair:
+    """Tests for the duplicated_repair_id column and self-relationship."""
+
+    def test_duplicated_repair_id_nullable(self, app, make_equipment):
+        eq = make_equipment()
+        record = RepairRecord(equipment_id=eq.id, description='Broken')
+        _db.session.add(record)
+        _db.session.commit()
+        assert record.duplicated_repair_id is None
+        assert record.duplicated_repair is None
+
+    def test_duplicated_repair_relationship(self, app, make_equipment):
+        eq = make_equipment()
+        original = RepairRecord(equipment_id=eq.id, description='Original')
+        _db.session.add(original)
+        _db.session.commit()
+        dup = RepairRecord(
+            equipment_id=eq.id,
+            description='Same thing again',
+            duplicated_repair_id=original.id,
+        )
+        _db.session.add(dup)
+        _db.session.commit()
+        _db.session.expire_all()
+        fetched = _db.session.get(RepairRecord, dup.id)
+        assert fetched.duplicated_repair_id == original.id
+        assert fetched.duplicated_repair.id == original.id
+        assert fetched.duplicated_repair.description == 'Original'
+
+    def test_on_delete_set_null(self, app, make_equipment):
+        """Deleting the target nulls the child's duplicated_repair_id (ON DELETE SET NULL)."""
+        eq = make_equipment()
+        target = RepairRecord(equipment_id=eq.id, description='Target')
+        _db.session.add(target)
+        _db.session.commit()
+        child = RepairRecord(
+            equipment_id=eq.id,
+            description='Child',
+            duplicated_repair_id=target.id,
+        )
+        _db.session.add(child)
+        _db.session.commit()
+        child_id = child.id
+        _db.session.delete(target)
+        _db.session.commit()
+        _db.session.expire_all()
+        refetched = _db.session.get(RepairRecord, child_id)
+        assert refetched is not None
+        assert refetched.duplicated_repair_id is None
+
+
 class TestRepairRecordConstants:
     """Tests for module-level constants."""
 

--- a/tests/test_models/test_repair_timeline_entry.py
+++ b/tests/test_models/test_repair_timeline_entry.py
@@ -115,4 +115,5 @@ class TestTimelineEntryConstants:
         assert 'creation' in TIMELINE_ENTRY_TYPES
         assert 'note' in TIMELINE_ENTRY_TYPES
         assert 'status_change' in TIMELINE_ENTRY_TYPES
-        assert len(TIMELINE_ENTRY_TYPES) == 6
+        assert 'duplicated_repair_id_change' in TIMELINE_ENTRY_TYPES
+        assert len(TIMELINE_ENTRY_TYPES) == 7

--- a/tests/test_services/test_repair_service.py
+++ b/tests/test_services/test_repair_service.py
@@ -655,12 +655,14 @@ class TestUpdateRepairRecordSlackNotification:
 
         area = make_area(name='Woodshop', slack_channel='#woodshop')
         equip = make_equipment(name='SawStop', area=area)
+        target = RepairRecord(equipment_id=equip.id, description='Original', status='In Progress')
         record = RepairRecord(equipment_id=equip.id, description='Test', status='In Progress')
-        _db.session.add(record)
+        _db.session.add_all([target, record])
         _db.session.commit()
 
         repair_service.update_repair_record(
-            record.id, 'staffuser', author_id=staff_user.id, status='Closed - Duplicate',
+            record.id, 'staffuser', author_id=staff_user.id,
+            status='Closed - Duplicate', duplicated_repair_id=target.id,
         )
 
         notifications = _db.session.execute(
@@ -1997,3 +1999,217 @@ class TestGetRepairQueue:
         results = repair_service.get_repair_queue(area_id=area1.id, assignee_id=tech.id)
         descriptions = [r.description for r in results]
         assert descriptions == ['area1-tech']
+
+
+class TestListDuplicateCandidates:
+    """Tests for list_duplicate_candidates()."""
+
+    def test_returns_same_equipment_excludes_self_newest_first(
+        self, app, make_area, make_equipment,
+    ):
+        area = make_area()
+        eq = make_equipment('Saw', area=area)
+        other_eq = make_equipment('Drill', area=area)
+        now = datetime.now(UTC).replace(tzinfo=None)
+        r2 = RepairRecord(
+            equipment_id=eq.id, description='r2 (oldest)',
+            created_at=now - timedelta(days=3),
+        )
+        r3 = RepairRecord(
+            equipment_id=eq.id, description='r3 (mid)',
+            created_at=now - timedelta(days=2),
+        )
+        r1 = RepairRecord(
+            equipment_id=eq.id, description='r1 (target self)',
+            created_at=now - timedelta(days=1),
+        )
+        r_other = RepairRecord(
+            equipment_id=other_eq.id, description='other equipment',
+            created_at=now - timedelta(hours=1),
+        )
+        _db.session.add_all([r2, r3, r1, r_other])
+        _db.session.commit()
+
+        results = repair_service.list_duplicate_candidates(r1.id)
+        result_descriptions = [r.description for r in results]
+        # Newest first; r1 (self) excluded; r_other (different eq) excluded.
+        assert result_descriptions == ['r3 (mid)', 'r2 (oldest)']
+
+    def test_empty_when_single_repair(self, app, make_equipment):
+        eq = make_equipment()
+        only = RepairRecord(equipment_id=eq.id, description='only one')
+        _db.session.add(only)
+        _db.session.commit()
+        assert repair_service.list_duplicate_candidates(only.id) == []
+
+    def test_raises_for_missing_record(self, app):
+        with pytest.raises(ValidationError, match='Repair record with id 99999 not found'):
+            repair_service.list_duplicate_candidates(99999)
+
+
+class TestDuplicatedRepairId:
+    """Tests for the duplicated_repair_id field in update_repair_record."""
+
+    def _two_repairs(self, make_equipment, status_r1='In Progress'):
+        eq = make_equipment()
+        r1 = RepairRecord(equipment_id=eq.id, description='r1 desc', status=status_r1)
+        r2 = RepairRecord(equipment_id=eq.id, description='r2 desc', status='In Progress')
+        _db.session.add_all([r1, r2])
+        _db.session.commit()
+        return r1, r2
+
+    def test_transition_to_closed_duplicate_succeeds(
+        self, app, make_equipment, staff_user, capture,
+    ):
+        """AC-4: transition to Closed - Duplicate with valid target succeeds, emits timeline + audit."""
+        r1, r2 = self._two_repairs(make_equipment)
+        repair_service.update_repair_record(
+            r1.id, 'staffuser', author_id=staff_user.id,
+            status='Closed - Duplicate', duplicated_repair_id=r2.id,
+        )
+        _db.session.expire_all()
+        refetched = _db.session.get(RepairRecord, r1.id)
+        assert refetched.status == 'Closed - Duplicate'
+        assert refetched.duplicated_repair_id == r2.id
+        # Timeline entry for the duplicate-link change
+        dup_entries = _db.session.execute(
+            _db.select(RepairTimelineEntry).filter_by(
+                repair_record_id=r1.id,
+                entry_type='duplicated_repair_id_change',
+            )
+        ).scalars().all()
+        assert len(dup_entries) == 1
+        assert dup_entries[0].old_value is None
+        assert dup_entries[0].new_value == str(r2.id)
+        # Mutation log includes the field
+        updated_logs = [
+            r for r in capture.records if 'repair_record.updated' in r.message
+        ]
+        log_data = json.loads(updated_logs[0].message)
+        assert log_data['data']['changes']['duplicated_repair_id'] == [None, str(r2.id)]
+
+    def test_transition_without_target_raises(self, app, make_equipment, staff_user):
+        """AC-5: ValidationError when transitioning to Closed - Duplicate with no target."""
+        r1, _r2 = self._two_repairs(make_equipment)
+        with pytest.raises(ValidationError, match='Closed - Duplicate'):
+            repair_service.update_repair_record(
+                r1.id, 'staffuser', author_id=staff_user.id,
+                status='Closed - Duplicate',
+            )
+        _db.session.expire_all()
+        assert _db.session.get(RepairRecord, r1.id).status == 'In Progress'
+
+    def test_self_reference_raises(self, app, make_equipment, staff_user):
+        """AC-6: ValidationError for duplicate-of-self."""
+        r1, _r2 = self._two_repairs(make_equipment)
+        with pytest.raises(ValidationError, match='cannot be a duplicate of itself'):
+            repair_service.update_repair_record(
+                r1.id, 'staffuser', author_id=staff_user.id,
+                status='Closed - Duplicate', duplicated_repair_id=r1.id,
+            )
+
+    def test_cross_equipment_raises(self, app, make_area, make_equipment, staff_user):
+        """AC-7: ValidationError when target is on different equipment."""
+        area = make_area()
+        eq1 = make_equipment('eq1', area=area)
+        eq2 = make_equipment('eq2', area=area)
+        r1 = RepairRecord(equipment_id=eq1.id, description='r1', status='In Progress')
+        r2 = RepairRecord(equipment_id=eq2.id, description='r2', status='In Progress')
+        _db.session.add_all([r1, r2])
+        _db.session.commit()
+        with pytest.raises(ValidationError, match='must be on the same equipment'):
+            repair_service.update_repair_record(
+                r1.id, 'staffuser', author_id=staff_user.id,
+                status='Closed - Duplicate', duplicated_repair_id=r2.id,
+            )
+
+    def test_nonexistent_target_raises(self, app, make_equipment, staff_user):
+        """AC-8: ValidationError when target id does not exist."""
+        r1, _r2 = self._two_repairs(make_equipment)
+        with pytest.raises(ValidationError, match='Duplicated repair 99999 not found'):
+            repair_service.update_repair_record(
+                r1.id, 'staffuser', author_id=staff_user.id,
+                status='Closed - Duplicate', duplicated_repair_id=99999,
+            )
+
+    def test_setting_dup_without_correct_status_raises(
+        self, app, make_equipment, staff_user,
+    ):
+        """AC-9: ValidationError when setting duplicated_repair_id without status=Closed - Duplicate."""
+        r1, r2 = self._two_repairs(make_equipment, status_r1='Resolved')
+        with pytest.raises(
+            ValidationError, match="may only be set when status is 'Closed - Duplicate'",
+        ):
+            repair_service.update_repair_record(
+                r1.id, 'staffuser', author_id=staff_user.id,
+                duplicated_repair_id=r2.id,
+            )
+
+    def test_transition_away_clears_duplicate_link(
+        self, app, make_equipment, staff_user, capture,
+    ):
+        """AC-10: transition away from Closed - Duplicate auto-clears duplicated_repair_id."""
+        eq_helper_record = make_equipment()
+        r2 = RepairRecord(equipment_id=eq_helper_record.id, description='r2', status='In Progress')
+        _db.session.add(r2)
+        _db.session.commit()
+        r1 = RepairRecord(
+            equipment_id=eq_helper_record.id,
+            description='r1',
+            status='Closed - Duplicate',
+            duplicated_repair_id=r2.id,
+        )
+        _db.session.add(r1)
+        _db.session.commit()
+
+        repair_service.update_repair_record(
+            r1.id, 'staffuser', author_id=staff_user.id, status='In Progress',
+        )
+        _db.session.expire_all()
+        refetched = _db.session.get(RepairRecord, r1.id)
+        assert refetched.duplicated_repair_id is None
+
+        # Timeline entry for the duplicate-link clear
+        dup_entries = _db.session.execute(
+            _db.select(RepairTimelineEntry).filter_by(
+                repair_record_id=r1.id,
+                entry_type='duplicated_repair_id_change',
+            )
+        ).scalars().all()
+        assert len(dup_entries) == 1
+        assert dup_entries[0].old_value == str(r2.id)
+        assert dup_entries[0].new_value is None
+
+        # Audit log captures the clear
+        audit = _db.session.execute(
+            _db.select(AuditLog).filter_by(
+                entity_type='repair_record', entity_id=r1.id, action='updated',
+            )
+        ).scalar_one()
+        assert audit.changes['duplicated_repair_id'] == [str(r2.id), None]
+
+    def test_legacy_record_unaffected_for_unrelated_edit(
+        self, app, make_equipment, staff_user,
+    ):
+        """AC-11: legacy Closed - Duplicate record with NULL dup_id can edit unrelated fields."""
+        eq = make_equipment()
+        legacy = RepairRecord(
+            equipment_id=eq.id,
+            description='legacy',
+            status='Closed - Duplicate',
+            duplicated_repair_id=None,
+        )
+        _db.session.add(legacy)
+        _db.session.commit()
+
+        # The web form would re-assert the existing status when editing
+        # an unrelated field. Should be a no-op transition.
+        repair_service.update_repair_record(
+            legacy.id, 'staffuser', author_id=staff_user.id,
+            status='Closed - Duplicate', specialist_description='x',
+        )
+        _db.session.expire_all()
+        refetched = _db.session.get(RepairRecord, legacy.id)
+        assert refetched.specialist_description == 'x'
+        assert refetched.status == 'Closed - Duplicate'
+        assert refetched.duplicated_repair_id is None

--- a/tests/test_services/test_repair_service.py
+++ b/tests/test_services/test_repair_service.py
@@ -2188,6 +2188,32 @@ class TestDuplicatedRepairId:
         ).scalar_one()
         assert audit.changes['duplicated_repair_id'] == [str(r2.id), None]
 
+    def test_clearing_dup_id_while_status_remains_closed_duplicate_raises(
+        self, app, make_equipment, staff_user,
+    ):
+        """Bug fix: cannot clear dup_id to None while status stays Closed - Duplicate."""
+        eq = make_equipment()
+        target = RepairRecord(equipment_id=eq.id, description='Target', status='In Progress')
+        _db.session.add(target)
+        _db.session.commit()
+        record = RepairRecord(
+            equipment_id=eq.id,
+            description='Existing dup',
+            status='Closed - Duplicate',
+            duplicated_repair_id=target.id,
+        )
+        _db.session.add(record)
+        _db.session.commit()
+
+        with pytest.raises(ValidationError, match='Closed - Duplicate'):
+            repair_service.update_repair_record(
+                record.id, 'staffuser', author_id=staff_user.id,
+                status='Closed - Duplicate', duplicated_repair_id=None,
+            )
+        _db.session.expire_all()
+        unchanged = _db.session.get(RepairRecord, record.id)
+        assert unchanged.duplicated_repair_id == target.id
+
     def test_legacy_record_unaffected_for_unrelated_edit(
         self, app, make_equipment, staff_user,
     ):

--- a/tests/test_slack/test_forms.py
+++ b/tests/test_slack/test_forms.py
@@ -242,7 +242,10 @@ class TestBuildRepairCreateModal:
 
         status_block = [b for b in modal['blocks'] if b['block_id'] == 'status_block'][0]
         status_values = [o['value'] for o in status_block['element']['options']]
-        assert status_values == REPAIR_STATUSES
+        # Closed - Duplicate is filtered out of the create modal: a repair
+        # cannot be created already-duplicate (the dup-target dropdown lives on
+        # the action modal). See tech-spec Technical Decisions §10.
+        assert status_values == [s for s in REPAIR_STATUSES if s != 'Closed - Duplicate']
 
     def test_no_assignee_block_when_no_users(self):
         """L2: Assignee block is excluded when no users available."""
@@ -779,6 +782,9 @@ class TestBuildRepairActionModal:
         area = make_area('Shop', '#shop')
         eq = make_equipment('Tool', 'X', 'M', area=area)
         rec = make_repair_record(equipment=eq, status='New', severity='Down', description='broken')
+        # Need a sibling so duplicate-candidates is non-empty -- otherwise the
+        # builder filters Closed - Duplicate out of the status options.
+        make_repair_record(equipment=eq, status='New', severity='Down', description='sibling')
 
         modal = build_repair_action_modal(rec)
         status_block = next(b for b in modal['blocks'] if b.get('block_id') == 'status_block')
@@ -799,6 +805,77 @@ class TestBuildRepairActionModal:
         modal = build_repair_action_modal(rec)
         eta_block = next(b for b in modal['blocks'] if b.get('block_id') == 'eta_block')
         assert eta_block['element']['initial_date'] == '2026-07-04'
+
+    def test_duplicate_block_when_candidates_exist(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """AC-19: duplicate_block present with each sibling repair as an option."""
+        from esb.slack.forms import build_repair_action_modal
+
+        area = make_area('Shop', '#shop')
+        eq = make_equipment('Tool', 'X', 'M', area=area)
+        rec1 = make_repair_record(equipment=eq, status='New', severity='Down', description='r1')
+        rec2 = make_repair_record(equipment=eq, status='In Progress', severity='Down', description='r2')
+
+        modal = build_repair_action_modal(rec1)
+        dup_block = next(
+            (b for b in modal['blocks'] if b.get('block_id') == 'duplicate_block'),
+            None,
+        )
+        assert dup_block is not None
+        values = [o['value'] for o in dup_block['element']['options']]
+        assert str(rec2.id) in values
+        # First option text starts with #ID [Status]
+        first_opt = dup_block['element']['options'][0]
+        assert first_opt['text']['text'].startswith(f'#{rec2.id} [In Progress]')
+
+    def test_no_duplicate_block_and_no_closed_duplicate_option_when_no_candidates(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """AC-20: lone repair has no duplicate_block AND status options exclude Closed - Duplicate."""
+        from esb.slack.forms import build_repair_action_modal
+
+        area = make_area('Shop', '#shop')
+        eq = make_equipment('Tool', 'X', 'M', area=area)
+        rec = make_repair_record(equipment=eq, status='New', severity='Down', description='r1')
+
+        modal = build_repair_action_modal(rec)
+        assert all(b.get('block_id') != 'duplicate_block' for b in modal['blocks'])
+        status_block = next(b for b in modal['blocks'] if b.get('block_id') == 'status_block')
+        values = [o['value'] for o in status_block['element']['options']]
+        assert 'Closed - Duplicate' not in values
+
+    def test_duplicate_option_label_budget(
+        self, app, make_area, make_equipment, make_repair_record,
+    ):
+        """No duplicate-option's text.text exceeds Slack's 75-char limit."""
+        from esb.slack.forms import build_repair_action_modal
+
+        area = make_area('Shop', '#shop')
+        eq = make_equipment('Tool', 'X', 'M', area=area)
+        rec1 = make_repair_record(equipment=eq, status='New', severity='Down', description='target')
+        # Very long description to force truncation
+        make_repair_record(
+            equipment=eq, status='In Progress', severity='Down',
+            description='X' * 500,
+        )
+
+        modal = build_repair_action_modal(rec1)
+        dup_block = next(b for b in modal['blocks'] if b.get('block_id') == 'duplicate_block')
+        for opt in dup_block['element']['options']:
+            assert len(opt['text']['text']) <= 75
+
+
+class TestRepairCreateModalStatusFilter:
+    """AC-21: Closed - Duplicate filtered out of create-modal status options."""
+
+    def test_closed_duplicate_excluded_from_create_modal_status(self, app):
+        from esb.slack.forms import build_repair_create_modal
+
+        modal = build_repair_create_modal([], [])
+        status_block = next(b for b in modal['blocks'] if b.get('block_id') == 'status_block')
+        values = [o['value'] for o in status_block['element']['options']]
+        assert 'Closed - Duplicate' not in values
 
 
 class TestFormatEquipmentStatusDetail:

--- a/tests/test_slack/test_handlers.py
+++ b/tests/test_slack/test_handlers.py
@@ -392,6 +392,45 @@ class TestEsbUpdateCommand:
         assert modal['callback_id'] == 'repair_update_submission'
         assert modal['private_metadata'] == str(self.record.id)
 
+    def test_modal_status_options_include_closed_duplicate_when_record_is_already(self):
+        """If the record's current status is already Closed - Duplicate, the
+        option must remain so Slack does not reject the modal (initial_option
+        must exist in options).
+        """
+        # Need a second repair to satisfy the service-layer validation for the
+        # existing Closed - Duplicate record. Then create one with that status.
+        target = _create_repair_record(
+            equipment=self.equipment, status='In Progress', description='target',
+        )
+        from esb.models.repair_record import RepairRecord
+        dup_record = RepairRecord(
+            equipment_id=self.equipment.id,
+            description='already closed as dup',
+            status='Closed - Duplicate',
+            duplicated_repair_id=target.id,
+        )
+        self.db.session.add(dup_record)
+        self.db.session.commit()
+
+        ack = MagicMock()
+        client = MagicMock()
+        client.users_info.return_value = {
+            'user': {'profile': {'email': self.staff_user.email}},
+        }
+        body = {
+            'trigger_id': 'T123', 'user_id': 'U123', 'channel_id': 'C123',
+            'text': str(dup_record.id),
+        }
+
+        self.handlers['command:/esb-update'](ack=ack, body=body, client=client)
+
+        modal = client.views_open.call_args.kwargs['view']
+        status_block = next(b for b in modal['blocks'] if b.get('block_id') == 'status_block')
+        values = [o['value'] for o in status_block['element']['options']]
+        assert 'Closed - Duplicate' in values
+        # initial_option set to the record's current status -- must also be in options.
+        assert status_block['element']['initial_option']['value'] == 'Closed - Duplicate'
+
     def test_modal_status_options_exclude_closed_duplicate(self):
         """Closed - Duplicate filtered from /esb-update modal: the update flow
         does not collect a dup target, so setting that status here would always

--- a/tests/test_slack/test_handlers.py
+++ b/tests/test_slack/test_handlers.py
@@ -1095,20 +1095,36 @@ class TestRepairActionSubmission:
         self.tech_user = _create_user('technician', username='techie')
         self.handlers = _register_and_capture(app)
 
-    def _build_view(self, repair_id, action=None, eta=None, status=None, note=None):
+    def _build_view(
+        self, repair_id, action=None, eta=None, status=None, note=None,
+        duplicate_id=None, include_duplicate_block=None,
+    ):
         action_block = {'action': {'selected_option': {'value': action}}} if action else {'action': {'selected_option': None}}
         eta_block = {'eta': {'selected_date': eta}}
         status_block = {'status': {'selected_option': {'value': status}}} if status else {'status': {'selected_option': None}}
         note_block = {'note': {'value': note}}
+        values = {
+            'action_block': action_block,
+            'eta_block': eta_block,
+            'status_block': status_block,
+            'note_block': note_block,
+        }
+        # Include duplicate_block when explicitly opted in, or when a duplicate_id is provided.
+        if include_duplicate_block or duplicate_id is not None:
+            if duplicate_id is not None:
+                values['duplicate_block'] = {
+                    'duplicated_repair_id': {
+                        'selected_option': {'value': str(duplicate_id)},
+                    },
+                }
+            else:
+                values['duplicate_block'] = {
+                    'duplicated_repair_id': {'selected_option': None},
+                }
         return {
             'private_metadata': str(repair_id),
             'state': {
-                'values': {
-                    'action_block': action_block,
-                    'eta_block': eta_block,
-                    'status_block': status_block,
-                    'note_block': note_block,
-                },
+                'values': values,
             },
         }
 
@@ -1449,11 +1465,11 @@ class TestRepairActionSubmission:
         client4 = self._client(self.tech_user.email)
         self.handlers['view:repair_action_submission'](
             ack=MagicMock(), body=self._body(self.tech_user.email), client=client4,
-            view=self._build_view(rec4.id, action='set_status', status='Closed - Duplicate'),
+            view=self._build_view(rec4.id, action='set_status', status='Closed - No Issue Found'),
         )
         text4 = client4.chat_postEphemeral.call_args.kwargs['text']
         assert ':white_check_mark:' in text4
-        assert 'closed: Closed - Duplicate' in text4
+        assert 'closed: Closed - No Issue Found' in text4
 
         # resolve_with_note → :white_check_mark:
         rec5 = _create_repair_record(equipment=self.equipment, status='In Progress', severity='Down', description='x')
@@ -1464,6 +1480,101 @@ class TestRepairActionSubmission:
         )
         assert ':white_check_mark:' in client5.chat_postEphemeral.call_args.kwargs['text']
 
+    def test_set_status_closed_duplicate_with_target_succeeds(self):
+        """AC-22: set_status to Closed - Duplicate with a valid target updates record + acks."""
+        target = _create_repair_record(
+            equipment=self.equipment, status='In Progress', severity='Down', description='target',
+        )
+        record = _create_repair_record(
+            equipment=self.equipment, status='In Progress', severity='Down', description='dup',
+        )
+        ack = MagicMock()
+        client = self._client(self.tech_user.email)
+        view = self._build_view(
+            record.id, action='set_status', status='Closed - Duplicate',
+            duplicate_id=target.id,
+        )
+        self.handlers['view:repair_action_submission'](
+            ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
+        )
+        ack.assert_called_once_with()
+
+        from esb.models.repair_record import RepairRecord
+        self.db.session.expire_all()
+        rec = self.db.session.get(RepairRecord, record.id)
+        assert rec.status == 'Closed - Duplicate'
+        assert rec.duplicated_repair_id == target.id
+        client.chat_postEphemeral.assert_called_once()
+        text = client.chat_postEphemeral.call_args.kwargs['text']
+        assert f'Repair #{record.id}' in text
+        assert 'Closed - Duplicate' in text
+
+    def test_set_status_closed_duplicate_without_target_returns_inline_error(self):
+        """AC-23: missing duplicate selection → ack errors and no update."""
+        target = _create_repair_record(
+            equipment=self.equipment, status='In Progress', severity='Down', description='target',
+        )
+        record = _create_repair_record(
+            equipment=self.equipment, status='In Progress', severity='Down', description='dup',
+        )
+        ack = MagicMock()
+        client = self._client(self.tech_user.email)
+        # include_duplicate_block True but no duplicate_id => selected_option None
+        view = self._build_view(
+            record.id, action='set_status', status='Closed - Duplicate',
+            include_duplicate_block=True,
+        )
+        self.handlers['view:repair_action_submission'](
+            ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
+        )
+        ack.assert_called_once()
+        kwargs = ack.call_args.kwargs
+        assert kwargs.get('response_action') == 'errors'
+        assert 'duplicate_block' in kwargs.get('errors', {})
+
+        from esb.models.repair_record import RepairRecord
+        self.db.session.expire_all()
+        rec = self.db.session.get(RepairRecord, record.id)
+        assert rec.status == 'In Progress'  # unchanged
+        # target untouched too
+        assert self.db.session.get(RepairRecord, target.id).status == 'In Progress'
+
+    def test_set_status_closed_duplicate_stale_target_surfaces_validation_error(self):
+        """AC-24: target deleted between modal build and submit → ValidationError surfaces on action_block."""
+        target = _create_repair_record(
+            equipment=self.equipment, status='In Progress', severity='Down', description='target',
+        )
+        record = _create_repair_record(
+            equipment=self.equipment, status='In Progress', severity='Down', description='dup',
+        )
+        target_id = target.id
+
+        # Simulate target deletion between modal-build and submit.
+        self.db.session.delete(target)
+        self.db.session.commit()
+
+        ack = MagicMock()
+        client = self._client(self.tech_user.email)
+        view = self._build_view(
+            record.id, action='set_status', status='Closed - Duplicate',
+            duplicate_id=target_id,
+        )
+        self.handlers['view:repair_action_submission'](
+            ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
+        )
+        ack.assert_called_once()
+        kwargs = ack.call_args.kwargs
+        assert kwargs.get('response_action') == 'errors'
+        assert 'action_block' in kwargs.get('errors', {})
+        assert f'Duplicated repair {target_id} not found' in kwargs['errors']['action_block']
+
+        from esb.models.repair_record import RepairRecord
+        self.db.session.expire_all()
+        rec = self.db.session.get(RepairRecord, record.id)
+        assert rec.status == 'In Progress'  # unchanged
+        assert rec.duplicated_repair_id is None
+        # No ephemeral message was posted
+        client.chat_postEphemeral.assert_not_called()
 
 class TestEsbReportRegression:
     """AC 30 / F13: /esb-report stays distinct from /esb-repair after the dispatcher refactor."""

--- a/tests/test_slack/test_handlers.py
+++ b/tests/test_slack/test_handlers.py
@@ -392,6 +392,29 @@ class TestEsbUpdateCommand:
         assert modal['callback_id'] == 'repair_update_submission'
         assert modal['private_metadata'] == str(self.record.id)
 
+    def test_modal_status_options_exclude_closed_duplicate(self):
+        """Closed - Duplicate filtered from /esb-update modal: the update flow
+        does not collect a dup target, so setting that status here would always
+        trip the service-layer validation."""
+        ack = MagicMock()
+        client = MagicMock()
+        client.users_info.return_value = {
+            'user': {'profile': {'email': self.staff_user.email}},
+        }
+        body = {
+            'trigger_id': 'T123',
+            'user_id': 'U123',
+            'channel_id': 'C123',
+            'text': str(self.record.id),
+        }
+
+        self.handlers['command:/esb-update'](ack=ack, body=body, client=client)
+
+        modal = client.views_open.call_args.kwargs['view']
+        status_block = next(b for b in modal['blocks'] if b.get('block_id') == 'status_block')
+        values = [o['value'] for o in status_block['element']['options']]
+        assert 'Closed - Duplicate' not in values
+
     def test_without_id_returns_error(self):
         """5.8: /esb-update without ID returns error message."""
         ack = MagicMock()

--- a/tests/test_views/test_repair_views.py
+++ b/tests/test_views/test_repair_views.py
@@ -310,6 +310,144 @@ class TestEditRepairRecord:
         assert resp.status_code == 302
         assert '/auth/login' in resp.headers['Location']
 
+    def test_edit_page_hides_duplicate_block_for_non_duplicate_status(
+        self, staff_client, make_repair_record,
+    ):
+        """AC-14: duplicate-block has display:none when status is not Closed - Duplicate."""
+        record = make_repair_record(status='In Progress')
+        resp = staff_client.get(f'/repairs/{record.id}/edit')
+        assert resp.status_code == 200
+        assert b'id="duplicate-block"' in resp.data
+        assert b'style="display: none;"' in resp.data
+
+    def test_edit_page_shows_duplicate_block_for_closed_duplicate(
+        self, staff_client, make_equipment,
+    ):
+        """AC-15: duplicate-block visible + target option selected when status is Closed - Duplicate."""
+        eq = make_equipment()
+        target = RepairRecord(equipment_id=eq.id, description='Target', status='In Progress')
+        _db.session.add(target)
+        _db.session.commit()
+        record = RepairRecord(
+            equipment_id=eq.id,
+            description='Duplicate of target',
+            status='Closed - Duplicate',
+            duplicated_repair_id=target.id,
+        )
+        _db.session.add(record)
+        _db.session.commit()
+
+        resp = staff_client.get(f'/repairs/{record.id}/edit')
+        assert resp.status_code == 200
+        assert b'id="duplicate-block"' in resp.data
+        # Block visible: no display:none style applied
+        body = resp.data.decode()
+        # Find the duplicate-block opening tag and verify it lacks display:none.
+        idx = body.index('id="duplicate-block"')
+        # Inspect the rest of that tag up to the first '>'.
+        tag_end = body.index('>', idx)
+        assert 'display: none' not in body[idx:tag_end]
+        # The target option appears selected.
+        assert f'<option selected value="{target.id}"'.encode() in resp.data \
+            or f'value="{target.id}" selected'.encode() in resp.data
+
+    def test_edit_post_set_closed_duplicate_with_target(
+        self, staff_client, make_equipment,
+    ):
+        """AC-16: POST with status=Closed - Duplicate + duplicated_repair_id redirects, saves link."""
+        eq = make_equipment()
+        target = RepairRecord(equipment_id=eq.id, description='Target', status='In Progress')
+        _db.session.add(target)
+        _db.session.commit()
+        record = RepairRecord(equipment_id=eq.id, description='Same problem', status='In Progress')
+        _db.session.add(record)
+        _db.session.commit()
+
+        resp = staff_client.post(f'/repairs/{record.id}/edit', data={
+            'status': 'Closed - Duplicate',
+            'severity': '',
+            'assignee_id': '0',
+            'specialist_description': '',
+            'duplicated_repair_id': str(target.id),
+            'note': '',
+        }, follow_redirects=False)
+        assert resp.status_code == 302
+        assert f'/repairs/{record.id}' in resp.headers['Location']
+
+        _db.session.expire_all()
+        updated = _db.session.get(RepairRecord, record.id)
+        assert updated.duplicated_repair_id == target.id
+
+        # Detail page renders the "Marked as duplicate of" link.
+        detail_resp = staff_client.get(f'/repairs/{record.id}')
+        assert b'Marked as duplicate of' in detail_resp.data
+        assert f'Repair #{target.id}'.encode() in detail_resp.data
+
+    def test_edit_post_closed_duplicate_without_target_shows_flash(
+        self, staff_client, make_equipment,
+    ):
+        """AC-17: missing duplicated_repair_id with status=Closed - Duplicate renders 200 with danger flash."""
+        eq = make_equipment()
+        # Also create a sibling so the duplicate-of dropdown has at least one option
+        # (otherwise the form coerces 0 and the request is shaped the same, but we
+        # want to be explicit).
+        sibling = RepairRecord(equipment_id=eq.id, description='Other', status='In Progress')
+        _db.session.add(sibling)
+        _db.session.commit()
+        record = RepairRecord(equipment_id=eq.id, description='Same problem', status='In Progress')
+        _db.session.add(record)
+        _db.session.commit()
+
+        resp = staff_client.post(f'/repairs/{record.id}/edit', data={
+            'status': 'Closed - Duplicate',
+            'severity': '',
+            'assignee_id': '0',
+            'specialist_description': '',
+            'duplicated_repair_id': '0',
+            'note': '',
+        }, follow_redirects=False)
+        assert resp.status_code == 200
+        # Status of underlying record unchanged
+        _db.session.expire_all()
+        assert _db.session.get(RepairRecord, record.id).status == 'In Progress'
+        # Service ValidationError surfaces via flash
+        assert b"Closed - Duplicate" in resp.data
+        assert b'duplicated_repair_id' in resp.data
+
+    def test_edit_post_transition_away_clears_link_and_flashes_info(
+        self, staff_client, make_equipment,
+    ):
+        """AC-18: status change away from Closed - Duplicate clears the link and surfaces info flash."""
+        eq = make_equipment()
+        target = RepairRecord(equipment_id=eq.id, description='Target', status='In Progress')
+        _db.session.add(target)
+        _db.session.commit()
+        record = RepairRecord(
+            equipment_id=eq.id,
+            description='Old dup',
+            status='Closed - Duplicate',
+            duplicated_repair_id=target.id,
+        )
+        _db.session.add(record)
+        _db.session.commit()
+
+        resp = staff_client.post(f'/repairs/{record.id}/edit', data={
+            'status': 'In Progress',
+            'severity': '',
+            'assignee_id': '0',
+            'specialist_description': '',
+            'duplicated_repair_id': '0',
+            'note': '',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        assert b'Duplicate link cleared' in resp.data
+
+        _db.session.expire_all()
+        updated = _db.session.get(RepairRecord, record.id)
+        assert updated.duplicated_repair_id is None
+        # Detail page no longer shows the duplicate row
+        assert b'Marked as duplicate of' not in resp.data
+
 
 class TestAddNote:
     """Tests for POST /repairs/<id>/notes."""

--- a/tests/test_views/test_repair_views.py
+++ b/tests/test_views/test_repair_views.py
@@ -313,12 +313,23 @@ class TestEditRepairRecord:
     def test_edit_page_hides_duplicate_block_for_non_duplicate_status(
         self, staff_client, make_repair_record,
     ):
-        """AC-14: duplicate-block has display:none when status is not Closed - Duplicate."""
+        """AC-14: duplicate-block is rendered (JS hides it on load when status is not Closed - Duplicate).
+
+        The template no longer applies server-side display:none -- no-JS users
+        get a visible block (degraded but functional). The inline script runs
+        sync() on load so JS users see the same visibility as before.
+        """
         record = make_repair_record(status='In Progress')
         resp = staff_client.get(f'/repairs/{record.id}/edit')
         assert resp.status_code == 200
         assert b'id="duplicate-block"' in resp.data
-        assert b'style="display: none;"' in resp.data
+        # The JS toggles visibility on load; no inline display:none lives on the block.
+        body = resp.data.decode()
+        idx = body.index('id="duplicate-block"')
+        tag_end = body.index('>', idx)
+        assert 'display: none' not in body[idx:tag_end]
+        # The sync() call happens on load (not just on change).
+        assert b'sync()' in resp.data
 
     def test_edit_page_shows_duplicate_block_for_closed_duplicate(
         self, staff_client, make_equipment,
@@ -413,6 +424,75 @@ class TestEditRepairRecord:
         # Service ValidationError surfaces via flash
         assert b"Closed - Duplicate" in resp.data
         assert b'duplicated_repair_id' in resp.data
+
+    def test_edit_post_transition_away_with_stale_dup_id_in_form_clears_link(
+        self, staff_client, make_equipment,
+    ):
+        """JS-toggle bug fix: browser POSTs the stale duplicated_repair_id when
+        the user changes status away from Closed - Duplicate (the toggle script
+        only hides the dropdown, doesn't reset its value). The view must force
+        None so the link is cleared and the flash is honest.
+        """
+        eq = make_equipment()
+        target = RepairRecord(equipment_id=eq.id, description='Target', status='In Progress')
+        _db.session.add(target)
+        _db.session.commit()
+        record = RepairRecord(
+            equipment_id=eq.id,
+            description='Stale-form-value dup',
+            status='Closed - Duplicate',
+            duplicated_repair_id=target.id,
+        )
+        _db.session.add(record)
+        _db.session.commit()
+
+        resp = staff_client.post(f'/repairs/{record.id}/edit', data={
+            'status': 'In Progress',
+            'severity': '',
+            'assignee_id': '0',
+            'specialist_description': '',
+            # Form still has the original dup_id selected -- simulates the
+            # browser submitting the visually-hidden dropdown's stale value.
+            'duplicated_repair_id': str(target.id),
+            'note': '',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        _db.session.expire_all()
+        updated = _db.session.get(RepairRecord, record.id)
+        assert updated.duplicated_repair_id is None
+        assert b'Duplicate link cleared' in resp.data
+
+    def test_edit_post_clear_dup_id_while_status_remains_closed_duplicate_rejected(
+        self, staff_client, make_equipment,
+    ):
+        """Service-layer bug fix: clearing dup_id to None while keeping status
+        Closed - Duplicate must be rejected (not silently allowed).
+        """
+        eq = make_equipment()
+        target = RepairRecord(equipment_id=eq.id, description='Target', status='In Progress')
+        _db.session.add(target)
+        _db.session.commit()
+        record = RepairRecord(
+            equipment_id=eq.id,
+            description='Existing dup',
+            status='Closed - Duplicate',
+            duplicated_repair_id=target.id,
+        )
+        _db.session.add(record)
+        _db.session.commit()
+
+        resp = staff_client.post(f'/repairs/{record.id}/edit', data={
+            'status': 'Closed - Duplicate',
+            'severity': '',
+            'assignee_id': '0',
+            'specialist_description': '',
+            'duplicated_repair_id': '0',  # sentinel: clear to None
+            'note': '',
+        }, follow_redirects=False)
+        assert resp.status_code == 200  # re-rendered, not redirected
+        _db.session.expire_all()
+        unchanged = _db.session.get(RepairRecord, record.id)
+        assert unchanged.duplicated_repair_id == target.id
 
     def test_edit_post_transition_away_clears_link_and_flashes_info(
         self, staff_client, make_equipment,


### PR DESCRIPTION
## Summary

Resolves [#43](https://github.com/jantman/equipment-status-board/issues/43). Adds a nullable, indexed self-referential FK `duplicated_repair_id` on `repair_records` so that closing a repair as `Closed - Duplicate` captures which prior repair on the same equipment it duplicates.

- **Schema:** new `duplicated_repair_id` column with `ON DELETE SET NULL`, indexed. SQLite test connections now enable `PRAGMA foreign_keys=ON` so the FK behavior is exercised end-to-end.
- **Service layer:** `update_repair_record` enforces same-equipment, non-self, target-exists, and status-paired invariants on real transitions while preserving the legacy carve-out for existing `Closed - Duplicate` rows with NULL targets. Adds `list_duplicate_candidates()` helper and a `duplicated_repair_id_change` timeline entry type.
- **Web UI:** `Duplicate of *` dropdown on the edit form (JS-toggled visibility on status change, no-JS fallback shows the block). Detail page renders the link; timeline component renders the change. Silent-clear info flash when transitioning away from `Closed - Duplicate`.
- **Slack:** action modal gains a duplicate-of `static_select` (and drops the `Closed - Duplicate` status option entirely when the equipment has no other repairs). Create modal filters `Closed - Duplicate` from its status list.

The full tech spec is at `_bmad-output/implementation-artifacts/tech-spec-duplicate-repair-association.md`.

## Test plan

- [x] `make lint` clean
- [x] `make test` — full suite (1475 tests) passes
- [x] New service-layer tests cover the 8 ACs for the validation rules and the silent-clear path
- [x] New web-view tests cover form rendering, POST happy/error paths, silent-clear info flash (AC-14 through AC-18)
- [x] New Slack form tests cover modal shape with/without candidates and the 75-char label budget (AC-19 through AC-21)
- [x] New Slack handler tests cover happy path, missing-target inline error, and stale-modal target-deleted race (AC-22 through AC-24)
- [x] Migration applied against the local MariaDB container
- [ ] Manual smoke test in browser + Slack per spec § Testing Strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)