### PR TITLE
Fix Slack Socket Mode in production (default to ProductionConfig)

### DIFF
--- a/esb/config.py
+++ b/esb/config.py
@@ -114,5 +114,11 @@ config = {
     'slack_test': SlackTestConfig,
     'production': ProductionConfig,
     'screenshot': ScreenshotConfig,
-    'default': DevelopmentConfig,
+    # 'default' is what create_app() uses when no config_name is passed, which
+    # is how gunicorn runs it in production (esb:create_app()). It must be a
+    # non-debug config: with DEBUG=True, app.debug is True and Slack's
+    # init_slack() hits the Werkzeug-reloader guard and skips the Socket Mode
+    # connection, so slash commands never get acked. Local dev is unaffected
+    # because `flask run --debug` forces app.debug=True at the CLI level.
+    'default': ProductionConfig,
 }

--- a/esb/slack/__init__.py
+++ b/esb/slack/__init__.py
@@ -79,7 +79,7 @@ def init_slack(app):
     # child serving process. Only the child should own a Slack Socket Mode
     # connection, otherwise one local `flask run --debug` can connect twice.
     if app.debug and os.environ.get('WERKZEUG_RUN_MAIN') != 'true':
-        logger.info('Werkzeug reloader parent, skipping Socket Mode connection')
+        logger.warning('Werkzeug reloader parent, skipping Socket Mode connection')
         return
 
     # Unified Socket Mode setup: import, instantiation, and connect all live

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "equipment-status-board"
-version = "0.17.0"
+version = "0.18.0"
 description = "Equipment status tracking and repair management for Decatur Makers makerspace"
 requires-python = ">=3.14"
 dependencies = [


### PR DESCRIPTION
## Problem

All Slack slash commands in the deployed app fail with *"<command> failed because the app did not respond."* Socket Mode is never established in production — the live `/metrics` endpoint reports `esb_socket_mode_enabled 0` and `esb_socket_mode_connected 0`, and there are no Slack log lines.

## Root cause

Gunicorn runs the app as `esb:create_app()` with **no `config_name`**, so it resolves to the `'default'` config — which mapped to `DevelopmentConfig` (`DEBUG=True`). Therefore `app.debug` is `True` in production. (`FLASK_DEBUG=0` in the container env is a red herring; that variable only affects `flask run`, not gunicorn.)

Since **v0.15.0**, `init_slack()` has a Werkzeug-reloader guard:

```python
if app.debug and os.environ.get('WERKZEUG_RUN_MAIN') != 'true':
    logger.info('Werkzeug reloader parent, skipping Socket Mode connection')
    return
```

Under gunicorn `WERKZEUG_RUN_MAIN` is never set, so with `app.debug=True` this returns early and Socket Mode never connects. Nothing acks slash commands → Slack times out. The early-return logs only at `INFO`, which is why no Slack log output was visible.

This matches the observed timeline: worked on 0.14.0 through June 30; broke when **0.15.0** was deployed July 2 (the commit `feat: slack reservation flows` that added the guard).

## Fix

Point `'default'` at `ProductionConfig` (`DEBUG=False`). Now `app.debug` is `False` in production, the guard passes, and Socket Mode connects. This also stops production from silently running Flask in debug mode.

Local dev is unaffected: `make run` uses `flask run --debug`, which forces `app.debug=True` at the CLI and sets `WERKZEUG_RUN_MAIN` in the reloader child, so the socket still connects locally.

Version bumped to **0.18.0** to trigger the release workflow. After the image builds, bump the puppet `$esb_image` tag to `0.18.0` and apply.

## Testing

- Full suite: `1947 passed`
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)