### PR TITLE
Issues #52, #53, #54: Status page styling and Slack notification fixes

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-status-page-slack-fixes.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-status-page-slack-fixes.md
@@ -2,7 +2,7 @@
 title: 'Status Page & Slack Notification Fixes (Issues #52, #53, #54)'
 slug: 'status-page-slack-fixes'
 created: '2026-06-07'
-status: 'ready-for-dev'
+status: 'Completed'
 stepsCompleted: [1, 2, 3, 4]
 tech_stack: ['Python 3.14', 'Flask', 'Flask-SQLAlchemy', 'MariaDB (Docker) / SQLite in tests', 'Slack Bolt SDK', 'Jinja2', 'Flask-WTF', 'pytest', 'ruff']
 files_to_modify:
@@ -160,24 +160,24 @@ Three small UX defects, tracked as GitHub Issues #52, #53, and #54:
 
 **Issue #52 — Center generated time on static status page**
 
-- [ ] Task 1: Restyle `.generated-at` rule
+- [x] Task 1: Restyle `.generated-at` rule
   - File: `esb/templates/public/static_page.html`
   - Action: On line 12, change `.generated-at { text-align: right; font-size: 0.85rem; color: #6c757d; margin-bottom: 1rem; }` to `text-align: center;` and `color: #000;` (keep `font-size: 0.85rem; margin-bottom: 1rem;` unchanged).
   - Notes: The div renders at line 41 directly below the centered `<h1>`, so no markup change is needed — CSS only.
 
-- [ ] Task 2: Test the new styling
+- [x] Task 2: Test the new styling
   - File: `tests/test_services/test_static_page_service.py`
   - Action: Add a test (near `test_includes_generated_timestamp`, line 49) asserting the generated HTML's `.generated-at` rule contains `text-align: center` and `color: #000`, and does NOT contain `text-align: right`.
   - Notes: Existing tests `test_includes_generated_timestamp` (49) and `test_generated_at_subheading_renders_above_areas` (131) assert structure, not style — they should pass unchanged.
 
 **Issue #53 — `/esb-repair` flow terminates on Apply**
 
-- [ ] Task 3: Close the full modal stack on successful submission
+- [x] Task 3: Close the full modal stack on successful submission
   - File: `esb/slack/handlers.py`
   - Action: In `handle_repair_action_submission` (line 525), change the success-path bare `ack()` at line 678 to `ack(response_action='clear')`.
   - Notes: `response_action='clear'` closes ALL views in the stack (pushed action modal + underlying dispatcher). This is the single shared success ack for all four actions (claim / set_eta / set_status / resolve_with_note). Do NOT touch the error-path `ack(response_action='errors', ...)` calls, the dispatcher's `ack(response_action='push', ...)` (line 522), or the `chat_postEphemeral` confirmation (lines 698-702), which still fires after the clear.
 
-- [ ] Task 4: Update and EXTEND Slack handler tests for the clear ack
+- [x] Task 4: Update and EXTEND Slack handler tests for the clear ack
   - File: `tests/test_slack/test_handlers.py`
   - Action: In `TestRepairActionSubmission` (line 1147):
     1. **Update** the only two existing success-ack assertions — `test_claim_assigns_to_caller_and_sets_status_to_assigned_when_new` (~line 1214) and `test_set_status_closed_duplicate_with_target_succeeds` (~line 1562) — from `ack.assert_called_once_with()` to `ack.assert_called_once_with(response_action='clear')`.
@@ -187,7 +187,7 @@ Three small UX defects, tracked as GitHub Issues #52, #53, and #54:
 
 **Issue #54 — Assignee in Slack notifications**
 
-- [ ] Task 5: Add the `notify_assignee_changed` trigger toggle (admin config)
+- [x] Task 5: Add the `notify_assignee_changed` trigger toggle (admin config)
   - Files: `esb/forms/admin_forms.py`, `esb/views/admin.py`, `esb/templates/admin/config.html`
   - Action:
     1. `admin_forms.py` (lines 33-64): add `notify_assignee_changed = BooleanField('Repair assignee changed')` to `AppConfigForm`, alongside the existing five trigger fields.
@@ -195,7 +195,7 @@ Three small UX defects, tracked as GitHub Issues #52, #53, and #54:
     3. `templates/admin/config.html` (Notification Triggers card, lines 59-116): add a `form-check form-switch` block for `form.notify_assignee_changed`, copying the structure of the existing five switches.
   - Notes: Follow the existing pattern exactly; values are `'true'`/`'false'` strings persisted via `config_service.set_config` only on change.
 
-- [ ] Task 6: Queue assignee notification data in `repair_service`
+- [x] Task 6: Queue assignee notification data in `repair_service`
   - File: `esb/services/repair_service.py`
   - Action:
     1. Add a module-level helper (near `_queue_slack_notification`) `_assignee_payload_fields(user)` returning `{'assignee_username': user.username, 'assignee_email': user.email, 'assignee_has_slack': bool(user.slack_handle)}` for a `User`, or `{'assignee_username': None, 'assignee_email': None, 'assignee_has_slack': False}` for `None`.
@@ -207,7 +207,7 @@ Three small UX defects, tracked as GitHub Issues #52, #53, and #54:
     4. In `create_repair_record()`: the `assignee` User object is already loaded for validation (lines 105-108). When `assignee_id` was provided, merge `{'old_assignee_username': None, **_assignee_payload_fields(assignee)}` into the `new_report` extra payload (~lines 168-176).
   - Notes: `claim_repair_record()` (lines 244-294) needs no changes — it funnels through `update_repair_record()`. A claim from `'New'` produces the enriched `status_changed` (or the fall-through `assignee_changed` if that toggle is off); a claim on an already-assigned repair produces `assignee_changed`. The severity/eta notification branches are untouched. The static-page-push hook (691-699) is untouched — assignee changes still don't regenerate the page.
 
-- [ ] Task 7: Format and resolve the assignee mention in `notification_service`
+- [x] Task 7: Format and resolve the assignee mention in `notification_service`
   - File: `esb/services/notification_service.py`
   - Action:
     1. **Copy the payload first** in `_deliver_slack_message()`: change line 253 from `payload = notification.payload or {}` to `payload = dict(notification.payload or {})` — the current expression aliases the ORM `db.JSON` attribute and any mutation would hit the model object.
@@ -221,28 +221,28 @@ Three small UX defects, tracked as GitHub Issues #52, #53, and #54:
     5. **Enriched `new_report`** (lines 302-311, three-line template): detect by **key presence** — `if 'assignee_username' in payload`, append `\nAssigned to: {display}` (creation never unassigns, so `assignee_username` is always truthy and `assignee_display` is always set here).
   - Notes: `_format_slack_message` stays a pure function — it only reads `assignee_display`/`old_assignee_username`/`assignee_username` from the payload; the Slack API call lives in delivery. Detection is **uniformly key-presence** across all three event types; the unassignment line needs no `assignee_display`. `old_assignee_username` renders as plain text (no mention) — only the NEW assignee gets pinged. The unknown-event/empty-payload fallbacks (tests at 1110/1122) must keep passing.
 
-- [ ] Task 8: Service-layer tests for assignee notifications
+- [x] Task 8: Service-layer tests for assignee notifications
   - File: `tests/test_services/test_repair_service.py`
   - Action:
     1. **Do NOT touch** `test_assignee_only_does_not_queue_notification` (lines 216-228, in `TestUpdateRepairRecordStaticPageHook`) — it guards static-page-push behavior (`notification_type='static_page_push'`), which is unchanged: assignee changes still must not regenerate the static page.
     2. **Add** new `slack_message`-typed tests (pattern: `TestUpdateRepairRecordSlackNotification`, class at line 318): (a) assignee-only change queues exactly one `assignee_changed` with correct payload fields (`old_assignee_username`, `assignee_username`, `assignee_email`, `assignee_has_slack`); (b) no `assignee_changed` when `notify_assignee_changed` is `'false'`; (c) claim from `'New'` queues a single enriched `status_changed` (no `assignee_changed`) whose payload includes the assignee delta; (d) any other open transition + assignee change (e.g. `New` → `In Progress` with assignment) also enriches `status_changed`; (e) **fall-through**: `notify_status_changed='false'` + `notify_assignee_changed='true'` + combined status+assignee update queues exactly one `assignee_changed`; (f) both toggles `'false'` + combined update queues nothing; (g) unassignment (`assignee_id=None`) queues `assignee_changed` with `assignee_username=None` and `old_assignee_username` set; (h) status→closed + assignee change queues only `resolved` with no assignee fields and no `assignee_changed`; (i) reassignment carries both old and new usernames; (j) `assignee_has_slack` is `False` when the user has no `slack_handle`; (k) `create_repair_record` with `assignee_id` includes the assignee fields in the `new_report` payload; without `assignee_id` it does not; (l) assignee change + severity change with NO status change queues BOTH `assignee_changed` AND `severity_changed` (the independent severity branch is unaffected) — assert both are present.
   - Notes: Use existing fixtures (`make_repair_record`, user factories) and the established `PendingNotification` query assertions filtered by `notification_type='slack_message'`.
 
