### PR TITLE
Fix release workflow: lowercase GHCR image name for DecaturMakers org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,14 @@ jobs:
             echo "should_release=$SHOULD" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Compute lowercase image name
+        if: steps.version_check.outputs.should_release == 'true'
+        id: image
+        run: |
+          # GHCR requires the repository namespace to be lowercase; the org
+          # (DecaturMakers) is mixed-case, so lowercase github.repository here.
+          echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         if: steps.version_check.outputs.should_release == 'true'
         uses: docker/setup-buildx-action@v3
@@ -64,8 +72,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ steps.version_check.outputs.current_version }}
+            ${{ steps.image.outputs.name }}:latest
+            ${{ steps.image.outputs.name }}:${{ steps.version_check.outputs.current_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -84,6 +92,7 @@ jobs:
           VERSION="${{ steps.version_check.outputs.current_version }}"
           TAG="v$VERSION"
           REPO="${{ github.repository }}"
+          IMAGE="${{ steps.image.outputs.name }}"
 
           # Generate changelog via GitHub API
           CHANGELOG=$(gh api \
@@ -96,8 +105,8 @@ jobs:
           {
             printf '%s\n' "$CHANGELOG"
             printf '\n---\n\n## Docker Image\n\n```bash\n'
-            printf 'docker pull ghcr.io/%s:%s\n' "$REPO" "$VERSION"
-            printf 'docker pull ghcr.io/%s:latest\n' "$REPO"
+            printf 'docker pull %s:%s\n' "$IMAGE" "$VERSION"
+            printf 'docker pull %s:latest\n' "$IMAGE"
             printf '```\n'
           } > /tmp/release_body.md
 


### PR DESCRIPTION
## Problem
The release build for v0.14.0 failed:

```
ERROR: failed to build: invalid tag "ghcr.io/DecaturMakers/equipment-status-board:latest": repository name must be lowercase
```

The workflow built the image as `ghcr.io/${{ github.repository }}`. After the repo transfer, `github.repository` is `DecaturMakers/equipment-status-board` (mixed case), and **GHCR requires repository namespaces to be lowercase**. This worked before only because the prior owner (`jantman`) was already all-lowercase.

## Fix
- Add a `Compute lowercase image name` step that lowercases `github.repository` (`${GITHUB_REPOSITORY,,}`) into `ghcr.io/decaturmakers/equipment-status-board`.
- Use that image name for the build/push **tags** and for the **docker pull** snippet in the generated release notes.
- The `generate-notes` API call still uses `github.repository` directly — the GitHub API is case-insensitive, so no change needed there.

## Effect on the failed release
The earlier run failed at the build step, **before** the tag/release steps — so no `v0.14.0` tag or GitHub Release was created (latest remains `v0.13.1`). Merging this re-triggers the release workflow, which reads `0.14.0` from `pyproject.toml`, sees it's greater than `v0.13.1`, and publishes cleanly to `ghcr.io/decaturmakers/equipment-status-board`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)