### PR TITLE
Release v0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "equipment-status-board"
-version = "0.6.0"
+version = "0.7.0"
 description = "Equipment status tracking and repair management for Decatur Makers makerspace"
 requires-python = ">=3.14"
 dependencies = [


### PR DESCRIPTION
## Summary

Bumps `version` in `pyproject.toml` from `0.6.0` to `0.7.0`. On merge to `main`, the release workflow will build/push the Docker image, tag `v0.7.0`, and publish the GitHub Release.

## Changes since v0.6.0

- **#40 — Show ETA on dashboards** (Issue #36): Surface `RepairRecord.eta` on status, kanban, kiosk, queue, and equipment-detail views.
- **#41 — CloudFront invalidation on static-page push** (Fixes #39): Issue CloudFront invalidations after S3 static-page push.
- **#42 — Slack UX improvements** (Issue #34): Emoji legend, status detail, and dispatcher for Slack interactions.
- **#46 — Technician web UI UX improvements** (Issue #35): Claim and Resolve quick actions plus an Assignee filter on the repair queue.
- **#47 — Static status page export improvements** (Issue #44): Improvements to the exported static status page.
- **#48 — Configurable sort order for areas** (Issue #45): Areas can now be ordered explicitly rather than alphabetically.
- **#49 — Duplicate repair association** (Issue #43): Allow associating duplicate repair records.

## Test plan

- [ ] CI passes on the release branch
- [ ] On merge, confirm the release workflow tags `v0.7.0`, pushes `ghcr.io/jantman/equipment-status-board:0.7.0` and `:latest`, and publishes the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)