-- [ ] Task 9: Formatting/delivery tests for assignee messages
+- [x] Task 9: Formatting/delivery tests for assignee messages
   - File: `tests/test_services/test_notification_service.py`
   - Action:
     1. In `TestFormatSlackMessage` (lines 929-1129) add exact-string tests for the normative templates in Technical Decisions: (a) `assignee_changed` assigned; (b) `assignee_changed` reassigned; (c) `assignee_changed` unassigned; (d) enriched `status_changed` assigned; (e) enriched `status_changed` reassigned (`(was {old})`); (f) enriched `status_changed` unassigned; (g) `status_changed` without assignee keys is byte-identical to current output (regression guard); (h) `new_report` with `assignee_display` appends the line; (i) `new_report` without it is unchanged.
     2. In the `_deliver_slack_message` tests: (a) `assignee_has_slack=True` + successful `users_lookupByEmail` → posted text contains `<@U...>`; (b) lookup raises → falls back to plain username, delivery still succeeds (notification marked delivered, not failed); (c) `assignee_has_slack=False` → `users_lookupByEmail` is never called, plain username used; (d) `notification.payload` (the model attribute) is not mutated by delivery — assert `assignee_display` is absent from it afterward.
   - Notes: Mock the Slack client per existing delivery-test pattern in this file. The unknown-event fallback (line 1110) and empty-payload fallback (line 1122) tests must keep passing.
 
-- [ ] Task 10: Admin UI tests for the new toggle
+- [x] Task 10: Admin UI tests for the new toggle
   - File: `tests/test_views/test_admin_views.py`
   - Action: Extend `TestAppConfigNotificationTriggers` (class at line 959): the config page shows the new switch; it defaults to enabled; disabling persists `notify_assignee_changed='false'`; re-enabling persists `'true'`; mutation logging fires on change (mirror `test_disable_status_changed_trigger`, ~line 1008).
   - Notes: Copy the structure of the existing per-trigger tests.
 
 **Wrap-up**
 
-- [ ] Task 11: Full verification and release bump
+- [x] Task 11: Full verification and release bump
   - Files: `pyproject.toml`
   - Action: Run `make test` (full suite) and `make lint`; fix any fallout. Bump `version` in `pyproject.toml` from `0.9.0` by a **minor** increment to `0.10.0` so the release workflow publishes on merge to `main`.
   - Notes: Per CLAUDE.md release guidance, **minor for new features** — #54 adds a new notification event type, a new persisted config key, and a new admin UI control, so a minor bump (not patch) is correct even though #52/#53 are pure fixes. No manual tags, no CHANGELOG.
@@ -251,34 +251,34 @@ Three small UX defects, tracked as GitHub Issues #52, #53, and #54:
 
 **Issue #52**
 
-- [ ] AC 1: Given the static status page is generated, when viewing the HTML, then the `.generated-at` CSS rule specifies `text-align: center` and `color: #000`, and the "Generated: ..." line renders directly under the page title.
-- [ ] AC 2: Given the static status page is generated, when inspecting the rest of the page, then all other styling (status colors, footer, layout) is unchanged.
+- [x] AC 1: Given the static status page is generated, when viewing the HTML, then the `.generated-at` CSS rule specifies `text-align: center` and `color: #000`, and the "Generated: ..." line renders directly under the page title.
+- [x] AC 2: Given the static status page is generated, when inspecting the rest of the page, then all other styling (status colors, footer, layout) is unchanged.
 
 **Issue #53**
 
-- [ ] AC 3: Given a technician submits the `/esb-repair` action modal with any valid action (claim, set ETA, set status, resolve with note), when they click Apply, then the handler acks with `response_action='clear'` (entire modal stack closes — no return to "Open Repairs") and the ephemeral confirmation message is still posted. Every action's success path has a test asserting the clear ack.
-- [ ] AC 4: Given the action modal submission fails validation (e.g. missing ETA, closed record, unauthorized user), when the handler acks, then it still uses `response_action='errors'` and the modal stack remains open showing the error.
-- [ ] AC 5: Given a technician selects a repair in the dispatcher modal and clicks Continue, when the dispatcher acks, then it still pushes the action modal (`response_action='push'`) — dispatcher behavior unchanged.
+- [x] AC 3: Given a technician submits the `/esb-repair` action modal with any valid action (claim, set ETA, set status, resolve with note), when they click Apply, then the handler acks with `response_action='clear'` (entire modal stack closes — no return to "Open Repairs") and the ephemeral confirmation message is still posted. Every action's success path has a test asserting the clear ack.
+- [x] AC 4: Given the action modal submission fails validation (e.g. missing ETA, closed record, unauthorized user), when the handler acks, then it still uses `response_action='errors'` and the modal stack remains open showing the error.
+- [x] AC 5: Given a technician selects a repair in the dispatcher modal and clicks Continue, when the dispatcher acks, then it still pushes the action modal (`response_action='push'`) — dispatcher behavior unchanged.
 
 **Issue #54**
 
-- [ ] AC 6: Given an unassigned repair in status `New` and `notify_status_changed` enabled (default), when a technician claims it (status promotes to `Assigned` and assignee is set in one update, with no severity/eta change), then exactly one `status_changed` Slack notification is queued whose payload includes the assignee fields, and the delivered message ends with `Assigned to: {assignee}`.
-- [ ] AC 7: Given any other open-transition status change bundled with an assignment in one update (e.g. `New` → `In Progress` + assign via the web edit form), then the `status_changed` notification is enriched with the assignee line and no separate `assignee_changed` is queued. ("Enriched, not separately notified" — the total notification count may still exceed one if severity/eta also changed in the same update.)
-- [ ] AC 7b: Given an assignee change AND a severity change in one update with NO status change, then both an `assignee_changed` and a `severity_changed` notification are queued (the independent severity branch is unaffected by the assignee logic).
-- [ ] AC 8: Given a status change bundled with a reassignment A→B in one update, then the enriched `status_changed` message shows `Assigned to: {B} (was {A})` — the displaced assignee is never silently dropped.
-- [ ] AC 9: Given a status change bundled with an unassignment in one update, then the enriched `status_changed` message shows `Unassigned (was {A})`.
-- [ ] AC 10: Given an already-assigned repair, when the assignee changes without a status change, then exactly one `assignee_changed` notification is queued and the delivered message shows `Reassigned: {old} -> {new}`.
-- [ ] AC 11: Given an assigned repair, when the assignee is cleared without a status change, then an `assignee_changed` notification is queued and the delivered message shows `Unassigned (was {old})`.
-- [ ] AC 12: Given `notify_status_changed` is `'false'` and `notify_assignee_changed` is `'true'`, when a single update changes both status (open transition) and assignee, then exactly one `assignee_changed` notification fires (fall-through); given both toggles are `'false'`, nothing fires.
-- [ ] AC 13: Given a repair record is created with an assignee, when the `new_report` notification is delivered, then its message includes an `Assigned to:` line; without an assignee at creation the message is unchanged.
-- [ ] AC 14: Given the new assignee has a `slack_handle` set and `users_lookupByEmail` resolves their email, when the notification is delivered, then the message contains a real Slack mention (`<@U...>`) for the new assignee.
-- [ ] AC 15: Given the new assignee has no `slack_handle` (or the email lookup fails/raises), when the notification is delivered, then the message falls back to the plain ESB username, delivery still succeeds, and `users_lookupByEmail` is not called at all in the no-handle case.
-- [ ] AC 16: Given `notify_assignee_changed` is `'false'`, when an assignee-only change occurs, then no `assignee_changed` notification is queued.
-- [ ] AC 17: Given a repair is closed (status → `Resolved`/`Closed - *`) in the same update that changes the assignee, then only the `resolved` notification fires, with its existing message format (no assignee line, no `assignee_changed`).
-- [ ] AC 18: Given a status change with no assignee change, when the `status_changed` notification is delivered, then its message is byte-identical to the current format (no assignee line).
-- [ ] AC 19: Given any assignment-related delivery, when it completes, then the persisted `PendingNotification.payload` does not contain `assignee_display` (delivery works on a copy, never mutates the model).
-- [ ] AC 20: Given a staff user opens `/admin/config`, when viewing the Notification Triggers card, then a "Repair assignee changed" switch appears, defaults to enabled, and toggling it persists `notify_assignee_changed` with mutation logging.
-- [ ] AC 21: Given an assignee-only change, when notifications are queued, then no `static_page_push` notification is queued (existing guard test at `test_repair_service.py:216-228` passes unchanged).
+- [x] AC 6: Given an unassigned repair in status `New` and `notify_status_changed` enabled (default), when a technician claims it (status promotes to `Assigned` and assignee is set in one update, with no severity/eta change), then exactly one `status_changed` Slack notification is queued whose payload includes the assignee fields, and the delivered message ends with `Assigned to: {assignee}`.
+- [x] AC 7: Given any other open-transition status change bundled with an assignment in one update (e.g. `New` → `In Progress` + assign via the web edit form), then the `status_changed` notification is enriched with the assignee line and no separate `assignee_changed` is queued. ("Enriched, not separately notified" — the total notification count may still exceed one if severity/eta also changed in the same update.)
+- [x] AC 7b: Given an assignee change AND a severity change in one update with NO status change, then both an `assignee_changed` and a `severity_changed` notification are queued (the independent severity branch is unaffected by the assignee logic).
+- [x] AC 8: Given a status change bundled with a reassignment A→B in one update, then the enriched `status_changed` message shows `Assigned to: {B} (was {A})` — the displaced assignee is never silently dropped.
+- [x] AC 9: Given a status change bundled with an unassignment in one update, then the enriched `status_changed` message shows `Unassigned (was {A})`.
+- [x] AC 10: Given an already-assigned repair, when the assignee changes without a status change, then exactly one `assignee_changed` notification is queued and the delivered message shows `Reassigned: {old} -> {new}`.
+- [x] AC 11: Given an assigned repair, when the assignee is cleared without a status change, then an `assignee_changed` notification is queued and the delivered message shows `Unassigned (was {old})`.
+- [x] AC 12: Given `notify_status_changed` is `'false'` and `notify_assignee_changed` is `'true'`, when a single update changes both status (open transition) and assignee, then exactly one `assignee_changed` notification fires (fall-through); given both toggles are `'false'`, nothing fires.
+- [x] AC 13: Given a repair record is created with an assignee, when the `new_report` notification is delivered, then its message includes an `Assigned to:` line; without an assignee at creation the message is unchanged.
+- [x] AC 14: Given the new assignee has a `slack_handle` set and `users_lookupByEmail` resolves their email, when the notification is delivered, then the message contains a real Slack mention (`<@U...>`) for the new assignee.
+- [x] AC 15: Given the new assignee has no `slack_handle` (or the email lookup fails/raises), when the notification is delivered, then the message falls back to the plain ESB username, delivery still succeeds, and `users_lookupByEmail` is not called at all in the no-handle case.
+- [x] AC 16: Given `notify_assignee_changed` is `'false'`, when an assignee-only change occurs, then no `assignee_changed` notification is queued.
+- [x] AC 17: Given a repair is closed (status → `Resolved`/`Closed - *`) in the same update that changes the assignee, then only the `resolved` notification fires, with its existing message format (no assignee line, no `assignee_changed`).
+- [x] AC 18: Given a status change with no assignee change, when the `status_changed` notification is delivered, then its message is byte-identical to the current format (no assignee line).
+- [x] AC 19: Given any assignment-related delivery, when it completes, then the persisted `PendingNotification.payload` does not contain `assignee_display` (delivery works on a copy, never mutates the model).
+- [x] AC 20: Given a staff user opens `/admin/config`, when viewing the Notification Triggers card, then a "Repair assignee changed" switch appears, defaults to enabled, and toggling it persists `notify_assignee_changed` with mutation logging.
+- [x] AC 21: Given an assignee-only change, when notifications are queued, then no `static_page_push` notification is queued (existing guard test at `test_repair_service.py:216-228` passes unchanged).
 
 ## Additional Context
 
