### PR TITLE
Move docs nav link to right-side menu as "Help"

### DIFF
--- a/esb/templates/base.html
+++ b/esb/templates/base.html
@@ -21,10 +21,6 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('equipment.index') }}">Equipment</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link {% if request.endpoint and request.endpoint.startswith('docs.') %}active{% endif %}"
-                           href="{{ url_for('docs.index') }}">Docs</a>
-                    </li>
                     {% if current_user.is_authenticated and current_user.role == 'staff' %}
                     <li class="nav-item">
                         <a class="nav-link {% if request.endpoint == 'repairs.kanban' %}active{% endif %}"
@@ -53,6 +49,10 @@
                     {% if current_user.is_authenticated %}
                     <li class="nav-item">
                         <span class="nav-link text-light">{{ current_user.display_name }}</span>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.endpoint and request.endpoint.startswith('docs.') %}active{% endif %}"
+                           href="{{ url_for('docs.index') }}">Help</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('auth.change_password') }}">Change Password</a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "equipment-status-board"
-version = "0.13.0"
+version = "0.13.1"
 description = "Equipment status tracking and repair management for Decatur Makers makerspace"
 requires-python = ">=3.14"
 dependencies = [


### PR DESCRIPTION
## Summary
On authenticated pages, the documentation link previously appeared as "Docs" — the second item in the left top navigation. This moves it to the right-side nav menu, renames it to "Help", and places it before "Change Password" and "Logout".

- Removed the "Docs" item from the left-side top navigation
- Added a "Help" item in the right-side nav (gated on authentication), before "Change Password"
- The link still points to `docs.index` (`/docs/`) and retains active-state highlighting on docs pages
- Public pages are unaffected — the documentation link there is still provided via the footer

Bumps patch version to 0.13.1.

## Test plan
- `pytest tests/test_views/test_docs_views.py` — 85 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)