### PR TITLE
Fixes #70: Rework /esb-status Slack command as an interactive modal

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-esb-status-modal.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-esb-status-modal.md
@@ -1,0 +1,496 @@
+---
+title: '/esb-status Modal with Per-Area Detail'
+slug: 'esb-status-modal'
+created: '2026-07-03'
+status: 'ready-for-dev'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack: [Python 3.14, Flask, slack-bolt 1.27, Block Kit, pytest]
+files_to_modify: [esb/slack/handlers.py, esb/slack/forms.py, tests/test_slack/test_handlers.py, tests/test_slack/test_forms.py]
+code_patterns: [views_open on command ack, views_update on button action, _ensure_app_context wrapper, Block Kit builders in forms.py]
+test_patterns: [_register_and_capture harness, MagicMock ack/client/body, per-class autouse setup fixture, factory helpers _create_area/_create_equipment/_create_repair_record]
+---
+
+# Tech-Spec: /esb-status Modal with Per-Area Detail
+
+**Created:** 2026-07-03
+
+## Overview
+
+### Problem Statement
+
+The UX for the `/esb-status` Slack command is confusing (GitHub issue #70). The
+slash command is available anywhere, but the bot replies with an **ephemeral
+message** via `chat_postEphemeral`. Two problems follow:
+
+1. The bot can only post responses in channels it is a member of.
+2. Less-experienced Slack users are confused by ephemeral ("Only visible to
+   you") messages appearing in a channel.
+
+### Solution
+
+Rework the `/esb-status` handler to open a **modal** (`client.views_open`) that
+shows the equipment status summary. Each area gets a **"View details" button**;
+clicking it swaps the modal in place (`client.views_update`) to that area's
+detailed status, which includes a **"Back to summary"** button.
+
+### Scope
+
+**In Scope:**
+- Replace the ephemeral reply with a modal opened via `views_open`.
+- Summary modal: one section per non-empty area with a "View details" button
+  accessory (per-area buttons, not a dropdown).
+- Area-detail modal view (reachable by button) + "Back to summary" navigation
+  via `views_update`.
+- Preserve the text-argument shortcut: `/esb-status <name>` opens the modal
+  directly on the matched result.
+- New Block Kit builders in `esb/slack/forms.py` and new `@bolt_app.action`
+  handlers in `esb/slack/handlers.py`.
+
+**Out of Scope:**
+- Equipment-level detail as its own modal level (area detail already lists each
+  item's status). Area-level detail only.
+- Any change to `status_service` data functions
+  (`get_area_status_dashboard`, `get_single_area_status_dashboard`).
+- Any change to the web dashboard, kiosk, or static-page rendering.
+- Reworking other slash commands.
+
+## Context for Development
+
+### Codebase Patterns
+
+- **Modal open pattern:** `/esb-reserve` (`handlers.py:77-95`) and `/esb-report`
+  (`handlers.py:389-407`) call `ack()` first, then
+  `client.views_open(trigger_id=body['trigger_id'], view=<block-kit dict>)`.
+  `trigger_id` is valid ~3s, so the dashboard query must run between `ack()` and
+  `views_open` (it does today — one `get_area_status_dashboard()` call).
+- **In-place modal update pattern:** button actions registered with
+  `@bolt_app.action('<action_id>')` call `ack()` then
+  `client.views_update(view_id=body['view']['id'], view=<new view>)`. The action
+  reads its payload value from `body['actions'][0]['value']` — see
+  `reservation_start_reserve` (`handlers.py:97-127`).
+- **App context:** every handler body that touches DB/services must be wrapped
+  in `with _ensure_app_context(app):` (`handlers.py:11-27`). `_resolve_esb_user`
+  and `forms.py` builders assume they're already inside such a wrapper.
+- **Block Kit builders** live in `esb/slack/forms.py` (e.g.
+  `build_problem_report_modal`, `build_repair_dispatcher_modal`). Slack caps
+  modal titles at 24 chars and button/option text at 75 — truncate explicitly
+  where needed (only `build_repair_action_modal` currently does, at
+  `forms.py:633`; the other builders happen to use short static titles). (F8)
+- **Button pattern precedent:** `reservation_forms.py` renders buttons inside
+  **`actions` blocks** (via the `_button(text, action_id, value, style, url)`
+  helper at `reservation_forms.py:83`), each in a uniquely-identified block such
+  as `reservation_tool_{id}_actions_block` (`reservation_forms.py:143-146`).
+  Note: **no `section`-with-`accessory` button exists anywhere in the codebase**
+  (`grep -rn accessory esb/` returns nothing). A `section` with a `button`
+  accessory *is* valid Block Kit, but it is a NEW pattern here (F4) — see Task 1
+  for the chosen approach and the `block_id` requirement (F5).
+- **Existing text formatters** (`format_status_summary`,
+  `format_area_status_detail`, `format_equipment_status_detail`,
+  `format_equipment_list`) are used **only** by the `/esb-status` handler.
+  After the rework: `format_area_status_detail` is reused inside
+  `build_area_status_modal`, and `format_status_summary`'s per-area logic is
+  shared via the extracted `_area_summary_mrkdwn` helper. The error fallback is
+  a static string — it does NOT call these formatters. That leaves
+  `format_equipment_status_detail` and `format_equipment_list` unused, and
+  `status_service.get_equipment_status_detail` (its only caller is the old
+  handler, `handlers.py:625`) also becomes unreferenced (G3). Since
+  `status_service` is out of scope, leave `get_equipment_status_detail` as-is;
+  the two dead `forms.py` formatters are optional cleanup — see Notes.
+
+### Test Harness (critical for writing tests)
+
+- `tests/test_slack/test_handlers.py` uses `_register_and_capture(app)`
+  (lines 13-42): a `MagicMock` Bolt app whose `.command/.view/.action`
+  decorators capture handler fns into a dict keyed
+  `command:/esb-status`, `action:<id>`, `view:<callback_id>`.
+- Handlers are invoked directly:
+  `handlers['command:/esb-status'](ack=ack, body=body, client=client)` with
+  `MagicMock()` for `ack`/`client`. Assertions inspect
+  `client.views_open.call_args.kwargs['view']` /
+  `client.views_update.call_args.kwargs['view']`.
+- Data factories: `_create_area`, `_create_equipment`, `_create_repair_record`,
+  `_create_user` (imported from `tests.conftest`). Forms tests use fixtures
+  `make_area`, `make_equipment`, `make_repair_record`.
+
+### Files to Reference
+
+| File | Purpose |
+| ---- | ------- |
+| esb/slack/handlers.py | `handle_esb_status` (596-639) to rewrite; add `@bolt_app.action` handlers for view-area + back-to-summary |
+| esb/slack/forms.py | Add `build_status_summary_modal` + `build_area_status_modal`; existing formatters (20-162) |
+| esb/slack/reservation_forms.py | Reference: `_button` helper (83), views_open/views_update flow |
+| esb/services/status_service.py | `get_area_status_dashboard()` (186) and `get_single_area_status_dashboard(area_id)` (288) — used unchanged; latter raises `AreaNotFound`/`AreaArchived` |
+| esb/utils/exceptions.py | Canonical home of `AreaNotFound` / `AreaArchived` (27-36); `AreaArchived` subclasses `AreaNotFound` — import from here (G1), not the `status_service` re-export |
+| esb/services/equipment_service.py | `get_area_by_name` (43), `search_equipment_by_name` (441) — used unchanged for the text-arg path |
+| tests/test_slack/test_handlers.py | `TestEsbStatusCommand` (1143-1361) — rewrite for modal assertions; `_register_and_capture` (13) |
+| tests/test_slack/test_forms.py | `TestFormatStatusSummary` (261), `TestFormatAreaStatusDetail` (417) — add modal-builder tests |
+
+### Technical Decisions
+
+- **Per-area buttons** (confirmed): each area section in the summary modal has a
+  "View details" **button accessory** with `action_id='esb_status_view_area'`
+  and `value=str(area.id)`. A single shared action_id keyed off the value is
+  fine, **but each area section MUST carry a distinct `block_id`** (e.g.
+  `f'esb_status_area_{area.id}_block'`) so the reused action_id is never
+  ambiguous — mirroring how the reservation buttons live in per-item
+  `reservation_tool_{id}_actions_block` blocks (F5).
+- **Back navigation** (confirmed): area-detail modal has a "Back to summary"
+  button (`action_id='esb_status_back_to_summary'`); its handler re-queries the
+  dashboard and `views_update`s back to the summary. No `private_metadata`
+  needed — both views rebuild from a fresh query.
+- **Text-arg behavior** (confirmed, "preserve"): resolve arg the same way the
+  current handler does — `get_area_by_name(arg)` first (area takes precedence),
+  then `search_equipment_by_name(arg)`. Open the modal directly on:
+  - area match → that area's detail view;
+  - exactly one equipment match → **that equipment's area** detail view
+    (area-detail only, no equipment-level modal). If resolving that area raises
+    `AreaNotFound`/`AreaArchived` (the matched tool's area is archived), fall
+    back to the **summary view**, not an error (F3);
+  - no match or multiple matches → the summary view (no error text needed; the
+    summary is a safe landing).
+- **Area detail only** (confirmed): no equipment-level modal drill-down.
+- **Error fallback (F1/F2):** wrap the handler body in try/except; on a genuinely
+  unexpected exception, fall back to `client.chat_postEphemeral(channel=
+  body['user_id'], user=body['user_id'], text=<error>)`. **Post to the user's DM
+  (`body['user_id']`), NOT `body['channel_id']`** — the whole point of this
+  feature is that the bot cannot post into channels it is not a member of, so a
+  `channel_id` ephemeral would fail silently in exactly the scenario we're
+  fixing (repair handlers already DM `body['user']['id']`, `handlers.py:459,591`).
+  Note the deep-link `AreaArchived`/`AreaNotFound` cases above are NOT errors —
+  they route to the summary view before this fallback is ever reached.
+- **Block limits:** modals allow ≤100 blocks and ≤3000 chars per section text.
+  Summary renders one section per non-empty area (fine for makerspace scale).
+  Area detail reuses `format_area_status_detail` output as one section's mrkdwn.
+
+## Implementation Plan
+
+Do the tasks in order. Tasks 1-2 are pure additive builders (no behavior change
+until Task 3 wires them in), so the suite stays green between commits.
+
+- [ ] **Task 1: Add `build_status_summary_modal(dashboard_data)` to `esb/slack/forms.py`**
+  - File: `esb/slack/forms.py`
+  - Action: Add a builder that returns a Block Kit **modal** view dict for the
+    equipment status summary.
+  - Details:
+    - Signature: `def build_status_summary_modal(dashboard_data):`
+    - `type: 'modal'`, `callback_id: 'esb_status_summary'`,
+      `title: {'type': 'plain_text', 'text': 'Equipment Status'}`,
+      `close: {'type': 'plain_text', 'text': 'Close'}` (no `submit` — this modal
+      is navigation-only, not a form).
+    - Empty case: if `dashboard_data` is falsy or every area has no equipment
+      (mirror the `format_status_summary` guard at `forms.py:37`), return a modal
+      with a single section `'No equipment has been registered yet.'`.
+    - First block: a `section` with mrkdwn `:bar_chart: *Equipment Status Summary*`.
+    - For each area in `dashboard_data` where `area_data['equipment']` is
+      non-empty (skip empty areas, matching current summary behavior):
+      - Compute green/yellow/red counts (reuse the loop at `forms.py:48-51`).
+      - Build one `section` block with a **distinct `block_id`**
+        `f'esb_status_area_{area.id}_block'` (F5 — required so the shared
+        `action_id` is unambiguous) whose mrkdwn text is the count line
+        (`*{area.name}* — {g} :white_check_mark: operational, {y} :warning:
+        degraded, {r} :x: down`) followed, on their own lines, by one bullet per
+        **non-green** item (`• {emoji} *{name}* — {truncated desc} (ETA: ...)`,
+        reusing `_STATUS_EMOJI`, `_truncate`, `_NON_GREEN_DESC_TRUNCATE` and the
+        ETA formatting from `forms.py:60-74`).
+      - Attach an `accessory` button to that section (NEW pattern — no existing
+        section accessory in the codebase; see Codebase Patterns note):
+        `{'type': 'button', 'text': {'type': 'plain_text', 'text': 'View details'},
+        'action_id': 'esb_status_view_area', 'value': str(area.id)}`.
+    - To avoid duplicating logic, extract **only the per-area line-building**
+      from `format_status_summary` into a module-private helper (e.g.
+      `_area_summary_mrkdwn(area_data) -> str` returning the count-line + bullets
+      for one area) and call it from BOTH `format_status_summary` and
+      `build_status_summary_modal`. **The header line (`:bar_chart: *Equipment
+      Status Summary*`, `forms.py:40`) and the trailing tip (`forms.py:76-77`)
+      stay in `format_status_summary`, NOT in the shared helper** (F11) — they
+      are outside the per-area loop, and moving them would break the
+      `'\n'.join` output. Keep `format_status_summary`'s output byte-identical
+      (its tests at `test_forms.py:261-415` must still pass).
+  - Notes: Section mrkdwn cap is 3000 chars; makerspace areas stay well under.
+    Modal block cap is 100; one section per non-empty area is safe.
+
+- [ ] **Task 2: Add `build_area_status_modal(area_data)` to `esb/slack/forms.py`**
+  - File: `esb/slack/forms.py`
+  - Action: Add a builder returning the area-detail **modal** view dict.
+  - Details:
+    - Signature: `def build_area_status_modal(area_data):` where `area_data` has
+      the shape `{'area': Area, 'equipment': [...]}` returned by
+      `get_single_area_status_dashboard()` (one entry of the dashboard list).
+    - `type: 'modal'`, `callback_id: 'esb_status_area_detail'`,
+      `title: {'type': 'plain_text', 'text': area.name[:24]}`,
+      `close: {'type': 'plain_text', 'text': 'Close'}`.
+    - Blocks:
+      1. A `section` whose mrkdwn is `format_area_status_detail(area_data)` (reuse
+         the existing formatter for byte-identical detail text).
+      2. A `divider`.
+      3. An `actions` block containing one button:
+         `{'type': 'button', 'text': {'type': 'plain_text', 'text': '⬅ Back to summary'},
+         'action_id': 'esb_status_back_to_summary', 'value': 'summary'}`.
+  - Notes: `format_area_status_detail` already handles the empty-area case
+    (`_No equipment in this area._`). Single-section detail text is under the
+    3000-char cap at makerspace scale.
+
+- [ ] **Task 3: Rewrite `handle_esb_status` in `esb/slack/handlers.py` to open a modal**
+  - File: `esb/slack/handlers.py` (replace body of `handle_esb_status`, 596-639)
+  - Action: `ack()` first, then resolve the text arg, then `client.views_open`
+    with the appropriate modal. Fall back to an ephemeral error on exception.
+  - Details:
+    - Keep `ack()` as the first statement and `search_term =
+      body.get('text', '').strip()`.
+    - Wrap the rest in `with _ensure_app_context(app):` and a `try/except`.
+    - Inside try:
+      - Import `status_service` and `equipment_service`.
+      - Determine the initial view:
+        - If `search_term` is empty → `view =
+          build_status_summary_modal(status_service.get_area_status_dashboard())`.
+        - Else, resolve the arg (preserve current precedence). Import the
+          canonical exception with `from esb.utils.exceptions import
+          AreaNotFound` (G1 — do NOT rely on the `status_service` re-export) so
+          the deep-link resolution can distinguish "archived/missing area →
+          summary" from a real failure. To keep both deep-link branches
+          consistent (G4), resolve the target area id first, then share ONE
+          guarded lookup:
+          - `target_area_id = None`.
+          - `area = equipment_service.get_area_by_name(search_term)`; if not None
+            → `target_area_id = area.id`. (`get_area_by_name` returns only
+            non-archived areas, so this normally won't raise — but the shared
+            guard below still covers a rare archive-race.)
+          - Else `matches = equipment_service.search_equipment_by_name(search_term)`;
+            if exactly one match with an area → `target_area_id = match.area_id`.
+          - Now resolve the view:
+            - If `target_area_id is not None`: **try**
+              `area_data = get_single_area_status_dashboard(target_area_id)` →
+              `view = build_area_status_modal(area_data)`; **except `AreaNotFound`
+              (parent of `AreaArchived`) → fall back to
+              `build_status_summary_modal(get_area_status_dashboard())` (F3/G4)**.
+              The matched area/tool is valid but its area is archived, so the
+              summary is the safe landing, not an error — and BOTH deep-link
+              branches (area-name and equipment) now handle this identically.
+            - Else (no area match; zero, multiple, or area-less equipment
+              matches) → `build_status_summary_modal(get_area_status_dashboard())`.
+      - `client.views_open(trigger_id=body['trigger_id'], view=view)`.
+    - `except Exception:` — `logger.warning('Error processing /esb-status
+      command', exc_info=True)` then post to the **user's DM** (F1/F2):
+      `client.chat_postEphemeral(channel=body['user_id'],
+      user=body['user_id'], text=':x: An error occurred while checking equipment
+      status. Please try again.')`.
+  - Notes: The `AreaNotFound`/`AreaArchived` deep-link case is handled *inline*
+    (routes to summary), NOT via the outer except — so a valid but
+    archived-area tool never surfaces the error message. The outer except is for
+    genuinely unexpected failures (DB down, Slack API error, `views_open`
+    trigger_id expiry). Catch `AreaNotFound` (the parent class) to cover both it
+    and `AreaArchived`.
+
+- [ ] **Task 4: Add the two `@bolt_app.action` handlers in `esb/slack/handlers.py`**
+  - File: `esb/slack/handlers.py` (add inside `register_handlers`, near the
+    `/esb-status` command handler)
+  - Action: Handle the "View details" and "Back to summary" buttons with
+    `views_update`.
+  - Details:
+    - Both handlers must, on error, `views_update` the open modal to a minimal
+      error view — **do NOT** leave the "pick one" choice open (F7). Add a tiny
+      local helper (mirroring `_update_reservation_error_modal`,
+      `handlers.py:63-69`) that builds a close-only modal with a single section
+      (e.g. `:x: Could not load equipment status. Please try again.`) and calls
+      `client.views_update(view_id=body['view']['id'], view=<error modal>)`.
+    - `@bolt_app.action('esb_status_view_area')` →
+      `def handle_esb_status_view_area(ack, body, client):`
+      - `ack()` first.
+      - `with _ensure_app_context(app):` and `try/except`:
+        - `area_id = int(body['actions'][0]['value'])`.
+        - `area_data = status_service.get_single_area_status_dashboard(area_id)`.
+        - `client.views_update(view_id=body['view']['id'],
+          view=build_area_status_modal(area_data))`.
+      - `except Exception:` → `logger.warning(...)` then `views_update` the modal
+        to the error view via the helper above (keeps the open modal from going
+        stale; no ephemeral, which could hit the channel-membership problem).
+    - `@bolt_app.action('esb_status_back_to_summary')` →
+      `def handle_esb_status_back_to_summary(ack, body, client):`
+      - `ack()` first.
+      - `with _ensure_app_context(app):` and `try/except` (F6 — same treatment as
+        `view_area`; do NOT leave this handler unguarded):
+        - `dashboard = status_service.get_area_status_dashboard()`.
+        - `client.views_update(view_id=body['view']['id'],
+          view=build_status_summary_modal(dashboard))`.
+      - `except Exception:` → `logger.warning(...)` then `views_update` to the
+        error view via the helper.
+  - Notes: Action payloads put the clicked button under `body['actions'][0]`
+    and the current view id under `body['view']['id']` (see
+    `reservation_start_reserve`, `handlers.py:106,121-122`).
+
+- [ ] **Task 5: Rewrite `TestEsbStatusCommand` and add action-handler tests in `tests/test_slack/test_handlers.py`**
+  - File: `tests/test_slack/test_handlers.py` (`TestEsbStatusCommand`, 1143-1361)
+  - Action: Replace `chat_postEphemeral`-text assertions with `views_open`/
+    `views_update` view assertions; add tests for the two action handlers.
+  - Details (rewrite each existing case to the modal equivalent):
+    - `test_handler_registered` — keep.
+    - no-args → `client.views_open` called once; view `callback_id ==
+      'esb_status_summary'`; a section text contains `Equipment Status Summary`.
+    - area-name arg (`'woodshop'`) → `views_open` view `callback_id ==
+      'esb_status_area_detail'`, title text `Woodshop`.
+    - area precedence over equipment (`'Woodshop'` with a `Woodshop Helper`
+      equipment present) → view is `esb_status_area_detail`, not a summary.
+    - single equipment arg (`'SawStop'`) → `views_open` with
+      `esb_status_area_detail` for SawStop's area (Woodshop).
+    - multiple matches (`'Saw'`) → `views_open` with `esb_status_summary`
+      (fallback), NOT an ephemeral list.
+    - no match (`'NonexistentThing'`) → `views_open` with `esb_status_summary`.
+    - empty dashboard (all equipment deleted) → `views_open` summary modal whose
+      section says `No equipment`.
+    - `ack` called before `views_open` (adapt `test_ack_called_before_response`
+      to record order of `ack` vs `views_open`).
+    - service error → patch `equipment_service.search_equipment_by_name` (or
+      `status_service.get_area_status_dashboard`) to raise; assert
+      `client.chat_postEphemeral` called with error text **and `channel ==
+      body['user_id']`** (DM fallback, F1), and `views_open` NOT called.
+    - archived-area deep-link (F3/F10): create equipment in an area, then archive
+      the area; `/esb-status <equipment name>` → `views_open` with
+      `esb_status_summary` (fallback), NOT `chat_postEphemeral`. (Use the
+      area-archive service/helper; confirm `search_equipment_by_name` still
+      returns the non-archived equipment.)
+  - New action tests (new class, e.g. `TestEsbStatusActions`). Include a
+    complete body dict with `user`/`channel` keys for realism/consistency with
+    the command tests (G2 — note the action handlers' error path only reads
+    `body['view']['id']` and `views_update`s; it does **not** DM or read
+    `user`/`channel`, so those keys are for realism, not to avoid a `KeyError`):
+    - `esb_status_view_area`: body `{'actions': [{'value': str(area.id)}],
+      'view': {'id': 'V1'}, 'user': {'id': 'U1'}, 'channel': {'id': 'C1'}}` →
+      `client.views_update` called with view `callback_id ==
+      'esb_status_area_detail'` and correct title.
+    - `esb_status_view_area` error path: patch
+      `status_service.get_single_area_status_dashboard` to raise → assert
+      `client.views_update` called with an error modal (section text contains
+      'Could not load'), not left stale.
+    - `esb_status_back_to_summary`: body `{'view': {'id': 'V1'},
+      'user': {'id': 'U1'}, 'channel': {'id': 'C1'}}` → `client.views_update`
+      with `callback_id == 'esb_status_summary'`.
+    - `esb_status_back_to_summary` error path (F6): patch
+      `status_service.get_area_status_dashboard` to raise → assert
+      `client.views_update` called with the error modal.
+    - All handlers call `ack()` first.
+
+- [ ] **Task 6: Add modal-builder unit tests in `tests/test_slack/test_forms.py`**
+  - File: `tests/test_slack/test_forms.py`
+  - Action: Add `TestBuildStatusSummaryModal` and `TestBuildAreaStatusModal`.
+  - Details:
+    - Summary builder: given a dashboard with a green + a red item across areas,
+      assert modal `type == 'modal'`, `callback_id == 'esb_status_summary'`,
+      each non-empty area yields a section with an `accessory` button whose
+      `action_id == 'esb_status_view_area'` and `value == str(area.id)`;
+      non-green item names appear; empty areas are skipped; empty dashboard →
+      single 'No equipment' section.
+    - Area builder: assert `callback_id == 'esb_status_area_detail'`, title text
+      == area name (≤24 chars), detail text matches
+      `format_area_status_detail(area_data)`, and a 'Back to summary' button with
+      `action_id == 'esb_status_back_to_summary'` is present.
+    - Verify `format_status_summary` output is unchanged (existing tests cover
+      this; run them).
+
+- [ ] **Task 7: Run lint + full test suite**
+  - Action: `make lint` and `make test`. Fix any ruff (120-col) issues.
+  - Notes: All existing `TestEsbStatusCommand` assertions are replaced in Task 5;
+    ensure no other test references the old ephemeral behavior.
+
+### Acceptance Criteria
+
+- [ ] **AC 1 (happy path, no arg):** Given equipment exists across areas, when a
+  user runs `/esb-status` with no argument, then the bot calls `views_open` with
+  a modal (`callback_id: esb_status_summary`) whose first section reads
+  ":bar_chart: *Equipment Status Summary*" and each non-empty area has a "View
+  details" button — and no ephemeral message is posted.
+- [ ] **AC 2 (area button → detail):** Given the summary modal is open, when the
+  user clicks an area's "View details" button (`action_id:
+  esb_status_view_area`), then the bot calls `views_update` on the same
+  `view['id']` with the area-detail modal (`callback_id:
+  esb_status_area_detail`) titled with that area's name and listing its
+  equipment statuses.
+- [ ] **AC 3 (back navigation):** Given the area-detail modal is open, when the
+  user clicks "Back to summary" (`action_id: esb_status_back_to_summary`), then
+  the bot calls `views_update` with the summary modal (`callback_id:
+  esb_status_summary`).
+- [ ] **AC 4 (text arg → area):** Given an area named "Woodshop", when a user
+  runs `/esb-status woodshop` (case-insensitive), then the modal opens directly
+  on the Woodshop area-detail view.
+- [ ] **AC 5 (area precedence):** Given an area "Woodshop" and an equipment
+  "Woodshop Helper", when a user runs `/esb-status Woodshop`, then the modal
+  opens on the area-detail view (area name match wins over equipment search).
+- [ ] **AC 6 (text arg → single equipment's area):** Given exactly one equipment
+  matches the arg and belongs to an area, when a user runs `/esb-status <name>`,
+  then the modal opens on that equipment's **area** detail view.
+- [ ] **AC 7 (ambiguous / no match → summary):** Given the arg matches zero or
+  multiple equipment and no area, when a user runs `/esb-status <arg>`, then the
+  modal opens on the summary view (no error text, no ephemeral list).
+- [ ] **AC 8 (empty state):** Given no equipment is registered, when a user runs
+  `/esb-status`, then the summary modal contains a single section reading "No
+  equipment has been registered yet."
+- [ ] **AC 9 (ack ordering):** Given any `/esb-status` invocation, when the
+  handler runs, then `ack()` is called before `views_open` (trigger_id used
+  promptly).
+- [ ] **AC 10 (error fallback → DM):** Given a service call raises an unexpected
+  exception, when a user runs `/esb-status`, then the bot logs a warning and
+  posts the ":x: An error occurred..." ephemeral to the **user's DM**
+  (`channel == body['user_id']`), not the invoking channel, and does not open a
+  modal.
+- [ ] **AC 11 (no regression in text formatters):** Given the existing
+  `format_status_summary` / `format_area_status_detail` tests, when the suite
+  runs, then they still pass (formatter output unchanged; logic only extracted
+  into a shared helper — header and trailing tip remain in
+  `format_status_summary`).
+- [ ] **AC 12 (archived-area deep-link → summary):** Given a non-archived
+  equipment item whose area has been archived, when a user runs `/esb-status
+  <that equipment name>`, then the modal opens on the **summary** view (the
+  `AreaArchived` raise is caught inline and routed to summary), and no error
+  ephemeral is posted.
+- [ ] **AC 13 (action error → error modal):** Given the "View details" or "Back
+  to summary" handler's service call raises, when the button is clicked, then
+  the bot calls `views_update` with a close-only error modal (section contains
+  "Could not load"), leaving no stale view — no channel ephemeral.
+
+## Additional Context
+
+### Dependencies
+
+- No new external libraries. Uses existing `slack-bolt` / `slack-sdk`
+  (`views_open`, `views_update`, `@bolt_app.action`) already in the project.
+- Depends on existing services (unchanged): `status_service.get_area_status_dashboard`,
+  `status_service.get_single_area_status_dashboard`,
+  `equipment_service.get_area_by_name`, `equipment_service.search_equipment_by_name`.
+- No DB migration, no config change.
+
+### Testing Strategy
+
+- **Unit (forms):** `tests/test_slack/test_forms.py` — new
+  `TestBuildStatusSummaryModal`, `TestBuildAreaStatusModal`; existing formatter
+  tests must remain green (regression guard on the extracted helper).
+- **Unit (handlers):** `tests/test_slack/test_handlers.py` — rewrite
+  `TestEsbStatusCommand` for modal assertions via
+  `client.views_open.call_args.kwargs['view']`; add `TestEsbStatusActions` for
+  the two `@bolt_app.action` handlers via
+  `client.views_update.call_args.kwargs['view']`. Use `_register_and_capture`
+  which already captures actions under `action:<id>`.
+- **Manual (optional, needs a live Slack workspace):** run `/esb-status` in a
+  channel the bot is NOT a member of and confirm the modal opens (proving the
+  channel-membership limitation is gone); click through area detail and back.
+- **Commands:** `make lint`; `make test`;
+  `venv/bin/python -m pytest tests/test_slack/ -v`.
+
+### Notes
+
+- **Risk — trigger_id expiry:** `views_open` needs the ~3s-valid `trigger_id`.
+  The single dashboard query between `ack()` and `views_open` matches what
+  `/esb-reserve` already does, so latency is acceptable. Do not add slow work
+  before `views_open`.
+- **Risk — stale text formatters:** after the rework, `format_status_summary`
+  and `format_area_status_detail` remain (reused inside builders);
+  `format_equipment_status_detail` and `format_equipment_list` become unused. Leaving
+  them is harmless; removing them (and their tests) is optional cleanup — the
+  spec keeps them to minimize blast radius. Decide during Task 3 whether to
+  delete the two now-dead formatters.
+- **Known limitation:** the modal is navigation-only (no search box inside it).
+  Users still type the area/equipment name as a slash-command arg to deep-link;
+  in-modal search is a possible future enhancement (out of scope).
+- **Future:** could add equipment-level detail as a third modal level, or a
+  refresh button. Explicitly out of scope for issue #70.
+- **Version bump:** this is a user-facing feature — bump the `version` minor in
+  `pyproject.toml` when merging (per CLAUDE.md release process). Not part of the
+  code tasks above; do it at PR time.

--- a/_bmad-output/implementation-artifacts/tech-spec-esb-status-modal.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-esb-status-modal.md
@@ -2,8 +2,8 @@
 title: '/esb-status Modal with Per-Area Detail'
 slug: 'esb-status-modal'
 created: '2026-07-03'
-status: 'ready-for-dev'
-stepsCompleted: [1, 2, 3, 4]
+status: 'completed'
+stepsCompleted: [1, 2, 3, 4, 5, 6]
 tech_stack: [Python 3.14, Flask, slack-bolt 1.27, Block Kit, pytest]
 files_to_modify: [esb/slack/handlers.py, esb/slack/forms.py, tests/test_slack/test_handlers.py, tests/test_slack/test_forms.py]
 code_patterns: [views_open on command ack, views_update on button action, _ensure_app_context wrapper, Block Kit builders in forms.py]
@@ -167,7 +167,7 @@ detailed status, which includes a **"Back to summary"** button.
 Do the tasks in order. Tasks 1-2 are pure additive builders (no behavior change
 until Task 3 wires them in), so the suite stays green between commits.
 
-- [ ] **Task 1: Add `build_status_summary_modal(dashboard_data)` to `esb/slack/forms.py`**
+- [x] **Task 1: Add `build_status_summary_modal(dashboard_data)` to `esb/slack/forms.py`**
   - File: `esb/slack/forms.py`
   - Action: Add a builder that returns a Block Kit **modal** view dict for the
     equipment status summary.
@@ -209,7 +209,7 @@ until Task 3 wires them in), so the suite stays green between commits.
   - Notes: Section mrkdwn cap is 3000 chars; makerspace areas stay well under.
     Modal block cap is 100; one section per non-empty area is safe.
 
-- [ ] **Task 2: Add `build_area_status_modal(area_data)` to `esb/slack/forms.py`**
+- [x] **Task 2: Add `build_area_status_modal(area_data)` to `esb/slack/forms.py`**
   - File: `esb/slack/forms.py`
   - Action: Add a builder returning the area-detail **modal** view dict.
   - Details:
@@ -230,7 +230,7 @@ until Task 3 wires them in), so the suite stays green between commits.
     (`_No equipment in this area._`). Single-section detail text is under the
     3000-char cap at makerspace scale.
 
-- [ ] **Task 3: Rewrite `handle_esb_status` in `esb/slack/handlers.py` to open a modal**
+- [x] **Task 3: Rewrite `handle_esb_status` in `esb/slack/handlers.py` to open a modal**
   - File: `esb/slack/handlers.py` (replace body of `handle_esb_status`, 596-639)
   - Action: `ack()` first, then resolve the text arg, then `client.views_open`
     with the appropriate modal. Fall back to an ephemeral error on exception.
@@ -281,7 +281,7 @@ until Task 3 wires them in), so the suite stays green between commits.
     trigger_id expiry). Catch `AreaNotFound` (the parent class) to cover both it
     and `AreaArchived`.
 
-- [ ] **Task 4: Add the two `@bolt_app.action` handlers in `esb/slack/handlers.py`**
+- [x] **Task 4: Add the two `@bolt_app.action` handlers in `esb/slack/handlers.py`**
   - File: `esb/slack/handlers.py` (add inside `register_handlers`, near the
     `/esb-status` command handler)
   - Action: Handle the "View details" and "Back to summary" buttons with
@@ -318,7 +318,7 @@ until Task 3 wires them in), so the suite stays green between commits.
     and the current view id under `body['view']['id']` (see
     `reservation_start_reserve`, `handlers.py:106,121-122`).
 
-- [ ] **Task 5: Rewrite `TestEsbStatusCommand` and add action-handler tests in `tests/test_slack/test_handlers.py`**
+- [x] **Task 5: Rewrite `TestEsbStatusCommand` and add action-handler tests in `tests/test_slack/test_handlers.py`**
   - File: `tests/test_slack/test_handlers.py` (`TestEsbStatusCommand`, 1143-1361)
   - Action: Replace `chat_postEphemeral`-text assertions with `views_open`/
     `views_update` view assertions; add tests for the two action handlers.
@@ -369,7 +369,7 @@ until Task 3 wires them in), so the suite stays green between commits.
       `client.views_update` called with the error modal.
     - All handlers call `ack()` first.
 
-- [ ] **Task 6: Add modal-builder unit tests in `tests/test_slack/test_forms.py`**
+- [x] **Task 6: Add modal-builder unit tests in `tests/test_slack/test_forms.py`**
   - File: `tests/test_slack/test_forms.py`
   - Action: Add `TestBuildStatusSummaryModal` and `TestBuildAreaStatusModal`.
   - Details:
@@ -386,7 +386,7 @@ until Task 3 wires them in), so the suite stays green between commits.
     - Verify `format_status_summary` output is unchanged (existing tests cover
       this; run them).
 
-- [ ] **Task 7: Run lint + full test suite**
+- [x] **Task 7: Run lint + full test suite**
   - Action: `make lint` and `make test`. Fix any ruff (120-col) issues.
   - Notes: All existing `TestEsbStatusCommand` assertions are replaced in Task 5;
     ensure no other test references the old ephemeral behavior.
@@ -494,3 +494,56 @@ until Task 3 wires them in), so the suite stays green between commits.
 - **Version bump:** this is a user-facing feature — bump the `version` minor in
   `pyproject.toml` when merging (per CLAUDE.md release process). Not part of the
   code tasks above; do it at PR time.
+
+## Review Notes
+
+- Adversarial review completed (step 5) via an isolated subagent seeing only the diff.
+- Findings: 14 total, 7 fixed, 7 skipped. Resolution approach: auto-fix real items + F3.
+- **Fixed:**
+  - **F3 (error delivery):** the error fallback now replies via the slash
+    command's `response_url` (Bolt's `respond(response_type='ephemeral', ...)`)
+    instead of `chat_postEphemeral(channel=user_id, ...)`. `response_url` is a
+    temporary webhook that works even when the bot is not a member of the
+    invoking channel — the exact limitation this feature fixes — and is more
+    robust than posting an ephemeral to a user-id-as-channel. **This supersedes
+    the AC 10 / "Error fallback (F1/F2)" decision above**, which called for a DM
+    via `chat_postEphemeral`.
+  - **F4 (dead code):** removed the now-unreferenced `format_status_summary`,
+    `format_equipment_status_detail`, and `format_equipment_list` from
+    `forms.py` plus their tests. `format_area_status_detail` and the extracted
+    `_area_summary_mrkdwn` are retained (used by the builders).
+    `status_service.get_equipment_status_detail` was left as-is (out of scope).
+  - **F8 (test gap):** added a test for the `views_open`-itself-fails path
+    (asserts the `respond` fallback still fires).
+  - **F9 (test gap):** builder tests now assert Block Kit limits (≤100 blocks,
+    ≤3000 chars per section text).
+  - **F12 (swallowed secondary failure):** the command `except` now wraps the
+    fallback `respond` in its own try/except so a secondary delivery failure is
+    logged, not propagated.
+  - **F13 (docstring):** `_area_summary_mrkdwn` docstring no longer references
+    the removed `format_status_summary`.
+  - **F14 (brittle test):** the archived-area deep-link test now pins the
+    mechanism (asserts the matched equipment's `area_id` is the archived area).
+- **Skipped:**
+  - **F1 / F2 (Block Kit section 3000-char / 100-block caps):** real but the
+    spec explicitly accepted them at makerspace scale; builder tests now guard
+    against a regression at the tested scale (F9).
+  - **F5 (loss of not-found feedback):** intended per AC 6 / AC 7 (summary is
+    the safe landing).
+  - **F6 (equipment with `area_id is None`):** not reproducible — `equipment.area_id`
+    is `NOT NULL` at the schema level, so the branch is unreachable defensive
+    code; the guard is kept as harmless defense.
+  - **F7 (`trigger_id` expiry race):** inherent to the `views_open` flow and
+    already acknowledged in Notes; mirrors `/esb-reserve`.
+  - **F10 (command DMs vs actions update-in-place):** necessary asymmetry — the
+    command has no open modal yet (must reply out-of-band), while the action
+    handlers have a live view to `views_update`.
+  - **F11 (shared `action_id` across area buttons):** valid Block Kit — button
+    action_id uniqueness is per-block, and each area section carries a distinct
+    `block_id`.
+
+## Post-Implementation Verification
+
+- `make lint` — clean.
+- `make test` — 1805 passed (dead-formatter tests removed with their functions).
+- `venv/bin/python -m pytest tests/test_slack/ -v` — all green.

--- a/esb/slack/forms.py
+++ b/esb/slack/forms.py
@@ -17,64 +17,51 @@ def _truncate(text: str, limit: int) -> str:
     return text[: max(0, limit - 1)].rstrip() + '\u2026'
 
 
-def format_status_summary(dashboard_data):
-    """Format area status dashboard data as Slack mrkdwn text.
+def _area_summary_mrkdwn(area_data):
+    """Build the per-area summary block (count line + non-green bullets) as mrkdwn.
 
-    Each non-archived area that has at least one piece of equipment
-    renders one count line; areas with no equipment at all are skipped
-    to avoid cluttering the summary with empty "0 / 0 / 0" rows. Areas
-    with non-green equipment also list those items as bullets (severity
-    emoji + name + truncated description + optional ETA). The message
-    ends with a hint pointing users at ``/esb-status <area name>`` for
-    one-area detail.
+    Used by ``build_status_summary_modal`` to render one section per area:
+    the count line for the area followed, on their own lines, by one bullet per
+    non-green equipment item. Callers must skip areas whose equipment list is
+    empty; this helper assumes at least one item.
 
     Args:
-        dashboard_data: List of dicts from status_service.get_area_status_dashboard().
+        area_data: One element of the dashboard list, shape
+            ``{'area': Area, 'equipment': [{'equipment': Equipment, 'status': {...}}, ...]}``.
 
     Returns:
-        Formatted mrkdwn string for ephemeral Slack message.
+        Multi-line mrkdwn string for one area.
     """
-    if not dashboard_data or all(not area_data['equipment'] for area_data in dashboard_data):
-        return 'No equipment has been registered yet.'
+    area = area_data['area']
+    equipment_list = area_data['equipment']
 
-    lines = [':bar_chart: *Equipment Status Summary*\n']
+    counts = {'green': 0, 'yellow': 0, 'red': 0}
+    for equip_data in equipment_list:
+        color = equip_data['status']['color']
+        counts[color] = counts.get(color, 0) + 1
 
-    for area_data in dashboard_data:
-        area = area_data['area']
-        equipment_list = area_data['equipment']
-        if not equipment_list:
+    lines = [
+        f"*{area.name}* — "
+        f"{counts['green']} :white_check_mark: operational, "
+        f"{counts['yellow']} :warning: degraded, "
+        f"{counts['red']} :x: down"
+    ]
+
+    for equip_data in equipment_list:
+        status = equip_data['status']
+        color = status['color']
+        if color == 'green':
             continue
-
-        counts = {'green': 0, 'yellow': 0, 'red': 0}
-        for equip_data in equipment_list:
-            color = equip_data['status']['color']
-            counts[color] = counts.get(color, 0) + 1
-
-        lines.append(
-            f"*{area.name}* — "
-            f"{counts['green']} :white_check_mark: operational, "
-            f"{counts['yellow']} :warning: degraded, "
-            f"{counts['red']} :x: down"
-        )
-
-        for equip_data in equipment_list:
-            status = equip_data['status']
-            color = status['color']
-            if color == 'green':
-                continue
-            equip = equip_data['equipment']
-            emoji = _STATUS_EMOJI.get(color, ':grey_question:')
-            parts = [f'\u2022 {emoji} *{equip.name}*']
-            desc = status.get('issue_description')
-            if desc:
-                parts.append(f'\u2014 {_truncate(desc, _NON_GREEN_DESC_TRUNCATE)}')
-            eta = status.get('eta')
-            if eta:
-                parts.append(f'(ETA: {eta.strftime("%b %d, %Y")})')
-            lines.append(' '.join(parts))
-
-    lines.append('')
-    lines.append('_Tip: try `/esb-status <area name>` for full details on one area._')
+        equip = equip_data['equipment']
+        emoji = _STATUS_EMOJI.get(color, ':grey_question:')
+        parts = [f'\u2022 {emoji} *{equip.name}*']
+        desc = status.get('issue_description')
+        if desc:
+            parts.append(f'\u2014 {_truncate(desc, _NON_GREEN_DESC_TRUNCATE)}')
+        eta = status.get('eta')
+        if eta:
+            parts.append(f'(ETA: {eta.strftime("%b %d, %Y")})')
+        lines.append(' '.join(parts))
 
     return '\n'.join(lines)
 
@@ -119,47 +106,97 @@ def format_area_status_detail(area_data):
     return '\n'.join(lines)
 
 
-def format_equipment_status_detail(equipment, status_detail):
-    """Format single equipment status detail as Slack mrkdwn text.
+def build_status_summary_modal(dashboard_data):
+    """Build the navigation-only equipment status summary modal.
+
+    Renders one ``section`` per non-empty area (count line + non-green bullets,
+    via :func:`_area_summary_mrkdwn`) with a "View details" button accessory that
+    deep-links to that area's detail view. This modal has no ``submit`` — it is
+    navigation-only.
 
     Args:
-        equipment: Equipment model instance.
-        status_detail: Dict from status_service.get_equipment_status_detail().
+        dashboard_data: List of dicts from
+            ``status_service.get_area_status_dashboard()``.
 
     Returns:
-        Formatted mrkdwn string.
+        A Block Kit modal view dict (``callback_id: esb_status_summary``).
     """
-    emoji = _STATUS_EMOJI.get(status_detail['color'], ':grey_question:')
-    area_name = equipment.area.name if equipment.area else 'No Area'
-    text = f"{emoji} *{equipment.name}* ({area_name}) — {status_detail['label']}"
+    modal = {
+        'type': 'modal',
+        'callback_id': 'esb_status_summary',
+        'title': {'type': 'plain_text', 'text': 'Equipment Status'},
+        'close': {'type': 'plain_text', 'text': 'Close'},
+        'blocks': [],
+    }
 
-    if status_detail['color'] != 'green':
-        if status_detail.get('issue_description'):
-            text += f"\n> {status_detail['issue_description']}"
-        if status_detail.get('eta'):
-            text += f"\n> ETA: {status_detail['eta'].strftime('%b %d, %Y')}"
-        if status_detail.get('assignee_name'):
-            text += f"\n> Assigned to: {status_detail['assignee_name']}"
+    if not dashboard_data or all(not area_data['equipment'] for area_data in dashboard_data):
+        modal['blocks'].append({
+            'type': 'section',
+            'text': {'type': 'mrkdwn', 'text': 'No equipment has been registered yet.'},
+        })
+        return modal
 
-    return text
+    modal['blocks'].append({
+        'type': 'section',
+        'text': {'type': 'mrkdwn', 'text': ':bar_chart: *Equipment Status Summary*'},
+    })
+
+    for area_data in dashboard_data:
+        if not area_data['equipment']:
+            continue
+        area = area_data['area']
+        modal['blocks'].append({
+            'type': 'section',
+            'block_id': f'esb_status_area_{area.id}_block',
+            'text': {'type': 'mrkdwn', 'text': _area_summary_mrkdwn(area_data)},
+            'accessory': {
+                'type': 'button',
+                'text': {'type': 'plain_text', 'text': 'View details'},
+                'action_id': 'esb_status_view_area',
+                'value': str(area.id),
+            },
+        })
+
+    return modal
 
 
-def format_equipment_list(matches, search_term):
-    """Format a list of matching equipment for disambiguation.
+def build_area_status_modal(area_data):
+    """Build the area-detail modal reached from the summary's "View details" button.
 
     Args:
-        matches: List of Equipment model instances.
-        search_term: Original search string from the user.
+        area_data: One entry of the dashboard list (shape returned by
+            ``status_service.get_single_area_status_dashboard()``):
+            ``{'area': Area, 'equipment': [...]}``.
 
     Returns:
-        Formatted mrkdwn string.
+        A Block Kit modal view dict (``callback_id: esb_status_area_detail``)
+        with a "Back to summary" button.
     """
-    lines = [f'Multiple equipment items match "{search_term}":']
-    for equip in matches:
-        area_name = equip.area.name if equip.area else 'No Area'
-        lines.append(f'\u2022 {equip.name} ({area_name})')
-    lines.append('\nPlease be more specific. Try `/esb-status [full name]`')
-    return '\n'.join(lines)
+    area = area_data['area']
+    return {
+        'type': 'modal',
+        'callback_id': 'esb_status_area_detail',
+        'title': {'type': 'plain_text', 'text': area.name[:24]},
+        'close': {'type': 'plain_text', 'text': 'Close'},
+        'blocks': [
+            {
+                'type': 'section',
+                'text': {'type': 'mrkdwn', 'text': format_area_status_detail(area_data)},
+            },
+            {'type': 'divider'},
+            {
+                'type': 'actions',
+                'elements': [
+                    {
+                        'type': 'button',
+                        'text': {'type': 'plain_text', 'text': '⬅ Back to summary'},
+                        'action_id': 'esb_status_back_to_summary',
+                        'value': 'summary',
+                    },
+                ],
+            },
+        ],
+    }
 
 
 def build_equipment_options():

--- a/esb/slack/forms.py
+++ b/esb/slack/forms.py
@@ -9,6 +9,12 @@ _STATUS_EMOJI = {
 
 _NON_GREEN_DESC_TRUNCATE = 80
 
+# Slack Block Kit hard-caps a section's text at 3000 characters; exceeding it
+# makes views_open/views_update fail with invalid_blocks. Repair descriptions
+# are unbounded (db.Text), so a single verbose record can blow past this — clamp
+# every modal section's mrkdwn to this limit.
+_SECTION_TEXT_LIMIT = 3000
+
 
 def _truncate(text: str, limit: int) -> str:
     """Truncate text to limit, appending an ellipsis when shortened."""
@@ -148,7 +154,7 @@ def build_status_summary_modal(dashboard_data):
         modal['blocks'].append({
             'type': 'section',
             'block_id': f'esb_status_area_{area.id}_block',
-            'text': {'type': 'mrkdwn', 'text': _area_summary_mrkdwn(area_data)},
+            'text': {'type': 'mrkdwn', 'text': _truncate(_area_summary_mrkdwn(area_data), _SECTION_TEXT_LIMIT)},
             'accessory': {
                 'type': 'button',
                 'text': {'type': 'plain_text', 'text': 'View details'},
@@ -181,7 +187,10 @@ def build_area_status_modal(area_data):
         'blocks': [
             {
                 'type': 'section',
-                'text': {'type': 'mrkdwn', 'text': format_area_status_detail(area_data)},
+                'text': {
+                    'type': 'mrkdwn',
+                    'text': _truncate(format_area_status_detail(area_data), _SECTION_TEXT_LIMIT),
+                },
             },
             {'type': 'divider'},
             {

--- a/esb/slack/handlers.py
+++ b/esb/slack/handlers.py
@@ -593,50 +593,124 @@ def register_handlers(bolt_app, app):
                 text=f':white_check_mark: Repair record #{record.id} created for *{equipment_name}*',
             )
 
+    def _update_esb_status_error_modal(client, body):
+        """Swap the open /esb-status modal to a close-only error view.
+
+        Used by the button action handlers so a failed re-query never leaves a
+        stale view open. Posting an ephemeral instead is avoided on purpose: the
+        whole point of this feature is that the bot may not be a channel member.
+        """
+        client.views_update(
+            view_id=body['view']['id'],
+            view={
+                'type': 'modal',
+                'callback_id': 'esb_status_error',
+                'title': {'type': 'plain_text', 'text': 'Equipment Status'},
+                'close': {'type': 'plain_text', 'text': 'Close'},
+                'blocks': [
+                    {
+                        'type': 'section',
+                        'text': {
+                            'type': 'mrkdwn',
+                            'text': ':x: Could not load equipment status. Please try again.',
+                        },
+                    },
+                ],
+            },
+        )
+
     @bolt_app.command('/esb-status')
-    def handle_esb_status(ack, body, client):
+    def handle_esb_status(ack, body, client, respond):
         ack()
         search_term = body.get('text', '').strip()
 
         with _ensure_app_context(app):
             try:
-                if not search_term:
-                    from esb.services import status_service
-                    dashboard = status_service.get_area_status_dashboard()
-                    from esb.slack.forms import format_status_summary
-                    text = format_status_summary(dashboard)
-                else:
-                    from esb.services import equipment_service, status_service
+                from esb.services import equipment_service, status_service
+                from esb.slack.forms import build_area_status_modal, build_status_summary_modal
+                from esb.utils.exceptions import AreaNotFound
 
+                if not search_term:
+                    view = build_status_summary_modal(status_service.get_area_status_dashboard())
+                else:
+                    # Resolve the deep-link target area id (area name takes
+                    # precedence over equipment search), then share ONE guarded
+                    # dashboard lookup so both branches handle archived areas
+                    # identically (fall back to summary, not an error).
+                    target_area_id = None
                     area = equipment_service.get_area_by_name(search_term)
                     if area is not None:
-                        from esb.slack.forms import format_area_status_detail
-                        area_data = status_service.get_single_area_status_dashboard(area.id)
-                        text = format_area_status_detail(area_data)
+                        target_area_id = area.id
                     else:
                         matches = equipment_service.search_equipment_by_name(search_term)
-                        if len(matches) == 0:
-                            text = (
-                                f':mag: Equipment not found: "{search_term}"\n'
-                                'Check the spelling or use the full equipment name. '
-                                'Try `/esb-status` with no arguments to see all equipment.'
-                            )
-                        elif len(matches) == 1:
-                            detail = status_service.get_equipment_status_detail(matches[0].id)
-                            from esb.slack.forms import format_equipment_status_detail
-                            text = format_equipment_status_detail(matches[0], detail)
-                        else:
-                            from esb.slack.forms import format_equipment_list
-                            text = format_equipment_list(matches, search_term)
+                        if len(matches) == 1 and matches[0].area_id is not None:
+                            target_area_id = matches[0].area_id
+
+                    if target_area_id is not None:
+                        try:
+                            area_data = status_service.get_single_area_status_dashboard(target_area_id)
+                            view = build_area_status_modal(area_data)
+                        except AreaNotFound:
+                            # Matched tool/area is valid but its area is archived
+                            # (AreaArchived subclasses AreaNotFound). Summary is
+                            # the safe landing, not an error.
+                            view = build_status_summary_modal(status_service.get_area_status_dashboard())
+                    else:
+                        # No area match; zero, multiple, or area-less equipment
+                        # matches all fall back to the summary view.
+                        view = build_status_summary_modal(status_service.get_area_status_dashboard())
+
+                client.views_open(trigger_id=body['trigger_id'], view=view)
             except Exception:
                 logger.warning('Error processing /esb-status command', exc_info=True)
-                text = ':x: An error occurred while checking equipment status. Please try again.'
+                # Reply via the slash command's response_url (Bolt's `respond`),
+                # NOT chat_postEphemeral into a channel: response_url is a
+                # temporary webhook that works even when the bot is not a member
+                # of the invoking channel — exactly the limitation this feature
+                # fixes. Guard the reply itself so a secondary failure (e.g.
+                # expired response_url) does not escape the handler.
+                try:
+                    respond(
+                        response_type='ephemeral',
+                        text=':x: An error occurred while checking equipment status. Please try again.',
+                    )
+                except Exception:
+                    logger.warning('Failed to deliver /esb-status error response', exc_info=True)
 
-            client.chat_postEphemeral(
-                channel=body['channel_id'],
-                user=body['user_id'],
-                text=text,
-            )
+    @bolt_app.action('esb_status_view_area')
+    def handle_esb_status_view_area(ack, body, client):
+        ack()
+        with _ensure_app_context(app):
+            try:
+                from esb.services import status_service
+                from esb.slack.forms import build_area_status_modal
+
+                area_id = int(body['actions'][0]['value'])
+                area_data = status_service.get_single_area_status_dashboard(area_id)
+                client.views_update(
+                    view_id=body['view']['id'],
+                    view=build_area_status_modal(area_data),
+                )
+            except Exception:
+                logger.warning('Error processing esb_status_view_area action', exc_info=True)
+                _update_esb_status_error_modal(client, body)
+
+    @bolt_app.action('esb_status_back_to_summary')
+    def handle_esb_status_back_to_summary(ack, body, client):
+        ack()
+        with _ensure_app_context(app):
+            try:
+                from esb.services import status_service
+                from esb.slack.forms import build_status_summary_modal
+
+                dashboard = status_service.get_area_status_dashboard()
+                client.views_update(
+                    view_id=body['view']['id'],
+                    view=build_status_summary_modal(dashboard),
+                )
+            except Exception:
+                logger.warning('Error processing esb_status_back_to_summary action', exc_info=True)
+                _update_esb_status_error_modal(client, body)
 
     # Dispatch path verified in Task 0: push_via_ack (slack-bolt 1.27.0
     # accepts ack(response_action='push', view=...) for view submissions).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "equipment-status-board"
-version = "0.15.0"
+version = "0.16.0"
 description = "Equipment status tracking and repair management for Decatur Makers makerspace"
 requires-python = ">=3.14"
 dependencies = [

--- a/tests/test_slack/test_forms.py
+++ b/tests/test_slack/test_forms.py
@@ -258,162 +258,6 @@ class TestBuildRepairCreateModal:
         assert 'assignee_block' not in block_ids
 
 
-class TestFormatStatusSummary:
-    """Tests for format_status_summary()."""
-
-    def test_multiple_areas(self, app, make_area, make_equipment, make_repair_record):
-        """Formats all areas with correct counts."""
-        from esb.services import status_service
-        from esb.slack.forms import format_status_summary
-
-        area1 = make_area('Woodshop', '#wood')
-        area2 = make_area('Metal Shop', '#metal')
-        make_equipment('SawStop', 'SawStop', 'PCS', area=area1)
-        eq2 = make_equipment('Band Saw', 'Jet', 'JWBS', area=area1)
-        make_repair_record(equipment=eq2, status='New', severity='Degraded', description='Belt issue')
-        make_equipment('Welder', 'Lincoln', '210MP', area=area2)
-
-        dashboard = status_service.get_area_status_dashboard()
-        result = format_status_summary(dashboard)
-
-        assert 'Equipment Status Summary' in result
-        assert 'Woodshop' in result
-        assert 'Metal Shop' in result
-        assert '1 :white_check_mark: operational' in result
-        assert '1 :warning: degraded' in result
-
-    def test_empty(self, app):
-        """Returns 'No equipment' for empty dashboard."""
-        from esb.slack.forms import format_status_summary
-
-        result = format_status_summary([])
-        assert result == 'No equipment has been registered yet.'
-
-    def test_all_green(self, app, make_area, make_equipment):
-        """All counts show 0 for degraded/down when all green."""
-        from esb.services import status_service
-        from esb.slack.forms import format_status_summary
-
-        area = make_area('Lab', '#lab')
-        make_equipment('Scope', 'Tek', 'TDS', area=area)
-        make_equipment('DMM', 'Fluke', '87V', area=area)
-
-        dashboard = status_service.get_area_status_dashboard()
-        result = format_status_summary(dashboard)
-
-        assert '2 :white_check_mark: operational' in result
-        assert '0 :warning: degraded' in result
-        assert '0 :x: down' in result
-
-    def test_non_green_items_listed_under_area(self, app, make_area, make_equipment, make_repair_record):
-        """AC 7: each non-green equipment is listed as a bullet under its area's count line."""
-        from esb.services import status_service
-        from esb.slack.forms import format_status_summary
-
-        area = make_area('Woodshop', '#wood')
-        eq_down = make_equipment('SawStop', 'SawStop', 'PCS', area=area)
-        eq_degraded = make_equipment('Band Saw', 'Jet', 'JWBS', area=area)
-        make_equipment('Drill Press', 'Jet', 'DP', area=area)  # green
-        make_repair_record(equipment=eq_down, status='New', severity='Down', description='Motor burned out')
-        make_repair_record(equipment=eq_degraded, status='New', severity='Degraded', description='Belt slipping')
-
-        dashboard = status_service.get_area_status_dashboard()
-        result = format_status_summary(dashboard)
-
-        # Bullets for each non-green item appear under the area count line.
-        assert ':x: *SawStop*' in result
-        assert ':warning: *Band Saw*' in result
-        assert 'Motor burned out' in result
-        assert 'Belt slipping' in result
-        # Green item does not get a bullet.
-        assert '*Drill Press*' not in result
-
-    def test_truncates_long_description_at_80(self, app, make_area, make_equipment, make_repair_record):
-        """Descriptions longer than 80 chars are truncated with an ellipsis."""
-        from esb.services import status_service
-        from esb.slack.forms import format_status_summary
-
-        area = make_area('Lab', '#lab')
-        eq = make_equipment('Tool', 'TC', 'TM', area=area)
-        long_desc = 'X' * 200
-        make_repair_record(equipment=eq, status='New', severity='Down', description=long_desc)
-
-        dashboard = status_service.get_area_status_dashboard()
-        result = format_status_summary(dashboard)
-
-        # Should not contain the full 200 X's but should contain a truncated form.
-        assert 'X' * 200 not in result
-        assert '\u2026' in result  # ellipsis
-
-    def test_eta_shown_when_present(self, app, make_area, make_equipment, make_repair_record):
-        """ETA is shown when present in status."""
-        from datetime import date
-        from esb.services import status_service
-        from esb.slack.forms import format_status_summary
-
-        area = make_area('Shop', '#shop')
-        eq = make_equipment('Lathe', 'X', 'M', area=area)
-        make_repair_record(equipment=eq, status='New', severity='Down', description='broken', eta=date(2026, 6, 15))
-
-        dashboard = status_service.get_area_status_dashboard()
-        result = format_status_summary(dashboard)
-        assert 'Jun 15, 2026' in result
-
-    def test_footer_hint_present(self, app, make_area, make_equipment):
-        """AC 8: footer hint appears at the end of the summary."""
-        from esb.services import status_service
-        from esb.slack.forms import format_status_summary
-
-        area = make_area('Lab', '#lab')
-        make_equipment('Scope', 'Tek', 'TDS', area=area)
-        dashboard = status_service.get_area_status_dashboard()
-        result = format_status_summary(dashboard)
-        assert '/esb-status <area name>' in result
-        assert 'full details on one area' in result
-
-    def test_all_green_area_no_equipment_bullets(self, app, make_area, make_equipment):
-        """AC 36: area with all-green equipment shows count line, no bullets beneath."""
-        from esb.services import status_service
-        from esb.slack.forms import format_status_summary
-
-        area = make_area('Lab', '#lab')
-        make_equipment('Scope', 'Tek', 'TDS', area=area)
-        make_equipment('DMM', 'Fluke', '87V', area=area)
-        dashboard = status_service.get_area_status_dashboard()
-        result = format_status_summary(dashboard)
-        # The count line is present.
-        assert 'Lab' in result
-        # And no equipment item is rendered as a bullet (no per-item lines).
-        assert '*Scope*' not in result
-        assert '*DMM*' not in result
-
-    def test_empty_returns_unchanged_text(self, app):
-        """AC 7 empty-state preservation."""
-        from esb.slack.forms import format_status_summary
-        assert format_status_summary([]) == 'No equipment has been registered yet.'
-
-    def test_format_status_summary_respects_area_sort_order(
-        self, app, make_area, make_equipment,
-    ):
-        """Per-area lines follow (sort_order, name) ordering."""
-        from esb.services import status_service
-        from esb.slack.forms import format_status_summary
-
-        area_a = make_area('Area A', '#a', sort_order=10)
-        area_b = make_area('Area B', '#b', sort_order=5)
-        area_c = make_area('Area C', '#c', sort_order=5)
-        make_equipment('Tool A', 'X', 'M', area=area_a)
-        make_equipment('Tool B', 'X', 'M', area=area_b)
-        make_equipment('Tool C', 'X', 'M', area=area_c)
-
-        summary = format_status_summary(status_service.get_area_status_dashboard())
-        pos_b = summary.find('Area B')
-        pos_c = summary.find('Area C')
-        pos_a = summary.find('Area A')
-        assert pos_b >= 0 and pos_c >= 0 and pos_a >= 0, summary
-        assert pos_b < pos_c < pos_a
-
-
 class TestFormatAreaStatusDetail:
     """Tests for format_area_status_detail()."""
 
@@ -743,76 +587,128 @@ class TestRepairCreateModalStatusFilter:
         assert 'Closed - Duplicate' not in values
 
 
-class TestFormatEquipmentStatusDetail:
-    """Tests for format_equipment_status_detail()."""
+class TestBuildStatusSummaryModal:
+    """Tests for build_status_summary_modal()."""
 
-    def test_green(self, app, make_equipment):
-        """Green shows emoji + name + Operational, no issue block."""
-        from esb.slack.forms import format_equipment_status_detail
+    def test_modal_structure_and_area_buttons(self, app, make_area, make_equipment, make_repair_record):
+        """Summary modal has one section per non-empty area with a 'View details' button."""
+        from esb.services import status_service
+        from esb.slack.forms import build_status_summary_modal
 
-        equip = make_equipment('SawStop #1', 'SawStop', 'PCS')
-        detail = {
-            'color': 'green', 'label': 'Operational',
-            'issue_description': None, 'severity': None,
-            'eta': None, 'assignee_name': None,
-        }
-        result = format_equipment_status_detail(equip, detail)
-        assert ':white_check_mark:' in result
-        assert 'SawStop #1' in result
-        assert 'Operational' in result
-        assert '>' not in result  # No blockquote lines
+        area1 = make_area('Woodshop', '#wood')
+        area2 = make_area('Metal Shop', '#metal')
+        make_equipment('SawStop', 'SawStop', 'PCS', area=area1)  # green
+        eq_down = make_equipment('Band Saw', 'Jet', 'JWBS', area=area1)
+        make_repair_record(equipment=eq_down, status='New', severity='Down', description='Motor dead')
+        make_equipment('Welder', 'Lincoln', '210MP', area=area2)  # green
 
-    def test_down_with_details(self, app, make_equipment):
-        """Down shows description, ETA, assignee."""
-        from datetime import date
-        from esb.slack.forms import format_equipment_status_detail
+        dashboard = status_service.get_area_status_dashboard()
+        modal = build_status_summary_modal(dashboard)
 
-        equip = make_equipment('SawStop #1', 'SawStop', 'PCS')
-        detail = {
-            'color': 'red', 'label': 'Down',
-            'issue_description': 'Motor makes grinding noise',
-            'severity': 'Down',
-            'eta': date(2026, 2, 20),
-            'assignee_name': 'Marcus',
-        }
-        result = format_equipment_status_detail(equip, detail)
-        assert ':x:' in result
-        assert 'Down' in result
-        assert '> Motor makes grinding noise' in result
-        assert '> ETA: Feb 20, 2026' in result
-        assert '> Assigned to: Marcus' in result
+        assert modal['type'] == 'modal'
+        assert modal['callback_id'] == 'esb_status_summary'
+        assert modal['title']['text'] == 'Equipment Status'
+        assert 'submit' not in modal
 
-    def test_degraded_no_eta(self, app, make_equipment):
-        """Degraded shows description but no ETA line."""
-        from esb.slack.forms import format_equipment_status_detail
+        # First block is the header section.
+        assert 'Equipment Status Summary' in modal['blocks'][0]['text']['text']
 
-        equip = make_equipment('Band Saw', 'Jet', 'JWBS')
-        detail = {
-            'color': 'yellow', 'label': 'Degraded',
-            'issue_description': 'Belt slipping',
-            'severity': 'Degraded',
-            'eta': None, 'assignee_name': None,
-        }
-        result = format_equipment_status_detail(equip, detail)
-        assert ':warning:' in result
-        assert 'Degraded' in result
-        assert '> Belt slipping' in result
-        assert 'ETA' not in result
+        # Each area section carries a distinct block_id and a View details button.
+        area_sections = [b for b in modal['blocks'] if b.get('block_id', '').startswith('esb_status_area_')]
+        assert len(area_sections) == 2
+        for section in area_sections:
+            accessory = section['accessory']
+            assert accessory['type'] == 'button'
+            assert accessory['action_id'] == 'esb_status_view_area'
+            assert accessory['text']['text'] == 'View details'
+
+        # The value of each button is the corresponding area id.
+        values = {s['accessory']['value'] for s in area_sections}
+        assert values == {str(area1.id), str(area2.id)}
+
+        # Non-green item name is present in the summary text.
+        assert any('Band Saw' in b['text']['text'] for b in area_sections)
+
+        # Block Kit limits (F9): modals allow ≤100 blocks and ≤3000 chars per
+        # section text.
+        assert len(modal['blocks']) <= 100
+        for block in modal['blocks']:
+            if block['type'] == 'section':
+                assert len(block['text']['text']) <= 3000
+
+    def test_empty_areas_skipped(self, app, make_area, make_equipment):
+        """Areas with no equipment produce no section."""
+        from esb.services import status_service
+        from esb.slack.forms import build_status_summary_modal
+
+        area1 = make_area('Lab', '#lab')
+        make_area('Empty', '#empty')  # no equipment
+        make_equipment('Scope', 'Tek', 'TDS', area=area1)
+
+        dashboard = status_service.get_area_status_dashboard()
+        modal = build_status_summary_modal(dashboard)
+
+        block_ids = {b.get('block_id') for b in modal['blocks']}
+        assert f'esb_status_area_{area1.id}_block' in block_ids
+        area_sections = [b for b in modal['blocks'] if b.get('block_id', '').startswith('esb_status_area_')]
+        assert len(area_sections) == 1
+
+    def test_empty_dashboard(self, app):
+        """Empty dashboard renders a single 'No equipment' section."""
+        from esb.slack.forms import build_status_summary_modal
+
+        modal = build_status_summary_modal([])
+        assert modal['callback_id'] == 'esb_status_summary'
+        assert len(modal['blocks']) == 1
+        assert 'No equipment has been registered yet.' in modal['blocks'][0]['text']['text']
 
 
-class TestFormatEquipmentList:
-    """Tests for format_equipment_list()."""
+class TestBuildAreaStatusModal:
+    """Tests for build_area_status_modal()."""
 
-    def test_lists_matches(self, app, make_area, make_equipment):
-        """Lists matching equipment with area names."""
-        from esb.slack.forms import format_equipment_list
+    def test_area_detail_modal(self, app, make_area, make_equipment, make_repair_record):
+        """Area modal title, detail text, and back button are correct."""
+        from esb.services import status_service
+        from esb.slack.forms import build_area_status_modal, format_area_status_detail
 
         area = make_area('Woodshop', '#wood')
-        eq1 = make_equipment('Band Saw', 'Jet', 'JWBS', area=area)
-        eq2 = make_equipment('SawStop #1', 'SawStop', 'PCS', area=area)
+        eq_down = make_equipment('SawStop', 'SawStop', 'PCS', area=area)
+        make_repair_record(equipment=eq_down, status='New', severity='Down', description='Motor dead')
 
-        result = format_equipment_list([eq1, eq2], 'saw')
-        assert 'Multiple equipment items match "saw"' in result
-        assert 'Band Saw (Woodshop)' in result
-        assert 'SawStop #1 (Woodshop)' in result
-        assert '/esb-status' in result
+        area_data = status_service.get_single_area_status_dashboard(area.id)
+        modal = build_area_status_modal(area_data)
+
+        assert modal['type'] == 'modal'
+        assert modal['callback_id'] == 'esb_status_area_detail'
+        assert modal['title']['text'] == 'Woodshop'
+        assert len(modal['title']['text']) <= 24
+
+        # Detail section reuses the existing formatter (byte-identical).
+        assert modal['blocks'][0]['text']['text'] == format_area_status_detail(area_data)
+
+        # Block Kit limits (F9): ≤100 blocks, ≤3000 chars per section text.
+        assert len(modal['blocks']) <= 100
+        for block in modal['blocks']:
+            if block['type'] == 'section':
+                assert len(block['text']['text']) <= 3000
+
+        # A 'Back to summary' button is present.
+        buttons = [
+            el
+            for b in modal['blocks']
+            if b['type'] == 'actions'
+            for el in b['elements']
+        ]
+        assert any(btn['action_id'] == 'esb_status_back_to_summary' for btn in buttons)
+
+    def test_long_area_name_truncated_to_24(self, app, make_area, make_equipment):
+        """Area names longer than 24 chars are truncated in the modal title."""
+        from esb.services import status_service
+        from esb.slack.forms import build_area_status_modal
+
+        area = make_area('A' * 40, '#long')
+        make_equipment('Tool', 'TC', 'TM', area=area)
+
+        area_data = status_service.get_single_area_status_dashboard(area.id)
+        modal = build_area_status_modal(area_data)
+        assert len(modal['title']['text']) == 24

--- a/tests/test_slack/test_forms.py
+++ b/tests/test_slack/test_forms.py
@@ -662,6 +662,23 @@ class TestBuildStatusSummaryModal:
         assert len(modal['blocks']) == 1
         assert 'No equipment has been registered yet.' in modal['blocks'][0]['text']['text']
 
+    def test_oversized_area_section_truncated_to_3000(self, app, make_area, make_equipment, make_repair_record):
+        """A verbose repair description cannot push a section past Slack's 3000-char cap."""
+        from esb.services import status_service
+        from esb.slack.forms import build_status_summary_modal
+
+        area = make_area('Woodshop', '#wood')
+        eq_down = make_equipment('SawStop', 'SawStop', 'PCS', area=area)
+        make_repair_record(equipment=eq_down, status='New', severity='Down', description='X' * 5000)
+
+        dashboard = status_service.get_area_status_dashboard()
+        modal = build_status_summary_modal(dashboard)
+
+        area_sections = [b for b in modal['blocks'] if b.get('block_id', '').startswith('esb_status_area_')]
+        assert area_sections
+        for section in area_sections:
+            assert len(section['text']['text']) <= 3000
+
 
 class TestBuildAreaStatusModal:
     """Tests for build_area_status_modal()."""
@@ -712,3 +729,19 @@ class TestBuildAreaStatusModal:
         area_data = status_service.get_single_area_status_dashboard(area.id)
         modal = build_area_status_modal(area_data)
         assert len(modal['title']['text']) == 24
+
+    def test_oversized_detail_section_truncated_to_3000(self, app, make_area, make_equipment, make_repair_record):
+        """A verbose repair description cannot push the detail section past 3000 chars."""
+        from esb.services import status_service
+        from esb.slack.forms import build_area_status_modal
+
+        area = make_area('Woodshop', '#wood')
+        eq_down = make_equipment('SawStop', 'SawStop', 'PCS', area=area)
+        make_repair_record(equipment=eq_down, status='New', severity='Down', description='X' * 5000)
+
+        area_data = status_service.get_single_area_status_dashboard(area.id)
+        modal = build_area_status_modal(area_data)
+
+        for block in modal['blocks']:
+            if block['type'] == 'section':
+                assert len(block['text']['text']) <= 3000

--- a/tests/test_slack/test_handlers.py
+++ b/tests/test_slack/test_handlers.py
@@ -1140,8 +1140,18 @@ class TestResolveEsbUser:
         assert user is None
 
 
+def _section_texts(view):
+    """Collect all section mrkdwn/plain_text strings from a modal view dict."""
+    texts = []
+    for block in view.get('blocks', []):
+        text = block.get('text')
+        if isinstance(text, dict) and 'text' in text:
+            texts.append(text['text'])
+    return texts
+
+
 class TestEsbStatusCommand:
-    """Tests for /esb-status command handler."""
+    """Tests for /esb-status command handler (modal rework, issue #70)."""
 
     @pytest.fixture(autouse=True)
     def setup(self, app, db):
@@ -1155,209 +1165,274 @@ class TestEsbStatusCommand:
         """Verify /esb-status is registered on bolt_app."""
         assert 'command:/esb-status' in self.handlers
 
-    def test_no_args_shows_summary(self):
-        """/esb-status with no args shows area summary."""
+    def test_no_args_opens_summary_modal(self):
+        """AC 1: /esb-status with no args opens the summary modal (no ephemeral)."""
         ack = MagicMock()
         client = MagicMock()
-        body = {
-            'trigger_id': 'T123',
-            'user_id': 'U123',
-            'channel_id': 'C123',
-            'text': '',
-        }
+        body = {'trigger_id': 'T123', 'user_id': 'U123', 'channel_id': 'C123', 'text': ''}
 
-        self.handlers['command:/esb-status'](ack=ack, body=body, client=client)
+        self.handlers['command:/esb-status'](ack=ack, body=body, client=client, respond=MagicMock())
 
         ack.assert_called_once()
-        client.chat_postEphemeral.assert_called_once()
-        response_text = client.chat_postEphemeral.call_args.kwargs['text']
-        assert 'Equipment Status Summary' in response_text
+        client.views_open.assert_called_once()
+        client.chat_postEphemeral.assert_not_called()
+        view = client.views_open.call_args.kwargs['view']
+        assert view['callback_id'] == 'esb_status_summary'
+        assert any('Equipment Status Summary' in t for t in _section_texts(view))
 
-    def test_exact_match_shows_detail(self):
-        """Single match shows equipment detail."""
+    def test_single_equipment_opens_area_detail_modal(self):
+        """AC 6: single equipment match opens that equipment's area-detail modal."""
         ack = MagicMock()
         client = MagicMock()
-        body = {
-            'trigger_id': 'T123',
-            'user_id': 'U123',
-            'channel_id': 'C123',
-            'text': 'SawStop',
-        }
+        body = {'trigger_id': 'T123', 'user_id': 'U123', 'channel_id': 'C123', 'text': 'SawStop'}
 
-        self.handlers['command:/esb-status'](ack=ack, body=body, client=client)
+        self.handlers['command:/esb-status'](ack=ack, body=body, client=client, respond=MagicMock())
 
-        ack.assert_called_once()
-        client.chat_postEphemeral.assert_called_once()
-        response_text = client.chat_postEphemeral.call_args.kwargs['text']
-        assert 'SawStop' in response_text
-        assert 'Operational' in response_text
+        client.views_open.assert_called_once()
+        view = client.views_open.call_args.kwargs['view']
+        assert view['callback_id'] == 'esb_status_area_detail'
+        assert view['title']['text'] == 'Woodshop'
 
-    def test_no_match_shows_error(self):
-        """Posts 'Equipment not found' for no matches."""
+    def test_no_match_opens_summary_modal(self):
+        """AC 7: no match falls back to the summary modal (no error text)."""
         ack = MagicMock()
         client = MagicMock()
-        body = {
-            'trigger_id': 'T123',
-            'user_id': 'U123',
-            'channel_id': 'C123',
-            'text': 'NonexistentThing',
-        }
+        body = {'trigger_id': 'T123', 'user_id': 'U123', 'channel_id': 'C123', 'text': 'NonexistentThing'}
 
-        self.handlers['command:/esb-status'](ack=ack, body=body, client=client)
+        self.handlers['command:/esb-status'](ack=ack, body=body, client=client, respond=MagicMock())
 
-        ack.assert_called_once()
-        client.chat_postEphemeral.assert_called_once()
-        response_text = client.chat_postEphemeral.call_args.kwargs['text']
-        assert 'Equipment not found' in response_text
+        client.views_open.assert_called_once()
+        view = client.views_open.call_args.kwargs['view']
+        assert view['callback_id'] == 'esb_status_summary'
 
-    def test_multiple_matches_shows_list(self):
-        """Posts disambiguation list for multiple matches."""
+    def test_multiple_matches_opens_summary_modal(self):
+        """AC 7: multiple matches fall back to the summary modal, not a list."""
         _create_equipment(name='Band Saw', area=self.area)
 
         ack = MagicMock()
         client = MagicMock()
-        body = {
-            'trigger_id': 'T123',
-            'user_id': 'U123',
-            'channel_id': 'C123',
-            'text': 'Saw',
-        }
+        body = {'trigger_id': 'T123', 'user_id': 'U123', 'channel_id': 'C123', 'text': 'Saw'}
 
-        self.handlers['command:/esb-status'](ack=ack, body=body, client=client)
+        self.handlers['command:/esb-status'](ack=ack, body=body, client=client, respond=MagicMock())
 
-        ack.assert_called_once()
-        client.chat_postEphemeral.assert_called_once()
-        response_text = client.chat_postEphemeral.call_args.kwargs['text']
-        assert 'Multiple equipment items match' in response_text
-        assert 'Band Saw' in response_text
-        assert 'SawStop' in response_text
+        client.views_open.assert_called_once()
+        view = client.views_open.call_args.kwargs['view']
+        assert view['callback_id'] == 'esb_status_summary'
+        client.chat_postEphemeral.assert_not_called()
 
-    def test_partial_match_single(self):
-        """Partial name with one match shows detail."""
-        ack = MagicMock()
-        client = MagicMock()
-        body = {
-            'trigger_id': 'T123',
-            'user_id': 'U123',
-            'channel_id': 'C123',
-            'text': 'Stop',
-        }
-
-        self.handlers['command:/esb-status'](ack=ack, body=body, client=client)
-
-        ack.assert_called_once()
-        client.chat_postEphemeral.assert_called_once()
-        response_text = client.chat_postEphemeral.call_args.kwargs['text']
-        assert 'SawStop' in response_text
-
-    def test_ack_called_before_response(self):
-        """ack() is called before chat_postEphemeral."""
+    def test_ack_called_before_views_open(self):
+        """AC 9: ack() is called before views_open (trigger_id used promptly)."""
         call_order = []
         ack = MagicMock(side_effect=lambda: call_order.append('ack'))
         client = MagicMock()
-        client.chat_postEphemeral = MagicMock(
-            side_effect=lambda **kwargs: call_order.append('chat_postEphemeral'),
-        )
-        body = {
-            'trigger_id': 'T123',
-            'user_id': 'U123',
-            'channel_id': 'C123',
-            'text': '',
-        }
+        client.views_open = MagicMock(side_effect=lambda **kwargs: call_order.append('views_open'))
+        body = {'trigger_id': 'T123', 'user_id': 'U123', 'channel_id': 'C123', 'text': ''}
 
-        self.handlers['command:/esb-status'](ack=ack, body=body, client=client)
+        self.handlers['command:/esb-status'](ack=ack, body=body, client=client, respond=MagicMock())
 
         assert call_order[0] == 'ack'
-        assert 'chat_postEphemeral' in call_order
+        assert 'views_open' in call_order
 
-    def test_service_error_returns_ephemeral_error(self):
-        """Service exception returns friendly error message."""
+    def test_service_error_responds_via_response_url_and_no_modal(self):
+        """AC 10: an unexpected service error replies via response_url and opens no modal.
+
+        Bolt's ``respond`` posts to the slash command's response_url, which works
+        even when the bot is not a member of the invoking channel — the exact
+        limitation this feature fixes. No channel ephemeral is posted.
+        """
         from unittest.mock import patch
 
         ack = MagicMock()
         client = MagicMock()
-        body = {
-            'trigger_id': 'T123',
-            'user_id': 'U123',
-            'channel_id': 'C123',
-            'text': 'SawStop',
-        }
+        respond = MagicMock()
+        body = {'trigger_id': 'T123', 'user_id': 'U123', 'channel_id': 'C123', 'text': 'SawStop'}
 
         with patch(
             'esb.services.equipment_service.search_equipment_by_name',
             side_effect=Exception('DB error'),
         ):
-            self.handlers['command:/esb-status'](ack=ack, body=body, client=client)
+            self.handlers['command:/esb-status'](ack=ack, body=body, client=client, respond=respond)
 
         ack.assert_called_once()
-        client.chat_postEphemeral.assert_called_once()
-        response_text = client.chat_postEphemeral.call_args.kwargs['text']
-        assert 'error occurred' in response_text.lower()
+        client.views_open.assert_not_called()
+        client.chat_postEphemeral.assert_not_called()
+        respond.assert_called_once()
+        kwargs = respond.call_args.kwargs
+        assert 'error occurred' in kwargs['text'].lower()
+        assert kwargs['response_type'] == 'ephemeral'
 
-    def test_empty_dashboard(self):
-        """No equipment returns appropriate message."""
+    def test_views_open_failure_responds_via_response_url(self):
+        """F8: if views_open itself rejects the view, the error reply still fires."""
+        ack = MagicMock()
+        client = MagicMock()
+        client.views_open = MagicMock(side_effect=Exception('invalid_blocks'))
+        respond = MagicMock()
+        body = {'trigger_id': 'T123', 'user_id': 'U123', 'channel_id': 'C123', 'text': ''}
+
+        self.handlers['command:/esb-status'](ack=ack, body=body, client=client, respond=respond)
+
+        respond.assert_called_once()
+        assert 'error occurred' in respond.call_args.kwargs['text'].lower()
+
+    def test_empty_dashboard_opens_summary_modal(self):
+        """AC 8: no equipment registered → summary modal with a 'No equipment' section."""
         from esb.models.equipment import Equipment
         Equipment.query.delete()
         self.db.session.commit()
 
         ack = MagicMock()
         client = MagicMock()
-        body = {
-            'trigger_id': 'T123',
-            'user_id': 'U123',
-            'channel_id': 'C123',
-            'text': '',
-        }
+        body = {'trigger_id': 'T123', 'user_id': 'U123', 'channel_id': 'C123', 'text': ''}
 
-        self.handlers['command:/esb-status'](ack=ack, body=body, client=client)
+        self.handlers['command:/esb-status'](ack=ack, body=body, client=client, respond=MagicMock())
 
-        ack.assert_called_once()
-        client.chat_postEphemeral.assert_called_once()
-        response_text = client.chat_postEphemeral.call_args.kwargs['text']
-        assert 'No equipment' in response_text
+        client.views_open.assert_called_once()
+        view = client.views_open.call_args.kwargs['view']
+        assert view['callback_id'] == 'esb_status_summary'
+        assert any('No equipment' in t for t in _section_texts(view))
 
-    def test_area_name_match_shows_area_detail(self):
-        """AC 9: exact case-insensitive area name shows the area-detail view."""
+    def test_area_name_opens_area_detail_modal(self):
+        """AC 4: exact case-insensitive area name opens the area-detail modal."""
         ack = MagicMock()
         client = MagicMock()
         body = {'trigger_id': 'T', 'user_id': 'U', 'channel_id': 'C', 'text': 'woodshop'}
 
-        self.handlers['command:/esb-status'](ack=ack, body=body, client=client)
+        self.handlers['command:/esb-status'](ack=ack, body=body, client=client, respond=MagicMock())
 
-        response_text = client.chat_postEphemeral.call_args.kwargs['text']
-        # Area-detail formatter starts with :bar_chart: *<area>*
-        assert ':bar_chart:' in response_text
-        assert '*Woodshop*' in response_text
+        view = client.views_open.call_args.kwargs['view']
+        assert view['callback_id'] == 'esb_status_area_detail'
+        assert view['title']['text'] == 'Woodshop'
 
     def test_area_name_takes_precedence_over_equipment(self):
-        """AC 10: when an area and equipment share a substring, area wins by exact-name match."""
-        # The setup creates area 'Woodshop' and equipment 'SawStop'. Create an
-        # equipment whose name CONTAINS 'Woodshop' to force the precedence test.
+        """AC 5: area name match wins over an equipment name containing the same substring."""
         _create_equipment(name='Woodshop Helper', area=self.area)
 
         ack = MagicMock()
         client = MagicMock()
         body = {'trigger_id': 'T', 'user_id': 'U', 'channel_id': 'C', 'text': 'Woodshop'}
 
-        self.handlers['command:/esb-status'](ack=ack, body=body, client=client)
+        self.handlers['command:/esb-status'](ack=ack, body=body, client=client, respond=MagicMock())
 
-        response_text = client.chat_postEphemeral.call_args.kwargs['text']
-        # Area-detail header is rendered (not the multi-match list).
-        assert ':bar_chart:' in response_text
-        assert 'Multiple equipment items match' not in response_text
+        view = client.views_open.call_args.kwargs['view']
+        assert view['callback_id'] == 'esb_status_area_detail'
+        assert view['title']['text'] == 'Woodshop'
 
-    def test_no_area_match_falls_back_to_equipment_search(self):
-        """AC 11: a non-matching area name falls through to equipment search."""
+    def test_archived_area_deep_link_falls_back_to_summary(self):
+        """AC 12: equipment whose area is archived deep-links to the summary, not an error."""
+        from esb.services import equipment_service
+
+        equipment_service.archive_area(self.area.id, archived_by='tester')
+        # Pin the mechanism (F14): the equipment is still resolvable by name and
+        # its area_id points at the now-archived area — so resolution reaches the
+        # AreaArchived branch, not merely "no match".
+        matches = equipment_service.search_equipment_by_name('SawStop')
+        assert len(matches) == 1
+        assert matches[0].area_id == self.area.id
+
         ack = MagicMock()
         client = MagicMock()
         body = {'trigger_id': 'T', 'user_id': 'U', 'channel_id': 'C', 'text': 'SawStop'}
 
-        self.handlers['command:/esb-status'](ack=ack, body=body, client=client)
+        self.handlers['command:/esb-status'](ack=ack, body=body, client=client, respond=MagicMock())
 
-        response_text = client.chat_postEphemeral.call_args.kwargs['text']
-        # Existing single-equipment detail formatter is used.
-        assert 'SawStop' in response_text
-        assert 'Operational' in response_text
+        client.views_open.assert_called_once()
+        view = client.views_open.call_args.kwargs['view']
+        assert view['callback_id'] == 'esb_status_summary'
+        client.chat_postEphemeral.assert_not_called()
+
+
+
+class TestEsbStatusActions:
+    """Tests for the /esb-status modal button action handlers."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, app, db):
+        self.app = app
+        self.db = db
+        self.area = _create_area(name='Woodshop', slack_channel='#woodshop')
+        self.equipment = _create_equipment(name='SawStop', area=self.area)
+        self.handlers = _register_and_capture(app)
+
+    def test_action_handlers_registered(self):
+        assert 'action:esb_status_view_area' in self.handlers
+        assert 'action:esb_status_back_to_summary' in self.handlers
+
+    def test_view_area_updates_to_area_detail(self):
+        """AC 2: clicking 'View details' updates the modal to that area's detail."""
+        ack = MagicMock()
+        client = MagicMock()
+        body = {
+            'actions': [{'value': str(self.area.id)}],
+            'view': {'id': 'V1'},
+            'user': {'id': 'U1'},
+            'channel': {'id': 'C1'},
+        }
+
+        self.handlers['action:esb_status_view_area'](ack=ack, body=body, client=client)
+
+        ack.assert_called_once()
+        client.views_update.assert_called_once()
+        kwargs = client.views_update.call_args.kwargs
+        assert kwargs['view_id'] == 'V1'
+        assert kwargs['view']['callback_id'] == 'esb_status_area_detail'
+        assert kwargs['view']['title']['text'] == 'Woodshop'
+
+    def test_view_area_error_shows_error_modal(self):
+        """AC 13: a failing 'View details' re-query updates to a close-only error modal."""
+        from unittest.mock import patch
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {
+            'actions': [{'value': str(self.area.id)}],
+            'view': {'id': 'V1'},
+            'user': {'id': 'U1'},
+            'channel': {'id': 'C1'},
+        }
+
+        with patch(
+            'esb.services.status_service.get_single_area_status_dashboard',
+            side_effect=Exception('DB error'),
+        ):
+            self.handlers['action:esb_status_view_area'](ack=ack, body=body, client=client)
+
+        client.views_update.assert_called_once()
+        view = client.views_update.call_args.kwargs['view']
+        assert any('Could not load' in t for t in _section_texts(view))
+        client.chat_postEphemeral.assert_not_called()
+
+    def test_back_to_summary_updates_to_summary(self):
+        """AC 3: clicking 'Back to summary' updates the modal to the summary view."""
+        ack = MagicMock()
+        client = MagicMock()
+        body = {'view': {'id': 'V1'}, 'user': {'id': 'U1'}, 'channel': {'id': 'C1'}}
+
+        self.handlers['action:esb_status_back_to_summary'](ack=ack, body=body, client=client)
+
+        ack.assert_called_once()
+        client.views_update.assert_called_once()
+        kwargs = client.views_update.call_args.kwargs
+        assert kwargs['view_id'] == 'V1'
+        assert kwargs['view']['callback_id'] == 'esb_status_summary'
+
+    def test_back_to_summary_error_shows_error_modal(self):
+        """AC 13 (F6): a failing 'Back to summary' re-query updates to the error modal."""
+        from unittest.mock import patch
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {'view': {'id': 'V1'}, 'user': {'id': 'U1'}, 'channel': {'id': 'C1'}}
+
+        with patch(
+            'esb.services.status_service.get_area_status_dashboard',
+            side_effect=Exception('DB error'),
+        ):
+            self.handlers['action:esb_status_back_to_summary'](ack=ack, body=body, client=client)
+
+        client.views_update.assert_called_once()
+        view = client.views_update.call_args.kwargs['view']
+        assert any('Could not load' in t for t in _section_texts(view))
+        client.chat_postEphemeral.assert_not_called()
 
 
 class TestEsbRepairDispatcher:
@@ -2189,11 +2264,16 @@ class TestHandlersOutsideAppContext:
         client = MagicMock()
         body = {'trigger_id': 'T1', 'user_id': 'U1', 'channel_id': 'C1', 'text': ''}
         # This would raise RuntimeError before the fix
-        handlers['command:/esb-status'](ack=ack, body=body, client=client)
+        handlers['command:/esb-status'](ack=ack, body=body, client=client, respond=MagicMock())
         ack.assert_called_once()
-        response_text = client.chat_postEphemeral.call_args.kwargs['text']
+        view = client.views_open.call_args.kwargs['view']
         # Check for specific data to make failures diagnostic
-        assert 'Woodshop' in response_text
+        section_texts = [
+            b['text']['text']
+            for b in view['blocks']
+            if isinstance(b.get('text'), dict) and 'text' in b['text']
+        ]
+        assert any('Woodshop' in t for t in section_texts)
         # Teardown
         with app.app_context():
             db.drop_all()


### PR DESCRIPTION
## Summary

Reworks the `/esb-status` Slack command (issue #70) from an ephemeral text reply into an interactive Block Kit **modal**, fixing two UX problems: the confusing "Only visible to you" ephemerals, and the bot's inability to post into channels it is not a member of.

- **Summary modal** (`views_open`): one section per non-empty area, each with a **"View details"** button accessory (in a distinct `block_id`) that swaps the modal in place (`views_update`) to that area's detail view, which has a **"Back to summary"** button.
- **Text-arg deep-link preserved**: area name wins over equipment search; a single equipment match opens its area's detail; ambiguous / no-match / archived-area targets land on the summary. Archived-area deep-links are routed to the summary inline (`AreaArchived`), not surfaced as an error.
- **Error fallback** now replies via the slash command's `response_url` (Bolt's `respond`), which works even when the bot is not a channel member — the exact limitation this feature fixes. Button-action failures swap to an in-modal error view.
- Adds `build_status_summary_modal` / `build_area_status_modal` builders plus the shared `_area_summary_mrkdwn` helper; removes the now-dead text formatters (`format_status_summary`, `format_equipment_status_detail`, `format_equipment_list`).
- Bumps version to **0.16.0**.

## Testing

- `make lint` — clean
- `make test` — **1805 passed**
- New/updated: `TestEsbStatusCommand` (modal assertions), `TestEsbStatusActions`, `TestBuildStatusSummaryModal`, `TestBuildAreaStatusModal` (incl. Block Kit ≤100-block / ≤3000-char guards).

Implemented via the BMAD quick-dev workflow; an adversarial review pass was run and its findings resolved (see `_bmad-output/implementation-artifacts/tech-spec-esb-status-modal.md` → Review Notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzHqw96wXCi9i6aK349yZa