@@ -307,3 +307,15 @@ Three small UX defects, tracked as GitHub Issues #52, #53, and #54:
 - **Not pinged**: the OLD assignee in a reassignment/unassignment is plain text by design; only the new assignee gets a mention.
 - **Future consideration (out of scope)**: storing the resolved Slack user ID on the `User` model would avoid the per-delivery email lookup.
 - GitHub Issues: #52 (static page timestamp), #53 (`/esb-repair` modal flow), #54 (assignment notification content).
+
+## Review Notes
+
+- Adversarial review completed (information-asymmetry subagent: diff-only context).
+- Findings: 5 total (0 Critical/High; 1 Medium, 4 Low) — 4 fixed, 1 skipped as noise.
+  - **F1 (Medium, fixed)**: `docs/administrators.md` trigger table said "All five default to true" and omitted `notify_assignee_changed` — updated to six keys with the new row (user-visible via the #58 docs site).
+  - **F2 (Low, fixed)**: documented the deliberate status→assignee fall-through in `docs/administrators.md`.
+  - **F3 (Low, fixed)**: `create_repair_record` now snapshots assignee scalars before `commit()` (avoids `expire_on_commit` reload SELECTs; matches `update_repair_record`).
+  - **F4 (Low, fixed)**: added a delivery test for a malformed `users_lookupByEmail` success response (KeyError → username fallback).
+  - **F5 (Low, skipped/noise)**: end-to-end delivery test for `<@U...>` injection only covers `assignee_changed`; format and delivery layers are independently covered.
+- Resolution approach: auto-fix real findings.
+- Verification: `make lint` clean; full suite **1731 passed**. Version bumped `0.10.0` → `0.11.0` (minor; the spec's planned 0.9.0→0.10.0 was superseded because #58 already published 0.10.0).

--- a/docs/administrators.md
+++ b/docs/administrators.md
@@ -270,17 +270,20 @@ After installation:
 
 ### Notification Trigger Configuration
 
-Slack outbound notifications are governed by per-event app-config keys. Each is a boolean stored in `app_config` (string `'true'` / `'false'`) and toggled via the admin UI at **Admin → App Configuration**. All five default to `'true'`, so a fresh deployment inherits notifications automatically.
+Slack outbound notifications are governed by per-event app-config keys. Each is a boolean stored in `app_config` (string `'true'` / `'false'`) and toggled via the admin UI at **Admin → App Configuration**. All six default to `'true'`, so a fresh deployment inherits notifications automatically.
 
 | Config key | Default | Fires on |
 |------------|---------|----------|
-| `notify_new_report` | `'true'` | A new problem report is filed (member or technician path). |
-| `notify_resolved` | `'true'` | A repair record's status transitions to a closed status (`Resolved`, `Closed - Duplicate`, `Closed - No Issue Found`). |
+| `notify_new_report` | `'true'` | A new problem report is filed (member or technician path). If the repair is created already assigned, the message gains an `Assigned to:` line. |
+| `notify_resolved` | `'true'` | A repair record's status transitions to a closed status (`Resolved`, `Closed - Duplicate`, `Closed - No Issue Found`). Assignee changes in the same update are never appended here. |
 | `notify_severity_changed` | `'true'` | A repair record's severity level changes. |
-| `notify_status_changed` | `'true'` | A repair record's status changes between **open** states (e.g., `New` → `In Progress`, `Assigned` → `Parts Needed`). Closed-status transitions go through `notify_resolved` instead, so disabling this key does not silence resolutions. |
+| `notify_status_changed` | `'true'` | A repair record's status changes between **open** states (e.g., `New` → `In Progress`, `Assigned` → `Parts Needed`). Closed-status transitions go through `notify_resolved` instead, so disabling this key does not silence resolutions. When the assignee also changes in the same update, the assignee is folded into this `status_changed` message rather than firing a separate `notify_assignee_changed`. |
+| `notify_assignee_changed` | `'true'` | A repair record's assignee changes (assignment, reassignment, or unassignment) **without** an accompanying open-status change. The new assignee is rendered as a real Slack mention when they have a Slack handle, falling back to their username. |
 | `notify_eta_updated` | `'true'` | A repair record's ETA is set or changed. |
 
 If `notify_resolved` is `'false'` AND a status transition lands on a closed status, no notification fires — the elif-structure does NOT fall through to `status_changed`.
+
+One deliberate fall-through exists for assignment visibility: if an open-status change and an assignee change happen in the **same** update but `notify_status_changed` is `'false'`, the assignee change is not silently lost — it falls through to a `notify_assignee_changed` notification instead (so assignment visibility is always governed by its own toggle). Disable both `notify_status_changed` and `notify_assignee_changed` to silence such combined updates entirely.
 
 ## Static Status Page Setup
 

--- a/esb/forms/admin_forms.py
+++ b/esb/forms/admin_forms.py
@@ -38,6 +38,7 @@ class AppConfigForm(FlaskForm):
     notify_resolved = BooleanField('Repair record resolved or closed')
     notify_severity_changed = BooleanField('Severity level changed')
     notify_status_changed = BooleanField('Repair status changed (open transitions)')
+    notify_assignee_changed = BooleanField('Repair assignee changed')
     notify_eta_updated = BooleanField('ETA set or updated')
     wifi_ssid = StringField('WiFi Network Name (SSID)', validators=[Optional(), Length(max=100)])
     wifi_password = PasswordField('WiFi Password', validators=[Optional(), Length(max=100)])

--- a/esb/services/notification_service.py
+++ b/esb/services/notification_service.py
@@ -28,6 +28,7 @@ _SEVERITY_PREFIX = ':wrench: '
 _STATUS_PREFIX = ':arrows_counterclockwise: '
 _ETA_PREFIX = ':calendar: '
 _RESOLVED_PREFIX = ':white_check_mark: '
+_ASSIGNEE_PREFIX = ':bust_in_silhouette: '
 
 # Exponential backoff schedule (in seconds): 30s, 1m, 2m, 5m, 15m, 1h max
 BACKOFF_SCHEDULE = [30, 60, 120, 300, 900, 3600]
@@ -250,7 +251,31 @@ def _deliver_slack_message(notification: PendingNotification) -> None:
     # timeout caps each Slack HTTP call so a hung connection cannot wedge the
     # worker loop indefinitely.
     client = WebClient(token=token, timeout=15)
-    payload = notification.payload or {}
+    # Copy the payload: notification.payload aliases the ORM db.JSON attribute,
+    # and the assignee_display we add below must not mutate the persisted model.
+    payload = dict(notification.payload or {})
+
+    # Delivery-time mention resolution: turn the queued assignee identity into a
+    # real Slack @mention (<@U...>) when possible, falling back to the plain
+    # username. Only the NEW assignee is resolved; the old one stays plain text.
+    if payload.get('assignee_username'):
+        if payload.get('assignee_has_slack') and payload.get('assignee_email'):
+            try:
+                result = client.users_lookupByEmail(email=payload['assignee_email'])
+                slack_user_id = result['user']['id']
+                payload['assignee_display'] = f'<@{slack_user_id}>'
+            except Exception:
+                # Any Slack API error / missing id degrades to the plain
+                # username. The lookup must never raise out of delivery.
+                logger.info(
+                    'Assignee Slack lookup failed for notification=%d, '
+                    'falling back to username', notification.id, exc_info=True,
+                )
+                payload['assignee_display'] = payload['assignee_username']
+        else:
+            # No Slack handle (or, defensively, no email) -- use plain username.
+            payload['assignee_display'] = payload['assignee_username']
+
     text, blocks = _format_slack_message(payload)
 
     # Post to primary target channel (area-specific or #general)
@@ -309,6 +334,11 @@ def _format_slack_message(payload: dict) -> tuple[str, list | None]:
             f'Severity: {severity} | Reported by: {reporter}\n'
             f'{description}'
         )
+        # Enriched when created already assigned. Detection is by key presence;
+        # creation never unassigns, so assignee_username/assignee_display are
+        # always truthy/set here.
+        if 'assignee_username' in payload:
+            text += f'\nAssigned to: {payload.get("assignee_display")}'
 
     elif event_type == 'resolved':
         new_status = payload.get('new_status', 'Resolved')
@@ -340,6 +370,28 @@ def _format_slack_message(payload: dict) -> tuple[str, list | None]:
             f'{_STATUS_PREFIX}Status changed: *{equipment_name}* ({area_name})\n'
             f'{old_status} -> {new_status}'
         )
+        # Enriched assignee line when the assignee changed in the same update.
+        # Detect by KEY PRESENCE (not truthiness) so unassignment still renders.
+        # NOTE: the reassignment wording here intentionally differs from the
+        # assignee_changed branch below -- do not factor into a shared helper.
+        if 'assignee_username' in payload:
+            old_assignee = payload.get('old_assignee_username')
+            if payload.get('assignee_username') is None:
+                text += f'\nUnassigned (was {old_assignee})'
+            elif not old_assignee:
+                text += f'\nAssigned to: {payload.get("assignee_display")}'
+            else:
+                text += f'\nAssigned to: {payload.get("assignee_display")} (was {old_assignee})'
+
+    elif event_type == 'assignee_changed':
+        old_assignee = payload.get('old_assignee_username')
+        heading = f'{_ASSIGNEE_PREFIX}Assignee changed: *{equipment_name}* ({area_name})'
+        if payload.get('assignee_username') is None:
+            text = f'{heading}\nUnassigned (was {old_assignee})'
+        elif not old_assignee:
+            text = f'{heading}\nAssigned to: {payload.get("assignee_display")}'
+        else:
+            text = f'{heading}\nReassigned: {old_assignee} -> {payload.get("assignee_display")}'
 
     elif event_type == 'eta_updated':
         eta = payload.get('eta', 'Unknown')

--- a/esb/services/repair_service.py
+++ b/esb/services/repair_service.py
@@ -30,6 +30,31 @@ def _serialize(value):
     return str(value) if value is not None else None
 
 
+def _assignee_payload_fields(user):
+    """Build the assignee-related payload fields for a Slack notification.
+
+    Args:
+        user: A User instance, or None for unassignment.
+
+    Returns:
+        Dict with assignee_username/assignee_email/assignee_has_slack. For a
+        None user (unassignment), all fields are None/False. ``assignee_has_slack``
+        records whether the user has a ``slack_handle`` set (the "wants Slack"
+        flag); the actual Slack-ID resolution happens at delivery time.
+    """
+    if user is None:
+        return {
+            'assignee_username': None,
+            'assignee_email': None,
+            'assignee_has_slack': False,
+        }
+    return {
+        'assignee_username': user.username,
+        'assignee_email': user.email,
+        'assignee_has_slack': bool(user.slack_handle),
+    }
+
+
 def _queue_slack_notification(equipment, event_type, extra_payload=None):
     """Queue a slack_message notification for a repair event.
 
@@ -102,10 +127,16 @@ def create_repair_record(
     if severity is not None and severity not in REPAIR_SEVERITIES:
         raise ValidationError(f'Invalid severity: {severity!r}')
 
+    # Snapshot assignee scalars BEFORE the commit below. The new_report
+    # notification block runs after db.session.commit(), and with
+    # expire_on_commit=True reading .username/.email/.slack_handle off the ORM
+    # User there would each trigger a refresh SELECT (mirrors update_repair_record).
+    assignee_fields = None
     if assignee_id is not None:
         assignee = db.session.get(User, assignee_id)
         if assignee is None:
             raise ValidationError(f'User with id {assignee_id} not found')
+        assignee_fields = _assignee_payload_fields(assignee)
 
     record = RepairRecord(
         equipment_id=equipment_id,
@@ -168,12 +199,20 @@ def create_repair_record(
     # Queue Slack notification if new_report trigger is enabled
     from esb.services import config_service
     if config_service.get_config('notify_new_report', 'true') == 'true':
-        _queue_slack_notification(equipment, 'new_report', {
+        new_report_payload = {
             'severity': severity,
             'description': description.strip(),
             'reporter_name': reporter_name,
             'has_safety_risk': has_safety_risk,
-        })
+        }
+        # When the repair is created already assigned, carry the assignee
+        # identity so the new_report message gains an "Assigned to:" line.
+        # Creation has no previous assignee, so old_assignee_username is None.
+        # Uses the scalars snapshotted before commit (see assignee_fields above).
+        if assignee_fields is not None:
+            new_report_payload['old_assignee_username'] = None
+            new_report_payload.update(assignee_fields)
+        _queue_slack_notification(equipment, 'new_report', new_report_payload)
 
     return record
 
@@ -606,6 +645,13 @@ def update_repair_record(
 
     # Detect changes and create timeline entries
     audit_changes = {}
+    # Capture assignee identity as plain scalars (NOT ORM objects) inside the
+    # assignee_id branch below. The Slack-notification block runs AFTER
+    # db.session.commit(); with Flask-SQLAlchemy's default expire_on_commit=True,
+    # reading .username/.email/.slack_handle off an ORM User there would each
+    # trigger a refresh SELECT. Pre-initialized here so they are always bound.
+    old_assignee_username = None
+    new_assignee_fields = _assignee_payload_fields(None)
     for field_name in _REPAIR_UPDATABLE_FIELDS:
         if field_name not in changes:
             continue
@@ -631,6 +677,11 @@ def update_repair_record(
         elif field_name == 'assignee_id':
             old_user = db.session.get(User, old_value) if old_value else None
             new_user = db.session.get(User, new_value) if new_value else None
+            # Snapshot scalars for the post-commit notification block (see note
+            # at audit_changes init). Do NOT re-derive old assignee from
+            # audit_changes['assignee_id'] -- those values are _serialize()'d strings.
+            old_assignee_username = old_user.username if old_user else None
+            new_assignee_fields = _assignee_payload_fields(new_user)
             db.session.add(RepairTimelineEntry(
                 repair_record_id=record.id,
                 entry_type='assignee_change',
@@ -704,18 +755,45 @@ def update_repair_record(
     if audit_changes:
         from esb.services import config_service
 
+        # Assignee delta (None unless the assignee actually changed in this
+        # update). The scalars were snapshotted in the audit loop above.
+        if 'assignee_id' in audit_changes:
+            assignee_delta = {'old_assignee_username': old_assignee_username, **new_assignee_fields}
+        else:
+            assignee_delta = None
+
+        # Status/assignee notification chain (single if/elif keyed on status).
+        # The severity/eta branches below are INDEPENDENT and still fire on top.
         if 'status' in audit_changes and audit_changes['status'][1] in CLOSED_STATUSES:
+            # Closed transition: resolved only -- assignee info never added,
+            # assignee_changed never queued (even if assignee also changed).
             if config_service.get_config('notify_resolved', 'true') == 'true':
                 _queue_slack_notification(record.equipment, 'resolved', {
                     'old_status': audit_changes['status'][0],
                     'new_status': audit_changes['status'][1],
                 })
         elif 'status' in audit_changes:
+            # Open transition. Enrich status_changed with the assignee delta when
+            # one is present; fall through to assignee_changed if status_changed
+            # is suppressed so assignment visibility is governed by its own toggle.
             if config_service.get_config('notify_status_changed', 'true') == 'true':
-                _queue_slack_notification(record.equipment, 'status_changed', {
+                status_payload = {
                     'old_status': audit_changes['status'][0],
                     'new_status': audit_changes['status'][1],
-                })
+                }
+                if assignee_delta is not None:
+                    status_payload.update(assignee_delta)
+                _queue_slack_notification(record.equipment, 'status_changed', status_payload)
+            elif assignee_delta is not None and (
+                config_service.get_config('notify_assignee_changed', 'true') == 'true'
+            ):
+                _queue_slack_notification(record.equipment, 'assignee_changed', assignee_delta)
+        elif assignee_delta is not None:
+            # Assignee changed with NO status change in the update. Guarded as the
+            # elif tail of the status-keyed chain so it can never double-fire
+            # alongside resolved or an enriched status_changed.
+            if config_service.get_config('notify_assignee_changed', 'true') == 'true':
+                _queue_slack_notification(record.equipment, 'assignee_changed', assignee_delta)
 
         # Severity changed trigger
         if 'severity' in audit_changes:

--- a/esb/slack/handlers.py
+++ b/esb/slack/handlers.py
@@ -675,7 +675,11 @@ def register_handlers(bolt_app, app):
                 })
                 return
 
-            ack()
+            # response_action='clear' closes the ENTIRE modal stack (the pushed
+            # action modal AND the underlying dispatcher), so the user is not
+            # returned to the "Open Repairs" dialog after a successful Apply
+            # (Issue #53). The ephemeral confirmation below still posts.
+            ack(response_action='clear')
 
             # Declarative wording (F28): the message describes post-state, so it
             # is accurate even when the value matched current state and no DB

--- a/esb/templates/admin/config.html
+++ b/esb/templates/admin/config.html
@@ -105,6 +105,16 @@
 
             <div class="mb-3">
                 <div class="form-check form-switch">
+                    {{ form.notify_assignee_changed(class="form-check-input", role="switch") }}
+                    <label class="form-check-label" for="{{ form.notify_assignee_changed.id }}">
+                        {{ form.notify_assignee_changed.label.text }}
+                    </label>
+                </div>
+                <div class="form-text">Notify when a repair's assignee changes without a status change (e.g., reassignment or unassignment).</div>
+            </div>
+
+            <div class="mb-3">
+                <div class="form-check form-switch">
                     {{ form.notify_eta_updated(class="form-check-input", role="switch") }}
                     <label class="form-check-label" for="{{ form.notify_eta_updated.id }}">
                         {{ form.notify_eta_updated.label.text }}

--- a/esb/templates/public/static_page.html
+++ b/esb/templates/public/static_page.html
@@ -9,7 +9,7 @@
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #212529; background: #f8f9fa; padding: 1rem; }
         h1 { font-size: 1.5rem; margin-bottom: 0.25rem; text-align: center; }
-        .generated-at { text-align: right; font-size: 0.85rem; color: #6c757d; margin-bottom: 1rem; }
+        .generated-at { text-align: center; font-size: 0.85rem; color: #000; margin-bottom: 1rem; }
         .area { margin-bottom: 1.5rem; }
         .area h2 { font-size: 1.1rem; border-bottom: 2px solid #dee2e6; padding-bottom: 0.3rem; margin-bottom: 0.5rem; }
         .equipment-list { list-style: none; }

--- a/esb/views/admin.py
+++ b/esb/views/admin.py
@@ -267,6 +267,9 @@ def app_config():
         form.notify_status_changed.data = (
             config_service.get_config('notify_status_changed', 'true') == 'true'
         )
+        form.notify_assignee_changed.data = (
+            config_service.get_config('notify_assignee_changed', 'true') == 'true'
+        )
         form.notify_eta_updated.data = (
             config_service.get_config('notify_eta_updated', 'true') == 'true'
         )
@@ -280,6 +283,7 @@ def app_config():
             ('notify_resolved', 'true'),
             ('notify_severity_changed', 'true'),
             ('notify_status_changed', 'true'),
+            ('notify_assignee_changed', 'true'),
             ('notify_eta_updated', 'true'),
         ]
         for key, default in config_keys:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "equipment-status-board"
-version = "0.10.0"
+version = "0.11.0"
 description = "Equipment status tracking and repair management for Decatur Makers makerspace"
 requires-python = ">=3.14"
 dependencies = [

--- a/tests/test_services/test_notification_service.py
+++ b/tests/test_services/test_notification_service.py
@@ -925,6 +925,126 @@ class TestDeliverSlackMessage:
 
         assert mock_client.chat_postMessage.call_count == 2
 
+    def test_assignee_with_slack_resolves_mention(self, app):
+        """AC 14: assignee_has_slack + successful lookup => message contains <@U...>."""
+        app.config['SLACK_BOT_TOKEN'] = 'xoxb-test-token'
+        n = _create_notification(
+            notification_type='slack_message',
+            target='#woodshop',
+            payload={'event_type': 'assignee_changed', 'equipment_name': 'SawStop',
+                     'area_name': 'Woodshop', 'old_assignee_username': None,
+                     'assignee_username': 'alice', 'assignee_email': 'alice@example.com',
+                     'assignee_has_slack': True},
+        )
+
+        from unittest.mock import MagicMock
+        mock_client = MagicMock()
+        mock_client.users_lookupByEmail.return_value = {'user': {'id': 'U999'}}
+        with patch('slack_sdk.WebClient', return_value=mock_client):
+            notification_service._deliver_slack_message(n)
+
+        mock_client.users_lookupByEmail.assert_called_once_with(email='alice@example.com')
+        text = mock_client.chat_postMessage.call_args_list[0].kwargs['text']
+        assert '<@U999>' in text
+        assert 'Assigned to: <@U999>' in text
+
+    def test_assignee_lookup_failure_falls_back_to_username(self, app):
+        """AC 15: lookup raises => falls back to plain username, delivery still succeeds."""
+        app.config['SLACK_BOT_TOKEN'] = 'xoxb-test-token'
+        n = _create_notification(
+            notification_type='slack_message',
+            target='#woodshop',
+            payload={'event_type': 'assignee_changed', 'equipment_name': 'SawStop',
+                     'area_name': 'Woodshop', 'old_assignee_username': None,
+                     'assignee_username': 'alice', 'assignee_email': 'alice@example.com',
+                     'assignee_has_slack': True},
+        )
+
+        from slack_sdk.errors import SlackApiError
+        from unittest.mock import MagicMock
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = {'ok': False, 'error': 'users_not_found'}
+        mock_client.users_lookupByEmail.side_effect = SlackApiError(
+            message='users_not_found', response=mock_response,
+        )
+        with patch('slack_sdk.WebClient', return_value=mock_client):
+            # Must NOT raise -- lookup failure degrades gracefully.
+            notification_service._deliver_slack_message(n)
+
+        text = mock_client.chat_postMessage.call_args_list[0].kwargs['text']
+        assert 'Assigned to: alice' in text
+        assert '<@' not in text
+
+    def test_assignee_malformed_lookup_response_falls_back_to_username(self, app):
+        """AC 15: a malformed lookup response (missing user id) degrades to the plain username."""
+        app.config['SLACK_BOT_TOKEN'] = 'xoxb-test-token'
+        n = _create_notification(
+            notification_type='slack_message',
+            target='#woodshop',
+            payload={'event_type': 'assignee_changed', 'equipment_name': 'SawStop',
+                     'area_name': 'Woodshop', 'old_assignee_username': None,
+                     'assignee_username': 'alice', 'assignee_email': 'alice@example.com',
+                     'assignee_has_slack': True},
+        )
+
+        from unittest.mock import MagicMock
+        mock_client = MagicMock()
+        # 'ok' response shape but no 'user' key => KeyError inside the try block.
+        mock_client.users_lookupByEmail.return_value = {'ok': True}
+        with patch('slack_sdk.WebClient', return_value=mock_client):
+            # Must NOT raise.
+            notification_service._deliver_slack_message(n)
+
+        text = mock_client.chat_postMessage.call_args_list[0].kwargs['text']
+        assert 'Assigned to: alice' in text
+        assert '<@' not in text
+
+    def test_assignee_without_slack_skips_lookup(self, app):
+        """AC 15: assignee_has_slack=False => users_lookupByEmail not called, plain username used."""
+        app.config['SLACK_BOT_TOKEN'] = 'xoxb-test-token'
+        n = _create_notification(
+            notification_type='slack_message',
+            target='#woodshop',
+            payload={'event_type': 'assignee_changed', 'equipment_name': 'SawStop',
+                     'area_name': 'Woodshop', 'old_assignee_username': None,
+                     'assignee_username': 'alice', 'assignee_email': 'alice@example.com',
+                     'assignee_has_slack': False},
+        )
+
+        from unittest.mock import MagicMock
+        mock_client = MagicMock()
+        with patch('slack_sdk.WebClient', return_value=mock_client):
+            notification_service._deliver_slack_message(n)
+
+        mock_client.users_lookupByEmail.assert_not_called()
+        text = mock_client.chat_postMessage.call_args_list[0].kwargs['text']
+        assert 'Assigned to: alice' in text
+
+    def test_delivery_does_not_mutate_persisted_payload(self, app):
+        """AC 19: the persisted PendingNotification.payload never gains assignee_display."""
+        app.config['SLACK_BOT_TOKEN'] = 'xoxb-test-token'
+        n = _create_notification(
+            notification_type='slack_message',
+            target='#woodshop',
+            payload={'event_type': 'assignee_changed', 'equipment_name': 'SawStop',
+                     'area_name': 'Woodshop', 'old_assignee_username': None,
+                     'assignee_username': 'alice', 'assignee_email': 'alice@example.com',
+                     'assignee_has_slack': True},
+        )
+
+        from unittest.mock import MagicMock
+        mock_client = MagicMock()
+        mock_client.users_lookupByEmail.return_value = {'user': {'id': 'U999'}}
+        with patch('slack_sdk.WebClient', return_value=mock_client):
+            notification_service._deliver_slack_message(n)
+
+        assert 'assignee_display' not in n.payload
+        # Re-fetch from the DB to be certain nothing was persisted.
+        _db.session.expire_all()
+        refetched = _db.session.get(PendingNotification, n.id)
+        assert 'assignee_display' not in refetched.payload
+
 
 class TestFormatSlackMessage:
     """Tests for _format_slack_message()."""
@@ -1106,6 +1226,157 @@ class TestFormatSlackMessage:
 
         assert 'SAFETY RISK' not in text
         assert ':rotating_light:' in text
+
+    def test_assignee_changed_assigned_format(self):
+        """assignee_changed with no previous assignee: 'Assigned to: {display}'."""
+        text, blocks = notification_service._format_slack_message({
+            'event_type': 'assignee_changed',
+            'equipment_name': 'SawStop',
+            'area_name': 'Woodshop',
+            'old_assignee_username': None,
+            'assignee_username': 'alice',
+            'assignee_display': '<@U123>',
+        })
+        assert text == (
+            ':bust_in_silhouette: Assignee changed: *SawStop* (Woodshop)\n'
+            'Assigned to: <@U123>'
+        )
+        assert blocks is None
+
+    def test_assignee_changed_reassigned_format(self):
+        """assignee_changed reassignment: 'Reassigned: {old} -> {display}'."""
+        text, _ = notification_service._format_slack_message({
+            'event_type': 'assignee_changed',
+            'equipment_name': 'SawStop',
+            'area_name': 'Woodshop',
+            'old_assignee_username': 'bob',
+            'assignee_username': 'alice',
+            'assignee_display': '<@U123>',
+        })
+        assert text == (
+            ':bust_in_silhouette: Assignee changed: *SawStop* (Woodshop)\n'
+            'Reassigned: bob -> <@U123>'
+        )
+
+    def test_assignee_changed_unassigned_format(self):
+        """assignee_changed unassignment: 'Unassigned (was {old})'."""
+        text, _ = notification_service._format_slack_message({
+            'event_type': 'assignee_changed',
+            'equipment_name': 'SawStop',
+            'area_name': 'Woodshop',
+            'old_assignee_username': 'bob',
+            'assignee_username': None,
+        })
+        assert text == (
+            ':bust_in_silhouette: Assignee changed: *SawStop* (Woodshop)\n'
+            'Unassigned (was bob)'
+        )
+
+    def test_status_changed_enriched_assigned(self):
+        """Enriched status_changed appends 'Assigned to: {display}' (no previous)."""
+        text, _ = notification_service._format_slack_message({
+            'event_type': 'status_changed',
+            'equipment_name': 'SawStop',
+            'area_name': 'Woodshop',
+            'old_status': 'New',
+            'new_status': 'Assigned',
+            'old_assignee_username': None,
+            'assignee_username': 'alice',
+            'assignee_display': '<@U123>',
+        })
+        assert text == (
+            ':arrows_counterclockwise: Status changed: *SawStop* (Woodshop)\n'
+            'New -> Assigned\n'
+            'Assigned to: <@U123>'
+        )
+
+    def test_status_changed_enriched_reassigned(self):
+        """Enriched status_changed reassignment appends 'Assigned to: {display} (was {old})'."""
+        text, _ = notification_service._format_slack_message({
+            'event_type': 'status_changed',
+            'equipment_name': 'SawStop',
+            'area_name': 'Woodshop',
+            'old_status': 'Assigned',
+            'new_status': 'In Progress',
+            'old_assignee_username': 'bob',
+            'assignee_username': 'alice',
+            'assignee_display': '<@U123>',
+        })
+        assert text == (
+            ':arrows_counterclockwise: Status changed: *SawStop* (Woodshop)\n'
+            'Assigned -> In Progress\n'
+            'Assigned to: <@U123> (was bob)'
+        )
+
+    def test_status_changed_enriched_unassigned(self):
+        """Enriched status_changed unassignment appends 'Unassigned (was {old})'."""
+        text, _ = notification_service._format_slack_message({
+            'event_type': 'status_changed',
+            'equipment_name': 'SawStop',
+            'area_name': 'Woodshop',
+            'old_status': 'Assigned',
+            'new_status': 'In Progress',
+            'old_assignee_username': 'bob',
+            'assignee_username': None,
+        })
+        assert text == (
+            ':arrows_counterclockwise: Status changed: *SawStop* (Woodshop)\n'
+            'Assigned -> In Progress\n'
+            'Unassigned (was bob)'
+        )
+
+    def test_status_changed_without_assignee_keys_unchanged(self):
+        """Regression guard: status_changed with no assignee keys is byte-identical to legacy output."""
+        text, _ = notification_service._format_slack_message({
+            'event_type': 'status_changed',
+            'equipment_name': 'SawStop',
+            'area_name': 'Woodshop',
+            'old_status': 'New',
+            'new_status': 'In Progress',
+        })
+        assert text == (
+            ':arrows_counterclockwise: Status changed: *SawStop* (Woodshop)\n'
+            'New -> In Progress'
+        )
+
+    def test_new_report_enriched_with_assignee(self):
+        """new_report with assignee keys appends 'Assigned to: {display}'."""
+        text, _ = notification_service._format_slack_message({
+            'event_type': 'new_report',
+            'equipment_name': 'SawStop',
+            'area_name': 'Woodshop',
+            'severity': 'Down',
+            'description': 'Broken',
+            'reporter_name': 'John',
+            'has_safety_risk': False,
+            'old_assignee_username': None,
+            'assignee_username': 'alice',
+            'assignee_display': '<@U123>',
+        })
+        assert text == (
+            ':rotating_light: New problem report: *SawStop* (Woodshop)\n'
+            'Severity: Down | Reported by: John\n'
+            'Broken\n'
+            'Assigned to: <@U123>'
+        )
+
+    def test_new_report_without_assignee_unchanged(self):
+        """new_report without assignee keys is unchanged (no trailing Assigned line)."""
+        text, _ = notification_service._format_slack_message({
+            'event_type': 'new_report',
+            'equipment_name': 'SawStop',
+            'area_name': 'Woodshop',
+            'severity': 'Down',
+            'description': 'Broken',
+            'reporter_name': 'John',
+            'has_safety_risk': False,
+        })
+        assert 'Assigned to:' not in text
+        assert text == (
+            ':rotating_light: New problem report: *SawStop* (Woodshop)\n'
+            'Severity: Down | Reported by: John\n'
+            'Broken'
+        )
 
     def test_unknown_event_type_fallback(self):
         """Unknown event type returns generic message."""

--- a/tests/test_services/test_repair_service.py
+++ b/tests/test_services/test_repair_service.py
@@ -691,6 +691,292 @@ class TestUpdateRepairRecordSlackNotification:
         assert notification.payload['area_name'] == 'No Slack Area'
 
 
+def _make_user(username, *, slack_handle=None, role='technician'):
+    """Create a User with an optional slack_handle for assignee-notification tests."""
+    from esb.models.user import User
+
+    user = User(
+        username=username,
+        email=f'{username}@example.com',
+        role=role,
+        slack_handle=slack_handle,
+    )
+    user.set_password('testpass')
+    _db.session.add(user)
+    _db.session.commit()
+    return user
+
+
+def _slack_notifications():
+    from esb.models.pending_notification import PendingNotification
+
+    return _db.session.execute(
+        _db.select(PendingNotification).filter_by(notification_type='slack_message')
+    ).scalars().all()
+
+
+class TestAssigneeNotification:
+    """Issue #54: assignee identity in slack_message notifications."""
+
+    def test_assignee_only_change_queues_assignee_changed(self, app, make_area, make_equipment, staff_user, capture):
+        """Assignee-only change queues exactly one assignee_changed with full payload."""
+        assignee = _make_user('alice', slack_handle='@alice')
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+        record = RepairRecord(equipment_id=equip.id, description='Test', status='In Progress')
+        _db.session.add(record)
+        _db.session.commit()
+
+        repair_service.update_repair_record(
+            record.id, 'staffuser', author_id=staff_user.id, assignee_id=assignee.id,
+        )
+
+        notifications = _slack_notifications()
+        assert len(notifications) == 1
+        payload = notifications[0].payload
+        assert payload['event_type'] == 'assignee_changed'
+        assert payload['old_assignee_username'] is None
+        assert payload['assignee_username'] == 'alice'
+        assert payload['assignee_email'] == 'alice@example.com'
+        assert payload['assignee_has_slack'] is True
+
+    def test_assignee_change_no_notification_when_disabled(self, app, make_area, make_equipment, staff_user, capture):
+        """notify_assignee_changed='false' suppresses assignee_changed (AC 16)."""
+        from esb.services import config_service
+
+        config_service.set_config('notify_assignee_changed', 'false', changed_by='test')
+        assignee = _make_user('alice', slack_handle='@alice')
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+        record = RepairRecord(equipment_id=equip.id, description='Test', status='In Progress')
+        _db.session.add(record)
+        _db.session.commit()
+
+        repair_service.update_repair_record(
+            record.id, 'staffuser', author_id=staff_user.id, assignee_id=assignee.id,
+        )
+
+        assert len(_slack_notifications()) == 0
+
+    def test_claim_from_new_enriches_status_changed(self, app, make_area, make_equipment, capture):
+        """AC 6: claim from New queues a single enriched status_changed (no assignee_changed)."""
+        claimer = _make_user('bob', slack_handle='@bob')
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+        record = RepairRecord(equipment_id=equip.id, description='Test', status='New')
+        _db.session.add(record)
+        _db.session.commit()
+
+        repair_service.claim_repair_record(
+            repair_record_id=record.id, claimed_by_user_id=claimer.id,
+            claimed_by_username=claimer.username,
+        )
+
+        notifications = _slack_notifications()
+        event_types = [n.payload['event_type'] for n in notifications]
+        assert event_types == ['status_changed']
+        payload = notifications[0].payload
+        assert payload['new_status'] == 'Assigned'
+        assert payload['old_assignee_username'] is None
+        assert payload['assignee_username'] == 'bob'
+        assert payload['assignee_has_slack'] is True
+
+    def test_other_open_transition_with_assignment_enriches_status_changed(self, app, make_area, make_equipment, staff_user, capture):
+        """AC 7: New -> In Progress + assignment enriches status_changed, no assignee_changed."""
+        assignee = _make_user('carol', slack_handle='@carol')
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+        record = RepairRecord(equipment_id=equip.id, description='Test', status='New')
+        _db.session.add(record)
+        _db.session.commit()
+
+        repair_service.update_repair_record(
+            record.id, 'staffuser', author_id=staff_user.id,
+            status='In Progress', assignee_id=assignee.id,
+        )
+
+        notifications = _slack_notifications()
+        event_types = [n.payload['event_type'] for n in notifications]
+        assert event_types == ['status_changed']
+        assert notifications[0].payload['assignee_username'] == 'carol'
+
+    def test_fall_through_to_assignee_changed_when_status_disabled(self, app, make_area, make_equipment, staff_user, capture):
+        """AC 12: notify_status_changed=false + notify_assignee_changed=true + combined update => one assignee_changed."""
+        from esb.services import config_service
+
+        config_service.set_config('notify_status_changed', 'false', changed_by='test')
+        assignee = _make_user('dave', slack_handle='@dave')
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+        record = RepairRecord(equipment_id=equip.id, description='Test', status='New')
+        _db.session.add(record)
+        _db.session.commit()
+
+        repair_service.update_repair_record(
+            record.id, 'staffuser', author_id=staff_user.id,
+            status='In Progress', assignee_id=assignee.id,
+        )
+
+        notifications = _slack_notifications()
+        event_types = [n.payload['event_type'] for n in notifications]
+        assert event_types == ['assignee_changed']
+        assert notifications[0].payload['assignee_username'] == 'dave'
+
+    def test_both_toggles_disabled_combined_update_queues_nothing(self, app, make_area, make_equipment, staff_user, capture):
+        """AC 12: both toggles false + combined status+assignee update => nothing queued."""
+        from esb.services import config_service
+
+        config_service.set_config('notify_status_changed', 'false', changed_by='test')
+        config_service.set_config('notify_assignee_changed', 'false', changed_by='test')
+        assignee = _make_user('erin', slack_handle='@erin')
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+        record = RepairRecord(equipment_id=equip.id, description='Test', status='New')
+        _db.session.add(record)
+        _db.session.commit()
+
+        repair_service.update_repair_record(
+            record.id, 'staffuser', author_id=staff_user.id,
+            status='In Progress', assignee_id=assignee.id,
+        )
+
+        assert len(_slack_notifications()) == 0
+
+    def test_unassignment_queues_assignee_changed(self, app, make_area, make_equipment, staff_user, capture):
+        """AC 11: clearing the assignee (no status change) queues assignee_changed with username=None."""
+        assignee = _make_user('frank', slack_handle='@frank')
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+        record = RepairRecord(
+            equipment_id=equip.id, description='Test', status='In Progress',
+            assignee_id=assignee.id,
+        )
+        _db.session.add(record)
+        _db.session.commit()
+
+        repair_service.update_repair_record(
+            record.id, 'staffuser', author_id=staff_user.id, assignee_id=None,
+        )
+
+        notifications = _slack_notifications()
+        assert len(notifications) == 1
+        payload = notifications[0].payload
+        assert payload['event_type'] == 'assignee_changed'
+        assert payload['assignee_username'] is None
+        assert payload['old_assignee_username'] == 'frank'
+
+    def test_closed_transition_with_assignee_change_queues_only_resolved(self, app, make_area, make_equipment, staff_user, capture):
+        """AC 17: status->closed + assignee change queues only resolved, no assignee fields."""
+        assignee = _make_user('grace', slack_handle='@grace')
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+        record = RepairRecord(equipment_id=equip.id, description='Test', status='In Progress')
+        _db.session.add(record)
+        _db.session.commit()
+
+        repair_service.update_repair_record(
+            record.id, 'staffuser', author_id=staff_user.id,
+            status='Resolved', assignee_id=assignee.id,
+        )
+
+        notifications = _slack_notifications()
+        event_types = [n.payload['event_type'] for n in notifications]
+        assert event_types == ['resolved']
+        assert 'assignee_username' not in notifications[0].payload
+
+    def test_reassignment_carries_old_and_new(self, app, make_area, make_equipment, staff_user, capture):
+        """AC 10: reassignment A->B (no status change) carries both usernames."""
+        old = _make_user('henry', slack_handle='@henry')
+        new = _make_user('ivy', slack_handle='@ivy')
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+        record = RepairRecord(
+            equipment_id=equip.id, description='Test', status='In Progress',
+            assignee_id=old.id,
+        )
+        _db.session.add(record)
+        _db.session.commit()
+
+        repair_service.update_repair_record(
+            record.id, 'staffuser', author_id=staff_user.id, assignee_id=new.id,
+        )
+
+        notifications = _slack_notifications()
+        assert len(notifications) == 1
+        payload = notifications[0].payload
+        assert payload['event_type'] == 'assignee_changed'
+        assert payload['old_assignee_username'] == 'henry'
+        assert payload['assignee_username'] == 'ivy'
+
+    def test_assignee_has_slack_false_without_handle(self, app, make_area, make_equipment, staff_user, capture):
+        """AC 15 (queue side): assignee_has_slack is False when the user has no slack_handle."""
+        assignee = _make_user('jack')  # no slack_handle
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+        record = RepairRecord(equipment_id=equip.id, description='Test', status='In Progress')
+        _db.session.add(record)
+        _db.session.commit()
+
+        repair_service.update_repair_record(
+            record.id, 'staffuser', author_id=staff_user.id, assignee_id=assignee.id,
+        )
+
+        payload = _slack_notifications()[0].payload
+        assert payload['assignee_has_slack'] is False
+        assert payload['assignee_email'] == 'jack@example.com'
+
+    def test_create_with_assignee_includes_fields(self, app, make_area, make_equipment, staff_user, capture):
+        """AC 13: create_repair_record with assignee_id includes assignee fields in new_report."""
+        assignee = _make_user('kate', slack_handle='@kate')
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+
+        repair_service.create_repair_record(
+            equipment_id=equip.id, description='Motor broken', created_by='staffuser',
+            severity='Down', assignee_id=assignee.id, author_id=staff_user.id,
+        )
+
+        payload = _slack_notifications()[0].payload
+        assert payload['event_type'] == 'new_report'
+        assert payload['old_assignee_username'] is None
+        assert payload['assignee_username'] == 'kate'
+        assert payload['assignee_has_slack'] is True
+
+    def test_create_without_assignee_omits_fields(self, app, make_area, make_equipment, staff_user, capture):
+        """AC 13: create_repair_record without assignee_id omits assignee fields."""
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+
+        repair_service.create_repair_record(
+            equipment_id=equip.id, description='Motor broken', created_by='staffuser',
+            severity='Down', author_id=staff_user.id,
+        )
+
+        payload = _slack_notifications()[0].payload
+        assert payload['event_type'] == 'new_report'
+        assert 'assignee_username' not in payload
+
+    def test_assignee_plus_severity_change_no_status_queues_both(self, app, make_area, make_equipment, staff_user, capture):
+        """AC 7b: assignee + severity change with NO status change queues BOTH events."""
+        assignee = _make_user('leo', slack_handle='@leo')
+        area = make_area(name='Woodshop', slack_channel='#woodshop')
+        equip = make_equipment(name='SawStop', area=area)
+        record = RepairRecord(
+            equipment_id=equip.id, description='Test', status='In Progress',
+            severity='Degraded',
+        )
+        _db.session.add(record)
+        _db.session.commit()
+
+        repair_service.update_repair_record(
+            record.id, 'staffuser', author_id=staff_user.id,
+            assignee_id=assignee.id, severity='Down',
+        )
+
+        event_types = {n.payload['event_type'] for n in _slack_notifications()}
+        assert event_types == {'assignee_changed', 'severity_changed'}
+
+
 class TestGetRepairRecord:
     """Tests for get_repair_record()."""
 

--- a/tests/test_services/test_static_page_service.py
+++ b/tests/test_services/test_static_page_service.py
@@ -61,6 +61,20 @@ class TestGenerate:
             html,
         )
 
+    def test_generated_at_style_is_centered_and_black(self, app, make_area, make_equipment):
+        """The .generated-at rule centers the timestamp and renders it black (Issue #52)."""
+        area = make_area(name='TestArea')
+        make_equipment(name='TestEquip', area=area)
+
+        html = static_page_service.generate()
+
+        rule = re.search(r'\.generated-at \{[^}]*\}', html)
+        assert rule is not None
+        rule_text = rule.group(0)
+        assert 'text-align: center' in rule_text
+        assert 'color: #000' in rule_text
+        assert 'text-align: right' not in rule_text
+
     def test_csp_meta_tag_directive_unchanged(self, app, make_area, make_equipment):
         """generate() includes the exact CSP directive on the meta tag (no policy weakening)."""
         area = make_area(name='TestArea')

--- a/tests/test_slack/test_handlers.py
+++ b/tests/test_slack/test_handlers.py
@@ -1211,7 +1211,7 @@ class TestRepairActionSubmission:
             ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
         )
 
-        ack.assert_called_once_with()
+        ack.assert_called_once_with(response_action='clear')
         from esb.models.repair_record import RepairRecord
         self.db.session.expire_all()
         rec = self.db.session.get(RepairRecord, record.id)
@@ -1233,6 +1233,7 @@ class TestRepairActionSubmission:
             ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
         )
 
+        ack.assert_called_once_with(response_action='clear')
         from esb.models.repair_record import RepairRecord
         self.db.session.expire_all()
         rec = self.db.session.get(RepairRecord, record.id)
@@ -1252,6 +1253,7 @@ class TestRepairActionSubmission:
             ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
         )
 
+        ack.assert_called_once_with(response_action='clear')
         from esb.models.repair_record import RepairRecord
         self.db.session.expire_all()
         rec = self.db.session.get(RepairRecord, record.id)
@@ -1271,6 +1273,7 @@ class TestRepairActionSubmission:
             ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
         )
 
+        ack.assert_called_once_with(response_action='clear')
         from datetime import date
         from esb.models.repair_record import RepairRecord
         from esb.models.repair_timeline_entry import RepairTimelineEntry
@@ -1298,6 +1301,7 @@ class TestRepairActionSubmission:
             ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
         )
 
+        ack.assert_called_once_with(response_action='clear')
         from esb.models.repair_timeline_entry import RepairTimelineEntry
         entries = self.db.session.execute(
             self.db.select(RepairTimelineEntry)
@@ -1339,6 +1343,7 @@ class TestRepairActionSubmission:
             ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
         )
 
+        ack.assert_called_once_with(response_action='clear')
         from esb.models.repair_record import RepairRecord
         from esb.models.repair_timeline_entry import RepairTimelineEntry
         self.db.session.expire_all()
@@ -1363,6 +1368,7 @@ class TestRepairActionSubmission:
             ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
         )
 
+        ack.assert_called_once_with(response_action='clear')
         from esb.models.repair_timeline_entry import RepairTimelineEntry
         entries = self.db.session.execute(
             self.db.select(RepairTimelineEntry)
@@ -1403,6 +1409,7 @@ class TestRepairActionSubmission:
             ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
         )
 
+        ack.assert_called_once_with(response_action='clear')
         from esb.models.repair_record import RepairRecord
         from esb.models.repair_timeline_entry import RepairTimelineEntry
         self.db.session.expire_all()
@@ -1430,6 +1437,7 @@ class TestRepairActionSubmission:
             ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
         )
 
+        ack.assert_called_once_with(response_action='clear')
         notifications = self.db.session.execute(
             self.db.select(PendingNotification).filter_by(notification_type='slack_message')
         ).scalars().all()
@@ -1559,7 +1567,7 @@ class TestRepairActionSubmission:
         self.handlers['view:repair_action_submission'](
             ack=ack, body=self._body(self.tech_user.email), client=client, view=view,
         )
-        ack.assert_called_once_with()
+        ack.assert_called_once_with(response_action='clear')
 
         from esb.models.repair_record import RepairRecord
         self.db.session.expire_all()

--- a/tests/test_views/test_admin_views.py
+++ b/tests/test_views/test_admin_views.py
@@ -937,8 +937,8 @@ class TestAppConfig:
             json.loads(r.message) for r in capture.records
             if 'app_config.updated' in r.message
         ]
-        # All 6 values change from defaults (tech_doc false→true, 5 triggers true→false)
-        assert len(entries) == 6
+        # All 7 values change from defaults (tech_doc false→true, 6 triggers true→false)
+        assert len(entries) == 7
         tech_doc_entries = [e for e in entries if e['data']['key'] == 'tech_doc_edit_enabled']
         assert len(tech_doc_entries) == 1
         assert tech_doc_entries[0]['data']['new_value'] == 'true'
@@ -968,6 +968,7 @@ class TestAppConfigNotificationTriggers:
         assert b'notify_resolved' in resp.data
         assert b'notify_severity_changed' in resp.data
         assert b'notify_status_changed' in resp.data
+        assert b'notify_assignee_changed' in resp.data
         assert b'notify_eta_updated' in resp.data
 
     def test_triggers_enabled_by_default(self, staff_client, staff_user):
@@ -978,7 +979,7 @@ class TestAppConfigNotificationTriggers:
         # Each trigger input should be rendered with checked attribute
         for field_name in ('notify_new_report', 'notify_resolved',
                            'notify_severity_changed', 'notify_status_changed',
-                           'notify_eta_updated'):
+                           'notify_assignee_changed', 'notify_eta_updated'):
             # Find the input tag for this field and verify it has 'checked'
             idx = html.find(f'id="{field_name}"')
             assert idx != -1, f'{field_name} input not found'
@@ -1019,6 +1020,44 @@ class TestAppConfigNotificationTriggers:
         assert resp.status_code == 200
         from esb.services import config_service
         assert config_service.get_config('notify_status_changed') == 'false'
+
+    def test_disable_assignee_changed_trigger(self, staff_client, staff_user, capture):
+        """AC 20: staff can disable notify_assignee_changed; the change is persisted and logged."""
+        capture.records.clear()
+        resp = staff_client.post('/admin/config', data={
+            'tech_doc_edit_enabled': 'y',
+            'notify_new_report': 'y',
+            'notify_resolved': 'y',
+            'notify_severity_changed': 'y',
+            'notify_status_changed': 'y',
+            'notify_eta_updated': 'y',
+            'wifi_info_default': 'none',
+            # notify_assignee_changed NOT included = disabled
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        from esb.services import config_service
+        assert config_service.get_config('notify_assignee_changed') == 'false'
+
+        entries = [
+            json.loads(r.message) for r in capture.records
+            if 'app_config.updated' in r.message
+        ]
+        assigned_entries = [e for e in entries if e['data']['key'] == 'notify_assignee_changed']
+        assert len(assigned_entries) == 1
+        assert assigned_entries[0]['data']['new_value'] == 'false'
+
+    def test_enable_assignee_changed_trigger(self, staff_client, staff_user):
+        """AC 20: staff can re-enable notify_assignee_changed after it was disabled."""
+        from esb.services import config_service
+        config_service.set_config('notify_assignee_changed', 'false', changed_by='test')
+
+        resp = staff_client.post('/admin/config', data={
+            'notify_assignee_changed': 'y',
+            'wifi_info_default': 'none',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        assert b'Configuration updated successfully' in resp.data
+        assert config_service.get_config('notify_assignee_changed') == 'true'
 
     def test_enable_trigger(self, staff_client, staff_user):
         """Staff can enable a notification trigger."""


### PR DESCRIPTION
Resolves #52, #53, #54.

## Summary

Three UX fixes implemented from `_bmad-output/implementation-artifacts/tech-spec-status-page-slack-fixes.md`.

### Issue #52 — Static status page timestamp
Center the `.generated-at` timestamp under the title and render it black (CSS-only change).

### Issue #53 — `/esb-repair` flow terminates on Apply
Change the success-path `ack()` in `handle_repair_action_submission` to `ack(response_action='clear')`, closing the entire modal stack (pushed action modal + dispatcher) instead of returning to the "Open Repairs" dialog. The ephemeral confirmation message still posts. Error paths (`response_action='errors'`) and the dispatcher's `response_action='push'` are unchanged.

### Issue #54 — Assignee in Slack notifications
- New `assignee_changed` event type with its own `notify_assignee_changed` admin toggle (form field, `/admin/config` view, template switch).
- Event matrix in `update_repair_record` (mutually exclusive status/assignee outcomes):
  - status + assignee change together → **enriched `status_changed`** with an assignee delta line.
  - assignee-only change (no status) → **`assignee_changed`**.
  - open-status + assignee change while `notify_status_changed` is off → **fall-through to `assignee_changed`** so assignment visibility is always governed by its own toggle.
  - closed transitions → **`resolved` unchanged**, no assignee info.
- Enriched `new_report` when a repair is created already assigned.
- Delivery-time `users_lookupByEmail` resolution to a real Slack mention (`<@U...>`) with username fallback, computed on a **copy** of the payload so the persisted `PendingNotification.payload` is never mutated.
- Assignee scalars snapshotted before `commit()` on both create and update paths to avoid `expire_on_commit` reload SELECTs.

## Testing
- `make lint` clean; full suite **1731 passed**.
- New tests: service-layer event matrix, exact-template formatting (incl. regression guards), delivery-time mention resolution (success / `SlackApiError` fallback / malformed-response fallback / no-handle skip / no-mutation), admin toggle round-trip, and the static-page CSS assertion.

## Review
Adversarial review run with diff-only context (information asymmetry). 5 findings (0 Critical/High); 4 real findings fixed (docs gap, pre-commit scalar snapshot on the create path, malformed-lookup fallback test), 1 skipped as noise. See `## Review Notes` in the tech-spec.

## Release
Version bumped `0.10.0` → `0.11.0` (minor — new feature). The spec planned `0.9.0`→`0.10.0`, but `0.10.0` was already published by the merged #58 docs-site work, so the next minor is `0.11.0`. Merging to `main` triggers the automated release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)